### PR TITLE
feat: ProfileGroupList and ProfileGroupItem — group hours with regula…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS.md
+
+Before reviewing code, read `docs\app-dev-guidelines.md`.
+
+Use that file as the primary reference for:
+- component architecture
+- modal ownership and error handling
+- Vue data-down, events-up patterns
+- capability and permission handling
+- UI consistency and accessibility expectations
+
+When reviewing pull requests:
+- flag deviations from those documented patterns
+- prioritise correctness, permission safety, and regression risks
+- prefer repo conventions over generic framework advice

--- a/docs/app-dev-guidelines.md
+++ b/docs/app-dev-guidelines.md
@@ -311,6 +311,34 @@ That is the preferred pattern for similar features elsewhere in the app.
 
 ---
 
+## No legacy fallbacks
+
+The v2 frontend and its API route handlers must not carry legacy fallback code paths from v1. Fallbacks exist to paper over old data or old callers — in v2 they hide bugs and create hidden risk, particularly around privacy.
+
+**The rule:** if input does not meet the expected format, fail immediately with a clear error. Do not guess, coerce, or fall back to a looser resolution.
+
+**Why this matters for profile slugs specifically:** Profile slugs must include the numeric ID suffix (e.g. `alice-bowen-42`). A fallback that resolves by name alone can silently return the wrong profile if two volunteers share a name — exposing one volunteer's data to another viewer. Even if middleware currently blocks the path for self-service users, the fallback must not exist.
+
+**The pattern:**
+```typescript
+// Good — fail early
+const profileId = profileIdFromSlug(slug);
+if (profileId === undefined) {
+  res.status(404).json({ error: 'Invalid profile slug' });
+  return;
+}
+
+// Bad — legacy fallback, do not use
+const profileId = profileIdFromSlug(slug);
+const profile = profileId !== undefined
+  ? profiles.find(p => p.ID === profileId)
+  : profiles.find(p => nameToSlug(p.Title) === slug); // silent privacy risk
+```
+
+This applies to all entity resolution — slugs, IDs, keys. If the caller supplies something malformed, the right response is a 404, not a creative attempt to find a match.
+
+---
+
 ## Quick test for future work
 
 When designing a new feature, ask:

--- a/frontend/src/components/profiles/ProfileGroupItem.vue
+++ b/frontend/src/components/profiles/ProfileGroupItem.vue
@@ -1,0 +1,105 @@
+<template>
+  <div class="pgi-card">
+    <template v-if="allowToggleRegular">
+      <span v-if="working" class="pgi-spinner" />
+      <input
+        v-else
+        type="checkbox"
+        class="pgi-checkbox"
+        :checked="isRegular"
+        @change="onToggle"
+      />
+    </template>
+    <input
+      v-else-if="isRegular"
+      type="checkbox"
+      class="pgi-checkbox pgi-checkbox--static"
+      checked
+      tabindex="-1"
+      readonly
+    />
+
+    <RouterLink :to="groupPath(groupKey)" class="pgi-name">{{ groupName }}</RouterLink>
+    <strong class="pgi-hours">{{ formatHours(hours) }}h</strong>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { RouterLink } from 'vue-router'
+import { groupPath } from '../../router/index'
+
+const props = defineProps<{
+  groupId: number
+  groupKey: string
+  groupName: string
+  hours: number
+  isRegular: boolean
+  regularId?: number
+  allowToggleRegular?: boolean
+  working?: boolean
+}>()
+
+const emit = defineEmits<{
+  addRegular: []
+  removeRegular: []
+}>()
+
+function formatHours(h: number): string {
+  return h % 1 === 0 ? String(h) : h.toFixed(1)
+}
+
+function onToggle(event: Event) {
+  const isAdding = (event.target as HTMLInputElement).checked
+  if (isAdding) emit('addRegular')
+  else emit('removeRegular')
+}
+</script>
+
+<style scoped>
+.pgi-card {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--color-dtv-sand);
+  padding: 0.5rem 0.75rem;
+}
+
+.pgi-checkbox {
+  accent-color: var(--color-dtv-green);
+  width: 1.1rem;
+  height: 1.1rem;
+  flex-shrink: 0;
+  cursor: pointer;
+}
+.pgi-checkbox--static {
+  pointer-events: none;
+  cursor: default;
+}
+
+.pgi-spinner {
+  display: block;
+  width: 1.1rem;
+  height: 1.1rem;
+  flex-shrink: 0;
+  border: 2px solid var(--color-dtv-sand-dark);
+  border-top-color: var(--color-dtv-green);
+  border-radius: 50%;
+  animation: pgi-spin 0.7s linear infinite;
+}
+@keyframes pgi-spin { to { transform: rotate(360deg); } }
+
+.pgi-name {
+  flex: 1;
+  font-size: 0.9rem;
+  color: var(--color-text);
+  text-decoration: none;
+}
+.pgi-name:hover { text-decoration: underline; }
+
+.pgi-hours {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--color-dtv-gold-dark);
+  white-space: nowrap;
+}
+</style>

--- a/frontend/src/components/profiles/ProfileGroupList.vue
+++ b/frontend/src/components/profiles/ProfileGroupList.vue
@@ -1,0 +1,115 @@
+<template>
+  <div class="pgl-wrap">
+    <div class="pgl-header">
+      <h2 class="pgl-title">Groups</h2>
+    </div>
+
+    <p v-if="!groups.length" class="pgl-empty">No groups yet.</p>
+
+    <div v-else class="pgl-grid">
+      <ProfileGroupItem
+        v-for="g in groups"
+        :key="g.groupId"
+        :group-id="g.groupId"
+        :group-key="g.groupKey"
+        :group-name="g.groupName"
+        :hours="hoursFor(g)"
+        :is-regular="g.isRegular"
+        :regular-id="g.regularId"
+        :allow-toggle-regular="allowToggleRegular"
+        :working="workingGroupId === g.groupId"
+        @add-regular="onAddRegular(g.groupId)"
+        @remove-regular="onRemoveRegular(g.regularId!, g.groupId)"
+      />
+    </div>
+
+    <div v-if="error" class="pgl-error">{{ error }}</div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import ProfileGroupItem from './ProfileGroupItem.vue'
+import type { ProfileGroupHours } from '../../../../types/api-responses'
+
+const props = withDefaults(defineProps<{
+  groups: ProfileGroupHours[]
+  allowToggleRegular?: boolean
+  fy?: 'all' | 'thisFY' | 'lastFY'
+}>(), {
+  fy: 'all',
+})
+
+const emit = defineEmits<{
+  addRegular: [groupId: number]
+  removeRegular: [regularId: number, groupId: number]
+}>()
+
+const workingGroupId = ref<number | null>(null)
+const error = ref('')
+
+function onAddRegular(groupId: number) {
+  workingGroupId.value = groupId
+  emit('addRegular', groupId)
+}
+
+function onRemoveRegular(regularId: number, groupId: number) {
+  workingGroupId.value = groupId
+  emit('removeRegular', regularId, groupId)
+}
+
+function hoursFor(g: ProfileGroupHours): number {
+  if (props.fy === 'thisFY') return g.hoursThisFY
+  if (props.fy === 'lastFY') return g.hoursLastFY
+  return g.hoursAll
+}
+
+defineExpose({
+  onSuccess(groupId: number) {
+    if (workingGroupId.value === groupId) workingGroupId.value = null
+    error.value = ''
+  },
+  onError(groupId: number, msg = 'Failed to update — please try again') {
+    if (workingGroupId.value === groupId) workingGroupId.value = null
+    error.value = msg
+  },
+})
+</script>
+
+<style scoped>
+.pgl-wrap {
+  background: var(--color-white);
+  padding: 1.25rem 1.5rem;
+}
+
+.pgl-header {
+  margin-bottom: 0.75rem;
+}
+
+.pgl-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-text);
+  margin: 0;
+}
+
+.pgl-empty {
+  font-size: 0.9rem;
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+.pgl-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.pgl-error {
+  margin-top: 0.75rem;
+  padding: 0.5rem 1rem;
+  background: var(--color-dtv-dirt-light);
+  color: var(--color-dtv-dirt);
+  font-size: 0.85rem;
+}
+</style>

--- a/frontend/src/components/profiles/ProfileRecordList.vue
+++ b/frontend/src/components/profiles/ProfileRecordList.vue
@@ -4,12 +4,12 @@
       <h2 class="prl-title">Records</h2>
       <div class="prl-actions">
         <a
-          v-if="profile.isOperational || profile.isSelfService"
+          v-if="showConsentLink"
           :href="`/profiles/${profileSlug}/consent.html`"
           class="prl-link"
         >Consent</a>
         <button
-          v-if="profile.isAdmin"
+          v-if="allowEdit"
           class="prl-add-btn"
           @click="openAdd"
         >+ Add</button>
@@ -24,8 +24,8 @@
         :key="r.id"
         class="prl-pill"
         :class="`prl-pill--${r.status.toLowerCase().replace(/\s+/g, '-')}`"
-        :disabled="!profile.isAdmin"
-        @click="profile.isAdmin && openEdit(r)"
+        :disabled="!allowEdit"
+        @click="allowEdit && openEdit(r)"
       >
         {{ r.type }} · {{ r.status }} · {{ formatDate(r.date) }}
       </button>
@@ -57,7 +57,6 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import type { ConsentRecordResponse } from '../../../../types/api-responses'
-import type { RoleContext } from '../../composables/useViewer'
 import RecordAddModal, { type AddRecordPayload } from '../../pages/modals/RecordAddModal.vue'
 import RecordEditModal, { type SaveRecordPayload } from '../../pages/modals/RecordEditModal.vue'
 
@@ -65,7 +64,8 @@ const props = withDefaults(defineProps<{
   records: ConsentRecordResponse[]
   profileId: number
   profileSlug: string
-  profile: RoleContext
+  showConsentLink?: boolean
+  allowEdit?: boolean
   types?: string[]
   statuses?: string[]
 }>(), {

--- a/frontend/src/pages/ProfileDetailPage.vue
+++ b/frontend/src/pages/ProfileDetailPage.vue
@@ -26,11 +26,20 @@
         </div>
       </div>
 
+      <ProfileGroupList
+        :groups="store.profile.groupHours"
+        :allow-toggle-regular="viewer.isOperational"
+        ref="groupListRef"
+        @add-regular="onAddRegular"
+        @remove-regular="onRemoveRegular"
+      />
+
       <ProfileRecordList
         :records="store.profile.records ?? []"
         :profile-id="store.profile.id"
         :profile-slug="store.profile.slug"
-        :profile="viewer.context"
+        :show-consent-link="viewer.isOperational || viewer.isSelfService"
+        :allow-edit="viewer.isAdmin"
         :types="recordTypes"
         :statuses="recordStatuses"
         ref="recordListRef"
@@ -68,6 +77,7 @@ import PageHeader from '../components/PageHeader.vue'
 import ProfileEntryList from '../components/profiles/ProfileEntryList.vue'
 import ProfileDetailActions from '../components/profiles/ProfileDetailActions.vue'
 import ProfileRecordList from '../components/profiles/ProfileRecordList.vue'
+import ProfileGroupList from '../components/profiles/ProfileGroupList.vue'
 import { useViewer } from '../composables/useViewer'
 import { usePageTitle } from '../composables/usePageTitle'
 import { useProfileDetailStore } from '../stores/profileDetail'
@@ -85,6 +95,7 @@ const store = useProfileDetailStore()
 const workingId = ref<number | null>(null)
 const actionsRef = ref<InstanceType<typeof ProfileDetailActions> | null>(null)
 const recordListRef = ref<InstanceType<typeof ProfileRecordList> | null>(null)
+const groupListRef = ref<InstanceType<typeof ProfileGroupList> | null>(null)
 const recordTypes = ref<string[]>([])
 const recordStatuses = ref<string[]>([])
 
@@ -177,6 +188,39 @@ async function onDeleteRecord(id: number) {
   } catch (e) {
     console.error('[ProfileDetailPage] onDeleteRecord failed', e)
     recordListRef.value?.onSaveError('Failed to delete — please try again')
+  }
+}
+
+async function onAddRegular(groupId: number) {
+  if (!store.profile) return
+  try {
+    const res = await fetch(`/api/profiles/${store.profile.slug}/regulars`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ groupId }),
+    })
+    if (!res.ok) throw new Error(`Add failed (${res.status})`)
+    const json = await res.json()
+    const group = store.profile.groupHours.find(g => g.groupId === groupId)
+    if (group) { group.isRegular = true; group.regularId = json.data.id }
+    groupListRef.value?.onSuccess(groupId)
+  } catch (e) {
+    console.error('[ProfileDetailPage] onAddRegular failed', e)
+    groupListRef.value?.onError(groupId, 'Failed to update — please try again')
+  }
+}
+
+async function onRemoveRegular(regularId: number, groupId: number) {
+  if (!store.profile) return
+  try {
+    const res = await fetch(`/api/regulars/${regularId}`, { method: 'DELETE' })
+    if (!res.ok) throw new Error(`Delete failed (${res.status})`)
+    const group = store.profile.groupHours.find(g => g.groupId === groupId)
+    if (group) { group.isRegular = false; group.regularId = undefined }
+    groupListRef.value?.onSuccess(groupId)
+  } catch (e) {
+    console.error('[ProfileDetailPage] onRemoveRegular failed', e)
+    groupListRef.value?.onError(groupId, 'Failed to update — please try again')
   }
 }
 

--- a/frontend/src/pages/ProfileDetailPage.vue
+++ b/frontend/src/pages/ProfileDetailPage.vue
@@ -194,7 +194,7 @@ async function onDeleteRecord(id: number) {
 async function onAddRegular(groupId: number) {
   if (!store.profile) return
   try {
-    const res = await fetch(`/api/profiles/${store.profile.slug}/regulars`, {
+    const res = await fetch(`/api/profiles/${route.params.slug}/regulars`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ groupId }),

--- a/frontend/src/pages/modals/RecordAddModal.vue
+++ b/frontend/src/pages/modals/RecordAddModal.vue
@@ -5,6 +5,7 @@
     action-icon="add"
     :working="working"
     :error="error"
+    :action-disabled="!form.type || !form.status"
     @close="emit('close')"
     @action="add"
   >

--- a/frontend/src/pages/sandbox/SandboxIndex.vue
+++ b/frontend/src/pages/sandbox/SandboxIndex.vue
@@ -52,6 +52,8 @@
           <RouterLink to="/sandbox/entry-card">EntryCard</RouterLink>
           <RouterLink to="/sandbox/entry-list">EntryList</RouterLink>
           <RouterLink to="/sandbox/profile-record-list">ProfileRecordList</RouterLink>
+          <RouterLink to="/sandbox/profile-group-list">ProfileGroupList</RouterLink>
+          <RouterLink to="/sandbox/profile-group-item">ProfileGroupItem</RouterLink>
         </nav>
       </section>
 

--- a/frontend/src/pages/sandbox/SandboxProfileGroupItem.vue
+++ b/frontend/src/pages/sandbox/SandboxProfileGroupItem.vue
@@ -1,0 +1,85 @@
+<template>
+  <DefaultLayout>
+    <div class="sandbox">
+
+      <RouterLink to="/sandbox" class="back">← Sandbox</RouterLink>
+      <h1>ProfileGroupItem</h1>
+
+      <h2>Toggle allowed — idle, not regular</h2>
+      <div class="demo">
+        <ProfileGroupItem
+          :group-id="1" group-key="sheepskull" group-name="Sheepskull"
+          :hours="40" :is-regular="false" :allow-toggle-regular="true"
+          @add-regular="log('addRegular')"
+          @remove-regular="log('removeRegular')"
+        />
+      </div>
+
+      <h2>Toggle allowed — idle, is regular</h2>
+      <div class="demo">
+        <ProfileGroupItem
+          :group-id="1" group-key="sheepskull" group-name="Sheepskull"
+          :hours="40" :is-regular="true" :regular-id="101" :allow-toggle-regular="true"
+          @add-regular="log('addRegular')"
+          @remove-regular="log('removeRegular')"
+        />
+      </div>
+
+      <h2>Toggle allowed — working (in-flight)</h2>
+      <div class="demo">
+        <ProfileGroupItem
+          :group-id="1" group-key="sheepskull" group-name="Sheepskull"
+          :hours="40" :is-regular="true" :regular-id="101"
+          :allow-toggle-regular="true" :working="true"
+        />
+      </div>
+
+      <h2>Read-only — is regular</h2>
+      <div class="demo">
+        <ProfileGroupItem
+          :group-id="1" group-key="sheepskull" group-name="Sheepskull"
+          :hours="40" :is-regular="true" :regular-id="101"
+        />
+      </div>
+
+      <h2>Read-only — not regular</h2>
+      <div class="demo">
+        <ProfileGroupItem
+          :group-id="2" group-key="dig-deep" group-name="Dig Deep"
+          :hours="6" :is-regular="false"
+        />
+      </div>
+
+      <h2>Fractional hours</h2>
+      <div class="demo">
+        <ProfileGroupItem
+          :group-id="3" group-key="riverside" group-name="Riverside Crew"
+          :hours="7.5" :is-regular="false" :allow-toggle-regular="true"
+        />
+      </div>
+
+      <h2>Event log</h2>
+      <div class="event-log">
+        <div v-if="!events.length" class="event-log-empty">No events yet.</div>
+        <div v-for="(e, i) in events" :key="i">{{ e }}</div>
+      </div>
+
+    </div>
+  </DefaultLayout>
+</template>
+
+<script setup lang="ts">
+import '../../styles/sandbox.css'
+import { ref } from 'vue'
+import { usePageTitle } from '../../composables/usePageTitle'
+import DefaultLayout from '../../layouts/DefaultLayout.vue'
+import ProfileGroupItem from '../../components/profiles/ProfileGroupItem.vue'
+
+usePageTitle('Sandbox')
+
+const events = ref<string[]>([])
+
+function log(msg: string) {
+  events.value.unshift(msg)
+}
+</script>

--- a/frontend/src/pages/sandbox/SandboxProfileGroupList.vue
+++ b/frontend/src/pages/sandbox/SandboxProfileGroupList.vue
@@ -1,0 +1,128 @@
+<template>
+  <DefaultLayout>
+    <div class="sandbox">
+
+      <RouterLink to="/sandbox" class="back">← Sandbox</RouterLink>
+      <h1>ProfileGroupList</h1>
+
+      <h2>Admin/Check-In — regular checkbox</h2>
+      <div class="demo">
+        <ProfileGroupList
+          :groups="mockGroups"
+          :allow-toggle-regular="true"
+          ref="adminRef"
+          @add-regular="onAddRegular"
+          @remove-regular="onRemoveRegular"
+        />
+      </div>
+
+      <h2>Self-Service / Read-Only — Regular badge, no toggle</h2>
+      <div class="demo">
+        <ProfileGroupList
+          :groups="mockGroups"
+        />
+      </div>
+
+      <h2>Empty state</h2>
+      <div class="demo">
+        <ProfileGroupList
+          :groups="[]"
+        />
+      </div>
+
+      <h2>This FY hours</h2>
+      <div class="demo">
+        <ProfileGroupList
+          :groups="mockGroups"
+          fy="thisFY"
+        />
+      </div>
+
+      <h2>Event log</h2>
+      <div class="event-log">
+        <div v-if="!events.length" class="event-log-empty">No events yet.</div>
+        <div v-for="(e, i) in events" :key="i">{{ e }}</div>
+      </div>
+
+    </div>
+  </DefaultLayout>
+</template>
+
+<script setup lang="ts">
+import '../../styles/sandbox.css'
+import { ref, reactive } from 'vue'
+import { usePageTitle } from '../../composables/usePageTitle'
+import DefaultLayout from '../../layouts/DefaultLayout.vue'
+import ProfileGroupList from '../../components/profiles/ProfileGroupList.vue'
+import type { ProfileGroupHours } from '../../../../types/api-responses'
+
+usePageTitle('Sandbox')
+
+const events = ref<string[]>([])
+const adminRef = ref<InstanceType<typeof ProfileGroupList> | null>(null)
+
+function log(msg: string) {
+  events.value.unshift(msg)
+}
+
+const FAIL_GROUP_ID = 2
+
+function onAddRegular(groupId: number) {
+  log(`addRegular groupId=${groupId}`)
+  setTimeout(() => {
+    if (groupId === FAIL_GROUP_ID) {
+      log(`addRegular groupId=${groupId} — FAILED`)
+      adminRef.value?.onError(groupId, 'Failed to add regular — please try again')
+      return
+    }
+    const g = mockGroups.find(g => g.groupId === groupId)
+    if (g) { g.isRegular = true; g.regularId = 999 }
+    adminRef.value?.onSuccess(groupId)
+  }, 1000)
+}
+
+function onRemoveRegular(regularId: number, groupId: number) {
+  log(`removeRegular regularId=${regularId} groupId=${groupId}`)
+  setTimeout(() => {
+    if (groupId === FAIL_GROUP_ID) {
+      log(`removeRegular groupId=${groupId} — FAILED`)
+      adminRef.value?.onError(groupId, 'Failed to remove regular — please try again')
+      return
+    }
+    const g = mockGroups.find(g => g.groupId === groupId)
+    if (g) { g.isRegular = false; g.regularId = undefined }
+    adminRef.value?.onSuccess(groupId)
+  }, 1000)
+}
+
+const mockGroups = reactive<ProfileGroupHours[]>([
+  {
+    groupId: 1,
+    groupKey: 'sheepskull',
+    groupName: 'Sheepskull',
+    hoursThisFY: 12,
+    hoursLastFY: 28,
+    hoursAll: 40,
+    isRegular: true,
+    regularId: 101,
+  },
+  {
+    groupId: 2,
+    groupKey: 'dig-deep',
+    groupName: 'Dig Deep',
+    hoursThisFY: 6,
+    hoursLastFY: 0,
+    hoursAll: 6,
+    isRegular: false,
+  },
+  {
+    groupId: 3,
+    groupKey: 'riverside',
+    groupName: 'Riverside Crew',
+    hoursThisFY: 0,
+    hoursLastFY: 14,
+    hoursAll: 14,
+    isRegular: false,
+  },
+])
+</script>

--- a/frontend/src/pages/sandbox/SandboxProfileRecordList.vue
+++ b/frontend/src/pages/sandbox/SandboxProfileRecordList.vue
@@ -11,7 +11,8 @@
           :records="mockRecords"
           :profile-id="1"
           profile-slug="alice-bowen-1"
-          :profile="adminContext"
+          :show-consent-link="true"
+          :allow-edit="true"
           :types="mockTypes"
           :statuses="mockStatuses"
           ref="adminRef"
@@ -27,7 +28,7 @@
           :records="mockRecords"
           :profile-id="1"
           profile-slug="alice-bowen-1"
-          :profile="checkInContext"
+          :show-consent-link="true"
           :types="mockTypes"
           :statuses="mockStatuses"
         />
@@ -39,7 +40,7 @@
           :records="mockRecords"
           :profile-id="1"
           profile-slug="alice-bowen-1"
-          :profile="selfServiceContext"
+          :show-consent-link="true"
           :types="mockTypes"
           :statuses="mockStatuses"
         />
@@ -51,7 +52,6 @@
           :records="mockRecords"
           :profile-id="1"
           profile-slug="alice-bowen-1"
-          :profile="readOnlyContext"
           :types="mockTypes"
           :statuses="mockStatuses"
         />
@@ -63,7 +63,8 @@
           :records="[]"
           :profile-id="1"
           profile-slug="alice-bowen-1"
-          :profile="adminContext"
+          :show-consent-link="true"
+          :allow-edit="true"
           :types="mockTypes"
           :statuses="mockStatuses"
         />
@@ -85,7 +86,6 @@ import { ref } from 'vue'
 import { usePageTitle } from '../../composables/usePageTitle'
 import DefaultLayout from '../../layouts/DefaultLayout.vue'
 import ProfileRecordList from '../../components/profiles/ProfileRecordList.vue'
-import type { RoleContext } from '../../composables/useViewer'
 import type { AddRecordPayload } from '../modals/RecordAddModal.vue'
 import type { SaveRecordPayload } from '../modals/RecordEditModal.vue'
 
@@ -111,30 +111,6 @@ function onSaveRecord(id: number, payload: SaveRecordPayload) {
 function onDeleteRecord(id: number) {
   log(`deleteRecord id=${id}`)
   setTimeout(() => adminRef.value?.onDeleteSuccess(), 1000)
-}
-
-const adminContext: RoleContext = {
-  isAdmin: true, isCheckIn: false, isReadOnly: false,
-  isSelfService: false, isTrusted: true, isAuthenticated: true,
-  isPublic: false, isOperational: true,
-}
-
-const checkInContext: RoleContext = {
-  isAdmin: false, isCheckIn: true, isReadOnly: false,
-  isSelfService: false, isTrusted: true, isAuthenticated: true,
-  isPublic: false, isOperational: true,
-}
-
-const selfServiceContext: RoleContext = {
-  isAdmin: false, isCheckIn: false, isReadOnly: false,
-  isSelfService: true, isTrusted: false, isAuthenticated: true,
-  isPublic: false, isOperational: false,
-}
-
-const readOnlyContext: RoleContext = {
-  isAdmin: false, isCheckIn: false, isReadOnly: true,
-  isSelfService: false, isTrusted: true, isAuthenticated: true,
-  isPublic: false, isOperational: false,
 }
 
 const mockTypes = [

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -62,6 +62,8 @@ export const router = createRouter({
     { path: '/sandbox/filter-components', component: () => import('../pages/sandbox/SandboxFilterComponents.vue') },
     { path: '/sandbox/session-term-list', component: () => import('../pages/sandbox/SandboxSessionTermList.vue') },
     { path: '/sandbox/profile-record-list', component: () => import('../pages/sandbox/SandboxProfileRecordList.vue') },
+    { path: '/sandbox/profile-group-list', component: () => import('../pages/sandbox/SandboxProfileGroupList.vue') },
+    { path: '/sandbox/profile-group-item', component: () => import('../pages/sandbox/SandboxProfileGroupItem.vue') },
   ]
 })
 

--- a/routes/profiles.ts
+++ b/routes/profiles.ts
@@ -19,7 +19,6 @@ import {
   buildBadgeLookups,
   safeParseLookupId,
   parseHours,
-  nameToSlug,
   profileSlug,
   profileIdFromSlug,
   toMatchName,
@@ -604,9 +603,11 @@ router.get('/profiles/:slug', async (req: Request, res: Response) => {
 
     const profiles = validateArray(rawProfiles, validateProfile, 'Profile');
     const profileId = profileIdFromSlug(slug);
-    const spProfile = profileId !== undefined
-      ? profiles.find(p => p.ID === profileId)
-      : profiles.find(p => nameToSlug(p.Title) === slug); // legacy: slug without ID
+    if (profileId === undefined) {
+      res.status(404).json({ success: false, error: 'Invalid profile slug' });
+      return;
+    }
+    const spProfile = profiles.find(p => p.ID === profileId);
     if (!spProfile) {
       res.status(404).json({ success: false, error: 'Profile not found' });
       return;
@@ -781,7 +782,7 @@ router.get('/profiles/:slug', async (req: Request, res: Response) => {
 
     const data: ProfileDetailResponse = {
       id: profile.id,
-      slug: nameToSlug(profile.name),
+      slug: profileSlug(profile.name, profile.id),
       name: profile.name,
       emails: profile.emails,
       matchName: spProfile.MatchName,
@@ -837,9 +838,11 @@ router.patch('/profiles/:slug', async (req: Request, res: Response) => {
     const rawProfiles = await profilesRepository.getAll();
     const profiles = validateArray(rawProfiles, validateProfile, 'Profile');
     const profileId = profileIdFromSlug(slug);
-    const spProfile = profileId !== undefined
-      ? profiles.find(p => p.ID === profileId)
-      : profiles.find(p => nameToSlug(p.Title) === slug); // legacy: slug without ID
+    if (profileId === undefined) {
+      res.status(404).json({ success: false, error: 'Invalid profile slug' });
+      return;
+    }
+    const spProfile = profiles.find(p => p.ID === profileId);
     if (!spProfile) {
       res.status(404).json({ success: false, error: 'Profile not found' });
       return;
@@ -876,9 +879,11 @@ router.post('/profiles/:slug/transfer', async (req: Request, res: Response) => {
 
     const profiles = validateArray(rawProfiles, validateProfile, 'Profile');
     const profileId = profileIdFromSlug(slug);
-    const sourceProfile = profileId !== undefined
-      ? profiles.find(p => p.ID === profileId)
-      : profiles.find(p => nameToSlug(p.Title) === slug); // legacy: slug without ID
+    if (profileId === undefined) {
+      res.status(404).json({ success: false, error: 'Invalid profile slug' });
+      return;
+    }
+    const sourceProfile = profiles.find(p => p.ID === profileId);
     if (!sourceProfile) {
       res.status(404).json({ success: false, error: 'Source profile not found' });
       return;
@@ -1002,9 +1007,11 @@ router.delete('/profiles/:slug', async (req: Request, res: Response) => {
 
     const profiles = validateArray(rawProfiles, validateProfile, 'Profile');
     const profileId = profileIdFromSlug(slug);
-    const spProfile = profileId !== undefined
-      ? profiles.find(p => p.ID === profileId)
-      : profiles.find(p => nameToSlug(p.Title) === slug); // legacy: slug without ID
+    if (profileId === undefined) {
+      res.status(404).json({ success: false, error: 'Invalid profile slug' });
+      return;
+    }
+    const spProfile = profiles.find(p => p.ID === profileId);
     if (!spProfile) {
       res.status(404).json({ success: false, error: 'Profile not found' });
       return;


### PR DESCRIPTION
…r toggle (step 3 of #2)

- ProfileGroupItem: sand card, green checkbox, gold hours, spinner while in-flight; read-only regular shows static green tick, no label
- ProfileGroupList: wrapping flex layout, error message on toggle failure, owns workingGroupId and error state
- ProfileDetailPage: wires addRegular/removeRegular API calls, mutates store.profile.groupHours on success
- ProfileRecordList, ProfileGroupList: replace profile: RoleContext prop with capability booleans (showConsentLink, allowEdit, allowToggleRegular)
- SandboxProfileGroupList, SandboxProfileGroupItem: full sandbox coverage; Dig Deep simulates failure
- RecordAddModal: disable Add button until both type and status are selected