### PR TITLE
feat: #1 Profile List Page v2

### DIFF
--- a/frontend/src/components/profiles/ProfileListActions.vue
+++ b/frontend/src/components/profiles/ProfileListActions.vue
@@ -1,0 +1,98 @@
+<template>
+  <div v-if="canBulkEdit" class="pla-wrap">
+    <span class="pla-stats">
+      {{ selected.length }} / {{ filteredProfiles.length }} {{ filteredProfiles.length === 1 ? 'profile' : 'profiles' }}
+    </span>
+    <div class="pla-buttons">
+      <AppButton
+        label="Add Records"
+        icon="add"
+        mode="icon-responsive"
+        :disabled="individualSelected.length === 0"
+        @click="emit('add-records')"
+      />
+      <AppButton
+        label="Download CSV"
+        icon="download"
+        mode="icon-responsive"
+        :disabled="selected.length === 0"
+        @click="downloadCsv"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import AppButton from '../AppButton.vue'
+import type { ProfileResponse } from '../../../../types/api-responses'
+
+const props = defineProps<{
+  filteredProfiles: ProfileResponse[]
+  selected: number[]
+  canBulkEdit: boolean
+  fy: string
+}>()
+
+const emit = defineEmits<{
+  'add-records': []
+  'update:selected': [ids: number[]]
+}>()
+
+// Only individual profiles (not groups) are eligible for bulk records
+const individualSelected = computed(() =>
+  props.selected.filter(id => {
+    const p = props.filteredProfiles.find(x => x.id === id)
+    return p && !p.isGroup
+  })
+)
+
+function hoursFor(p: ProfileResponse): number {
+  return props.fy === 'all' ? p.hoursAll : p.hoursThisFY
+}
+
+function sessionsFor(p: ProfileResponse): number {
+  return props.fy === 'all' ? p.sessionsAll : p.sessionsThisFY
+}
+
+function downloadCsv() {
+  const source = props.filteredProfiles.filter(p => props.selected.includes(p.id))
+
+  const headers = ['Name', 'Email', 'Sessions', 'Hours']
+  const rows = source.map(p => [
+    p.name ?? '',
+    p.email ?? '',
+    sessionsFor(p),
+    Math.round(hoursFor(p) * 10) / 10,
+  ])
+
+  const csv = [headers, ...rows]
+    .map(row => row.map(cell => {
+      const str = String(cell)
+      return /[,"\n]/.test(str) ? `"${str.replace(/"/g, '""')}"` : str
+    }).join(','))
+    .join('\n')
+
+  const today = new Date().toISOString().slice(0, 10)
+  const a = document.createElement('a')
+  a.href = URL.createObjectURL(new Blob(['\uFEFF' + csv], { type: 'text/csv;charset=utf-8' }))
+  a.download = `${today} Profiles.csv`
+  a.click()
+  URL.revokeObjectURL(a.href)
+}
+</script>
+
+<style scoped>
+.pla-wrap {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  background: var(--color-dtv-sand);
+  padding: 0.75rem 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.pla-stats { flex: 1; font-size: 0.85rem; color: var(--color-text-secondary); }
+.pla-buttons { display: flex; gap: 0.5rem; margin-left: auto; }
+</style>

--- a/frontend/src/components/profiles/ProfileListFilter.vue
+++ b/frontend/src/components/profiles/ProfileListFilter.vue
@@ -1,0 +1,198 @@
+<template>
+  <div class="plf-wrap">
+    <!-- Row 1: search + FY + group + sort -->
+    <div class="plf-row">
+      <input
+        v-model="search"
+        type="text"
+        class="plf-search"
+        placeholder="Search volunteers…"
+        autocomplete="off"
+      />
+      <FyFilter v-model="fy" />
+      <select v-model="group" class="plf-select">
+        <option value="">All groups</option>
+        <option v-for="g in groups" :key="g.key" :value="g.key">{{ g.displayName ?? g.key }}</option>
+      </select>
+      <select v-model="sort" class="plf-select">
+        <option value="az">A–Z</option>
+        <option value="hours">Hours</option>
+      </select>
+    </div>
+
+    <!-- Row 2: advanced filters (always visible) -->
+    <div class="plf-row plf-row--advanced">
+      <select v-model="type" class="plf-select">
+        <option value="">All profiles</option>
+        <option value="individuals">Individuals</option>
+        <option value="groups">Groups</option>
+        <option value="users">Users</option>
+      </select>
+      <select v-model="hoursFilter" class="plf-select">
+        <option value="">All hours</option>
+        <option value="0">0h</option>
+        <option value="lt15">&lt;15h</option>
+        <option value="15plus">15h+</option>
+        <option value="15to30">15–30h</option>
+        <option value="30plus">30h+</option>
+      </select>
+      <select v-model="recordType" class="plf-select">
+        <option value="">All record types</option>
+        <option v-for="t in recordOptions.types" :key="t" :value="t">{{ t }}</option>
+      </select>
+      <select v-model="recordStatus" class="plf-select" :disabled="!recordType">
+        <option value="">All statuses</option>
+        <option value="none">No record</option>
+        <option v-for="s in recordOptions.statuses" :key="s" :value="s">{{ s }}</option>
+      </select>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue'
+import { useRoute } from 'vue-router'
+import FyFilter from '../FyFilter.vue'
+import type { ProfileResponse } from '../../../../types/api-responses'
+import type { GroupResponse } from '../../../../types/api-responses'
+
+const props = defineProps<{
+  profiles: ProfileResponse[]
+  groups: GroupResponse[]
+  recordOptions: { types: string[]; statuses: string[] }
+}>()
+
+const emit = defineEmits<{
+  filtered: [profiles: ProfileResponse[]]
+  'fy-change': [fy: string]
+  'group-change': [group: string]
+}>()
+
+const route = useRoute()
+
+const fy          = ref((route.query.fy as string)           || 'rolling')
+const group       = ref((route.query.group as string)        || '')
+const search      = ref((route.query.search as string)       || '')
+const sort        = ref((route.query.sort as string)         || 'az')
+const type        = ref((route.query.type as string)         || '')
+const hoursFilter = ref((route.query.hours as string)        || '')
+const recordType  = ref((route.query.recordType as string)   || '')
+const recordStatus = ref((route.query.recordStatus as string) || '')
+
+// FY and group changes require a store re-fetch — emit upward
+watch(fy, val => emit('fy-change', val))
+watch(group, val => emit('group-change', val))
+
+// Clear record status when record type is cleared
+watch(recordType, val => { if (!val) recordStatus.value = '' })
+
+function hoursForProfile(p: ProfileResponse): number {
+  return fy.value === 'all' ? p.hoursAll : p.hoursThisFY
+}
+
+function sessionsForProfile(p: ProfileResponse): number {
+  return fy.value === 'all' ? p.sessionsAll : p.sessionsThisFY
+}
+
+const filtered = computed<ProfileResponse[]>(() => {
+  let list = props.profiles
+
+  // FY visibility: hide zero-activity profiles unless showing 'all' or filtering for 0h
+  if (fy.value !== 'all' && hoursFilter.value !== '0') {
+    list = list.filter(p => p.hoursThisFY > 0 || p.sessionsThisFY > 0)
+  }
+
+  // Search (3+ chars)
+  if (search.value.length >= 3) {
+    const q = search.value.toLowerCase()
+    list = list.filter(p => (p.name ?? '').toLowerCase().includes(q))
+  }
+
+  // Type filter
+  if (type.value === 'individuals') list = list.filter(p => !p.isGroup)
+  else if (type.value === 'groups')  list = list.filter(p => p.isGroup)
+  else if (type.value === 'users')   list = list.filter(p => !p.isGroup && !!p.user)
+
+  // Hours filter
+  if (hoursFilter.value) {
+    list = list.filter(p => {
+      const h = hoursForProfile(p)
+      if (hoursFilter.value === '0')      return h === 0
+      if (hoursFilter.value === 'lt15')   return h > 0 && h < 15
+      if (hoursFilter.value === '15plus') return h >= 15
+      if (hoursFilter.value === '15to30') return h >= 15 && h <= 30
+      if (hoursFilter.value === '30plus') return h > 30
+      return true
+    })
+  }
+
+  // Record filter
+  if (recordType.value) {
+    list = list.filter(p => {
+      const recs = (p.records ?? []).filter(r => r.type === recordType.value)
+      if (recordStatus.value === 'none') return recs.length === 0
+      if (recordStatus.value)           return recs.some(r => r.status === recordStatus.value)
+      return recs.length > 0
+    })
+  } else if (recordStatus.value === 'none') {
+    // Status 'none' with no type means no records at all
+    list = list.filter(p => !(p.records ?? []).length)
+  }
+
+  // Sort
+  list = [...list].sort((a, b) => {
+    if (sort.value === 'hours') {
+      const diff = hoursForProfile(b) - hoursForProfile(a)
+      return diff !== 0 ? diff : (a.name ?? '').localeCompare(b.name ?? '')
+    }
+    const nameDiff = (a.name ?? '').localeCompare(b.name ?? '')
+    return nameDiff !== 0 ? nameDiff : hoursForProfile(b) - hoursForProfile(a)
+  })
+
+  return list
+})
+
+watch(filtered, list => emit('filtered', list), { immediate: true })
+</script>
+
+<style scoped>
+.plf-wrap {
+  background: var(--color-dtv-sand);
+  padding: 1rem 1.5rem;
+  margin-bottom: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.plf-row {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: stretch;
+}
+
+.plf-search {
+  flex: 2 1 180px;
+  padding: 0.5rem 0.75rem;
+  border: 2px solid var(--color-border);
+  font-size: 0.95rem;
+  font-family: inherit;
+  color: var(--color-text);
+  background: var(--color-white);
+  box-sizing: border-box;
+}
+.plf-search:focus { outline: none; border-color: var(--color-dtv-green); }
+
+.plf-select {
+  flex: 1 1 130px;
+  padding: 0.45rem 0.6rem;
+  border: 1px solid var(--color-border);
+  font-size: 0.85rem;
+  font-family: inherit;
+  color: var(--color-text);
+  background: var(--color-white);
+  cursor: pointer;
+}
+.plf-select:disabled { opacity: 0.5; cursor: default; }
+</style>

--- a/frontend/src/components/profiles/ProfileListFilter.vue
+++ b/frontend/src/components/profiles/ProfileListFilter.vue
@@ -80,8 +80,9 @@ const recordType  = ref((route.query.recordType as string)   || '')
 const recordStatus = ref((route.query.recordStatus as string) || '')
 
 // FY and group changes require a store re-fetch — emit upward
-watch(fy, val => emit('fy-change', val))
-watch(group, val => emit('group-change', val))
+// immediate: true ensures deep-linked query params are emitted on first load
+watch(fy, val => emit('fy-change', val), { immediate: true })
+watch(group, val => emit('group-change', val), { immediate: true })
 
 // Clear record status when record type is cleared
 watch(recordType, val => { if (!val) recordStatus.value = '' })

--- a/frontend/src/components/profiles/ProfileListItem.vue
+++ b/frontend/src/components/profiles/ProfileListItem.vue
@@ -1,0 +1,104 @@
+<template>
+  <RouterLink :to="profilePath(profile.slug)" class="pli-wrap">
+    <span class="pli-left">
+      <span class="pli-name">{{ profile.name ?? '(no name)' }}</span>
+      <span class="pli-badges">
+        <img v-if="profile.isGroup" src="/icons/group.svg" class="pli-badge svg-black" alt="Group" title="Group" />
+        <img v-if="profile.isMember && !profile.isGroup" src="/icons/member.svg" class="pli-badge svg-black" alt="Member" title="Member" />
+        <img
+          v-if="profile.cardStatus"
+          src="/icons/card.svg"
+          class="pli-badge"
+          :class="profile.cardStatus === 'Invited' ? 'svg-orange' : 'svg-green'"
+          :alt="`Card: ${profile.cardStatus}`"
+          :title="`Card: ${profile.cardStatus}`"
+        />
+      </span>
+    </span>
+    <span class="pli-meta">
+      <span class="pli-stat">{{ displaySessions }} <span class="pli-stat-label">sessions</span></span>
+      <span class="pli-stat">{{ displayHoursFormatted }} <span class="pli-stat-label">hours</span></span>
+    </span>
+  </RouterLink>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { profilePath } from '../../router/index'
+import type { ProfileResponse } from '../../../../types/api-responses'
+
+const props = defineProps<{
+  profile: ProfileResponse
+  displayHours: number
+  displaySessions: number
+}>()
+
+const displayHoursFormatted = computed(() =>
+  Math.round(props.displayHours * 10) / 10
+)
+</script>
+
+<style scoped>
+.pli-wrap {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0.5rem 1.5rem;
+  background: var(--color-dtv-light);
+  text-decoration: none;
+  color: var(--color-text);
+}
+
+.pli-wrap:hover { background: var(--color-dtv-sand-light); }
+
+.pli-left {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.25rem;
+  overflow: hidden;
+}
+
+.pli-name {
+  font-weight: 400;
+  font-size: 0.95rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex-shrink: 1;
+  min-width: 0;
+}
+
+.pli-badges {
+  display: flex;
+  gap: 0.25rem;
+  flex-shrink: 0;
+  align-items: flex-start;
+}
+
+.pli-badge {
+  width: 0.875rem;
+  height: 0.875rem;
+  object-fit: contain;
+  align-self: flex-start;
+}
+
+.pli-meta {
+  display: flex;
+  gap: 1rem;
+  flex-shrink: 0;
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+}
+
+.pli-stat { white-space: nowrap; }
+.pli-stat-label { color: var(--color-text-muted); }
+
+.svg-green { filter: invert(40%) sepia(80%) saturate(400%) hue-rotate(90deg) brightness(90%); }
+.svg-orange { filter: invert(65%) sepia(80%) saturate(600%) hue-rotate(5deg) brightness(95%); }
+
+@media (width < 48em) {
+  .pli-meta { gap: 0.5rem; }
+}
+</style>

--- a/frontend/src/components/profiles/ProfileListResults.vue
+++ b/frontend/src/components/profiles/ProfileListResults.vue
@@ -1,0 +1,115 @@
+<template>
+  <div class="plr-section">
+    <div v-if="loading" class="plr-empty">Loading…</div>
+    <div v-else-if="!profiles.length" class="plr-empty">No volunteers found.</div>
+    <template v-else>
+      <div v-if="canSelect && selected" class="plr-select-row">
+        <button class="plr-select-all" @click="toggleSelectAll">
+          {{ allSelected ? 'Deselect all' : 'Select all' }}
+        </button>
+      </div>
+      <div class="plr-list">
+        <div v-for="p in profiles" :key="p.id" class="plr-item">
+          <input
+            v-if="canSelect && selected"
+            type="checkbox"
+            class="plr-checkbox"
+            :checked="selected.includes(p.id)"
+            @change="toggle(p.id)"
+          />
+          <ProfileListItem
+            :profile="p"
+            :display-hours="hoursFor(p)"
+            :display-sessions="sessionsFor(p)"
+          />
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import ProfileListItem from './ProfileListItem.vue'
+import type { ProfileResponse } from '../../../../types/api-responses'
+
+
+const props = defineProps<{
+  profiles: ProfileResponse[]
+  loading?: boolean
+  selected?: number[]
+  canSelect: boolean
+  fy: string
+}>()
+
+const emit = defineEmits<{ 'update:selected': [ids: number[]] }>()
+
+function hoursFor(p: ProfileResponse): number {
+  return props.fy === 'all' ? p.hoursAll : p.hoursThisFY
+}
+
+function sessionsFor(p: ProfileResponse): number {
+  return props.fy === 'all' ? p.sessionsAll : p.sessionsThisFY
+}
+
+
+const allSelected = computed(() =>
+  props.profiles.length > 0 && props.profiles.every(p => props.selected?.includes(p.id))
+)
+
+function toggleSelectAll() {
+  emit('update:selected', allSelected.value ? [] : props.profiles.map(p => p.id))
+}
+
+function toggle(id: number) {
+  if (!props.selected) return
+  const next = props.selected.includes(id)
+    ? props.selected.filter(i => i !== id)
+    : [...props.selected, id]
+  emit('update:selected', next)
+}
+</script>
+
+<style scoped>
+.plr-section { padding: 0; }
+
+.plr-empty { padding: 1.5rem 0; color: var(--color-text-muted); font-size: 0.9rem; }
+
+.plr-select-row {
+  padding: 0.5rem 1.5rem;
+  border-bottom: 1px solid var(--color-surface-hover);
+}
+
+.plr-select-all {
+  background: none; border: none; cursor: pointer;
+  font-size: 0.85rem; font-weight: 600; color: var(--color-dtv-green); padding: 0;
+}
+.plr-select-all:hover { text-decoration: underline; }
+
+.plr-list { display: flex; flex-direction: column; }
+
+.plr-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding-left: 1.5rem;
+}
+
+.plr-item :deep(.pli-wrap) { padding-left: 0; flex: 1; }
+
+.plr-checkbox {
+  flex-shrink: 0;
+  appearance: none;
+  width: 20px; height: 20px;
+  border-radius: 0;
+  border: 1.5px solid var(--color-border);
+  background: var(--color-dtv-sand);
+  cursor: pointer;
+}
+
+.plr-checkbox:checked {
+  background: var(--color-dtv-green);
+  border-color: var(--color-dtv-green);
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M3 8l3.5 3.5L13 4.5' stroke='white' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+}
+</style>

--- a/frontend/src/components/sessions/SessionListActions.vue
+++ b/frontend/src/components/sessions/SessionListActions.vue
@@ -5,25 +5,15 @@
     </span>
 
     <div class="sa-buttons">
-      <AppButton label="Add Tags" icon="add" mode="icon-responsive" :disabled="!selected.length" @click="showTagModal = true" />
+      <AppButton label="Add Tags" icon="add" mode="icon-responsive" :disabled="!selected.length" @click="emit('add-tags')" />
       <AppButton label="Download CSV" icon="download" mode="icon-responsive" :disabled="!selected.length" @click="downloadCsv" />
     </div>
-
-    <SessionAddTagsModal
-      v-if="showTagModal"
-      :count="selected.length"
-      :working="tagWorking"
-      :error="tagError"
-      @close="showTagModal = false"
-      @save="onSave"
-    />
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { computed } from 'vue'
 import AppButton from '../AppButton.vue'
-import SessionAddTagsModal from '../../pages/modals/SessionAddTagsModal.vue'
 import type { Session } from '../../types/session'
 
 const props = defineProps<{
@@ -34,12 +24,8 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   'update:selected': [ids: number[]]
-  applyTag: [label: string, termGuid: string]
+  'add-tags': []
 }>()
-
-const showTagModal = ref(false)
-const tagWorking = ref(false)
-const tagError = ref('')
 
 const selectedSessions = computed(() => props.sessions.filter(s => props.selected.includes(s.id)))
 
@@ -48,24 +34,6 @@ const selectedHours = computed(() =>
 
 const totalHours = computed(() =>
   Math.round(props.sessions.reduce((sum, s) => sum + (s.hours || 0), 0) * 10) / 10)
-
-function onSave(label: string, termGuid: string) {
-  tagWorking.value = true
-  tagError.value = ''
-  emit('applyTag', label, termGuid)
-}
-
-defineExpose({
-  onTagSuccess() {
-    showTagModal.value = false
-    tagWorking.value = false
-    tagError.value = ''
-  },
-  onTagError(msg: string) {
-    tagWorking.value = false
-    tagError.value = msg
-  },
-})
 
 function downloadCsv() {
   const headers = ['Date', 'Group', 'Name', 'Registrations', 'Hours', 'New', 'Children', 'Regulars', 'Financial Year']

--- a/frontend/src/pages/ProfileListPage.vue
+++ b/frontend/src/pages/ProfileListPage.vue
@@ -1,23 +1,130 @@
 <template>
   <DefaultLayout>
     <h1 class="sr-only">Profiles</h1>
-    <DebugData :item="{ profiles: profilesStore.profiles }" label="profiles" />
-    <DebugData :item="profile.context" label="userProfile" />
+    <PageHeader>Volunteers</PageHeader>
+    <div class="px-6 pb-6">
+      <ProfileListFilter
+        :profiles="store.profiles"
+        :groups="groupsStore.groups"
+        :record-options="recordOptions"
+        @filtered="filtered = $event"
+        @fy-change="onFyChange"
+        @group-change="onGroupChange"
+      />
+      <ProfileListActions
+        :filtered-profiles="filtered"
+        :selected="selected"
+        :can-bulk-edit="profile.isAdmin"
+        :fy="fy"
+        @add-records="showBulkModal = true"
+        @update:selected="selected = $event"
+      />
+      <ProfileListResults
+        :profiles="filtered"
+        :loading="store.loading"
+        :selected="selected"
+        :can-select="profile.isAdmin"
+        :fy="fy"
+        @update:selected="selected = $event"
+      />
+    </div>
+
+    <ProfileBulkRecordsModal
+      v-if="showBulkModal"
+      :count="individualSelectedCount"
+      :record-options="recordOptions"
+      :working="bulkWorking"
+      :error="bulkError"
+      @close="showBulkModal = false"
+      @save="onBulkSave"
+    />
   </DefaultLayout>
 </template>
 
 <script setup lang="ts">
-import { onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import DefaultLayout from '../layouts/DefaultLayout.vue'
-import DebugData from '../components/DebugData.vue'
+import PageHeader from '../components/PageHeader.vue'
+import ProfileListFilter from '../components/profiles/ProfileListFilter.vue'
+import ProfileListActions from '../components/profiles/ProfileListActions.vue'
+import ProfileListResults from '../components/profiles/ProfileListResults.vue'
+import ProfileBulkRecordsModal from './modals/ProfileBulkRecordsModal.vue'
+import type { BulkRecordPayload } from './modals/ProfileBulkRecordsModal.vue'
 import { usePageTitle } from '../composables/usePageTitle'
 import { useViewer } from '../composables/useViewer'
 import { useProfileListStore } from '../stores/profileList'
+import { useGroupListStore } from '../stores/groupList'
+import type { ProfileResponse } from '../../../types/api-responses'
 
-usePageTitle('Profiles')
+usePageTitle('Volunteers')
 
 const profile = useViewer()
-const profilesStore = useProfileListStore()
+const store = useProfileListStore()
+const groupsStore = useGroupListStore()
 
-onMounted(() => profilesStore.fetch())
+const fy = ref('rolling')
+const group = ref('')
+const filtered = ref<ProfileResponse[]>([])
+const selected = ref<number[]>([])
+const showBulkModal = ref(false)
+const bulkWorking = ref(false)
+const bulkError = ref('')
+const recordOptions = ref<{ types: string[]; statuses: string[] }>({ types: [], statuses: [] })
+
+// Individual (non-group) profile IDs from current selection
+const individualSelectedCount = computed(() =>
+  selected.value.filter(id => {
+    const p = store.profiles.find(x => x.id === id)
+    return p && !p.isGroup
+  }).length
+)
+
+function onFyChange(val: string) {
+  fy.value = val
+  store.fetch(val, group.value)
+}
+
+function onGroupChange(val: string) {
+  group.value = val
+  store.fetch(fy.value, val)
+}
+
+async function onBulkSave(payload: BulkRecordPayload) {
+  bulkWorking.value = true
+  bulkError.value = ''
+  try {
+    const individualIds = selected.value.filter(id => {
+      const p = store.profiles.find(x => x.id === id)
+      return p && !p.isGroup
+    })
+    const res = await fetch('/api/records/bulk', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ profileIds: individualIds, ...payload }),
+    })
+    if (!res.ok) throw new Error(`Bulk records failed (${res.status})`)
+    showBulkModal.value = false
+    selected.value = []
+    await store.fetch(fy.value, group.value)
+  } catch (e) {
+    bulkError.value = e instanceof Error ? e.message : 'An error occurred'
+    console.error('[ProfileListPage] onBulkSave', e)
+  } finally {
+    bulkWorking.value = false
+  }
+}
+
+onMounted(async () => {
+  groupsStore.fetch()
+  store.fetch(fy.value, group.value)
+  try {
+    const res = await fetch('/api/records/options')
+    if (res.ok) {
+      const json = await res.json()
+      recordOptions.value = json.data ?? { types: [], statuses: [] }
+    }
+  } catch (e) {
+    console.error('[ProfileListPage] failed to load record options', e)
+  }
+})
 </script>

--- a/frontend/src/pages/ProfileListPage.vue
+++ b/frontend/src/pages/ProfileListPage.vue
@@ -116,7 +116,7 @@ async function onBulkSave(payload: BulkRecordPayload) {
 
 onMounted(async () => {
   groupsStore.fetch()
-  store.fetch(fy.value, group.value)
+  // Initial profiles fetch is driven by the immediate fy/group watchers in ProfileListFilter
   try {
     const res = await fetch('/api/records/options')
     if (res.ok) {

--- a/frontend/src/pages/SessionListPage.vue
+++ b/frontend/src/pages/SessionListPage.vue
@@ -5,14 +5,22 @@
     <div class="px-6 pb-6">
       <SessionListFilter :sessions="store.sessions" @filtered="filtered = $event" />
       <SessionListActions
-        ref="actionsRef"
         :sessions="filtered"
         :can-bulk-tag="profile.isAdmin"
         v-model:selected="selected"
-        @apply-tag="onApplyTag"
+        @add-tags="showTagModal = true"
       />
       <SessionListResults :sessions="filtered" :loading="store.loading" v-model:selected="selected" />
     </div>
+
+    <SessionAddTagsModal
+      v-if="showTagModal"
+      :count="selected.length"
+      :working="tagWorking"
+      :error="tagError"
+      @close="showTagModal = false"
+      @save="onApplyTag"
+    />
   </DefaultLayout>
 </template>
 
@@ -24,6 +32,7 @@ import PageHeader from '../components/PageHeader.vue'
 import SessionListFilter from '../components/sessions/SessionListFilter.vue'
 import SessionListActions from '../components/sessions/SessionListActions.vue'
 import SessionListResults from '../components/sessions/SessionListResults.vue'
+import SessionAddTagsModal from './modals/SessionAddTagsModal.vue'
 import { useSessionListStore } from '../stores/sessionList'
 import { useViewer } from '../composables/useViewer'
 import type { Session } from '../types/session'
@@ -34,11 +43,15 @@ const store = useSessionListStore()
 const profile = useViewer()
 const filtered = ref<Session[]>([])
 const selected = ref<number[]>([])
-const actionsRef = ref<InstanceType<typeof SessionListActions> | null>(null)
+const showTagModal = ref(false)
+const tagWorking = ref(false)
+const tagError = ref('')
 
 store.fetch()
 
 async function onApplyTag(label: string, termGuid: string) {
+  tagWorking.value = true
+  tagError.value = ''
   const tag = { label, termGuid }
   const res = await fetch('/api/sessions/bulk-tag', {
     method: 'POST',
@@ -46,12 +59,15 @@ async function onApplyTag(label: string, termGuid: string) {
     body: JSON.stringify({ sessionIds: selected.value, tags: [tag] }),
   })
   if (!res.ok) {
-    actionsRef.value?.onTagError('Bulk tag failed — please try again')
+    tagError.value = 'Bulk tag failed — please try again'
+    tagWorking.value = false
     console.error('[SessionListPage] bulk-tag failed', res.status)
     return
   }
   store.applyTag(selected.value, tag)
-  actionsRef.value?.onTagSuccess()
+  showTagModal.value = false
+  tagWorking.value = false
+  tagError.value = ''
   selected.value = []
 }
 </script>

--- a/frontend/src/pages/modals/ProfileBulkRecordsModal.vue
+++ b/frontend/src/pages/modals/ProfileBulkRecordsModal.vue
@@ -1,0 +1,85 @@
+<template>
+  <ModalLayout
+    :title="`Add Record — ${count} ${count === 1 ? 'profile' : 'profiles'}`"
+    action="Add"
+    action-icon="add"
+    :working="working"
+    :error="error"
+    @close="emit('close')"
+    @action="save"
+  >
+    <FormLayout :disabled="working">
+      <FormRow title="Type" :full-width="true">
+        <select v-model="form.type" class="pbrm-select">
+          <option value="" disabled>Select type…</option>
+          <option v-for="t in recordOptions.types" :key="t" :value="t">{{ t }}</option>
+        </select>
+      </FormRow>
+      <FormRow title="Status" :full-width="true">
+        <select v-model="form.status" class="pbrm-select">
+          <option value="" disabled>Select status…</option>
+          <option v-for="s in recordOptions.statuses" :key="s" :value="s">{{ s }}</option>
+        </select>
+      </FormRow>
+      <FormRow title="Date" :full-width="true">
+        <input v-model="form.date" class="pbrm-input" type="date" />
+      </FormRow>
+    </FormLayout>
+  </ModalLayout>
+</template>
+
+<script setup lang="ts">
+import { reactive } from 'vue'
+import ModalLayout from '../../components/ModalLayout.vue'
+import FormLayout from '../../components/FormLayout.vue'
+import FormRow from '../../components/FormRow.vue'
+
+export interface BulkRecordPayload {
+  type: string
+  status: string
+  date: string
+}
+
+const props = defineProps<{
+  count: number
+  recordOptions: { types: string[]; statuses: string[] }
+  working: boolean
+  error?: string
+}>()
+
+const emit = defineEmits<{
+  close: []
+  save: [payload: BulkRecordPayload]
+}>()
+
+const today = new Date().toISOString().slice(0, 10)
+
+const form = reactive({
+  type: '',
+  status: '',
+  date: today,
+})
+
+function save() {
+  if (!form.type || !form.status) return
+  emit('save', {
+    type: form.type,
+    status: form.status,
+    date: form.date,
+  })
+}
+</script>
+
+<style scoped>
+.pbrm-select,
+.pbrm-input {
+  width: 100%;
+  background: var(--color-dtv-light);
+  border: none;
+  color: var(--color-text);
+  padding: 0.3rem 0.5rem;
+  font-family: inherit;
+  font-size: 0.95rem;
+  box-sizing: border-box;
+}
+</style>

--- a/frontend/src/pages/sandbox/SandboxActionBars.vue
+++ b/frontend/src/pages/sandbox/SandboxActionBars.vue
@@ -46,11 +46,10 @@
 
       <h2>SessionListActions (some selected)</h2>
       <SessionListActions
-        ref="listActionsRef"
         :sessions="mockSessions"
         :can-bulk-tag="true"
         v-model:selected="someSelected"
-        @apply-tag="label => onListAction(listActionsRef, label)"
+        @add-tags="onListAddTags"
       />
 
       <h2>GroupDetailActions (with Eventbrite)</h2>
@@ -99,7 +98,6 @@ import type { Session } from '../../types/session'
 
 const actionsWithEbRef = ref<InstanceType<typeof GroupDetailActions> | null>(null)
 const actionsWithoutEbRef = ref<InstanceType<typeof GroupDetailActions> | null>(null)
-const listActionsRef = ref<InstanceType<typeof SessionListActions> | null>(null)
 
 const failNext = ref(false)
 const events = ref<string[]>([])
@@ -127,19 +125,8 @@ async function onGroupAction(actions: ActionsInstance, label: string, data?: unk
   log(`${label} → done`)
 }
 
-type ListActionsInstance = InstanceType<typeof SessionListActions> | null
-
-async function onListAction(actions: ListActionsInstance, label: string) {
-  log(`apply-tag: "${label}" → saving…`)
-  await new Promise(r => setTimeout(r, 2000))
-  if (failNext.value) {
-    failNext.value = false
-    actions?.onTagError('Server error — please try again')
-    log(`apply-tag → failed`)
-    return
-  }
-  actions?.onTagSuccess()
-  log(`apply-tag → done`)
+function onListAddTags() {
+  log('add-tags → (modal would open on real page)')
 }
 
 const mockGroups = [

--- a/frontend/src/pages/sandbox/SandboxIndex.vue
+++ b/frontend/src/pages/sandbox/SandboxIndex.vue
@@ -36,12 +36,14 @@
       </section>
 
       <section>
-        <h2>Group and Session Lists</h2>
+        <h2>Group, Session and Profile Lists</h2>
         <nav>
           <RouterLink to="/sandbox/action-bars">Action Bars</RouterLink>
           <RouterLink to="/sandbox/filter-components">Filter Components</RouterLink>
           <RouterLink to="/sandbox/session-card">SessionCard</RouterLink>
           <RouterLink to="/sandbox/group-card">GroupCard</RouterLink>
+          <RouterLink to="/sandbox/profile-list-item">ProfileListItem</RouterLink>
+          <RouterLink to="/sandbox/profile-list-results">ProfileListResults</RouterLink>
         </nav>
       </section>
 

--- a/frontend/src/pages/sandbox/SandboxProfileListItem.vue
+++ b/frontend/src/pages/sandbox/SandboxProfileListItem.vue
@@ -1,0 +1,185 @@
+<template>
+  <DefaultLayout>
+    <div class="sandbox">
+      <RouterLink to="/sandbox" class="back">← Sandbox</RouterLink>
+      <h1>ProfileListItem</h1>
+      <p class="sandbox-warning">Static mocked data — no API calls.</p>
+
+      <h2>No badges — has hours (standard volunteer)</h2>
+      <div class="demo">
+        <ProfileListItem :profile="standard" :display-hours="42.5" :display-sessions="18" />
+      </div>
+
+      <h2>Group profile (isGroup: true — group icon)</h2>
+      <div class="demo">
+        <ProfileListItem :profile="group" :display-hours="312" :display-sessions="48" />
+      </div>
+
+      <h2>Member (isMember: true — member badge)</h2>
+      <div class="demo">
+        <ProfileListItem :profile="member" :display-hours="27" :display-sessions="11" />
+      </div>
+
+      <h2>Card: Accepted (green card icon)</h2>
+      <div class="demo">
+        <ProfileListItem :profile="cardAccepted" :display-hours="18" :display-sessions="7" />
+      </div>
+
+      <h2>Card: Invited (orange card icon)</h2>
+      <div class="demo">
+        <ProfileListItem :profile="cardInvited" :display-hours="15" :display-sessions="6" />
+      </div>
+
+      <h2>All badges combined (member + card accepted)</h2>
+      <div class="demo">
+        <ProfileListItem :profile="allBadges" :display-hours="56" :display-sessions="22" />
+      </div>
+
+      <h2>Zero hours</h2>
+      <div class="demo">
+        <ProfileListItem :profile="zeroHours" :display-hours="0" :display-sessions="0" />
+      </div>
+
+      <h2>No email (email field absent)</h2>
+      <div class="demo">
+        <ProfileListItem :profile="noEmail" :display-hours="8.5" :display-sessions="3" />
+      </div>
+
+      <h2>FY: All — shows hoursAll</h2>
+      <div class="demo">
+        <ProfileListItem :profile="standard" :display-hours="97.5" :display-sessions="42" />
+      </div>
+
+      <h2>With checkboxes — canSelect: true (admin view via ProfileListResults)</h2>
+      <p class="sandbox-warning">IDs 1 and 3 pre-selected to show checked state.</p>
+      <div class="demo">
+        <ProfileListResults
+          :profiles="mockProfiles"
+          :selected="selected"
+          :can-select="true"
+          fy="rolling"
+          @update:selected="selected = $event"
+        />
+      </div>
+      <p class="plsr-note">Selected IDs: {{ selected.length ? selected.join(', ') : '(none)' }}</p>
+    </div>
+  </DefaultLayout>
+</template>
+
+<script setup lang="ts">
+import '../../styles/sandbox.css'
+import { ref } from 'vue'
+import DefaultLayout from '../../layouts/DefaultLayout.vue'
+import ProfileListItem from '../../components/profiles/ProfileListItem.vue'
+import ProfileListResults from '../../components/profiles/ProfileListResults.vue'
+import { usePageTitle } from '../../composables/usePageTitle'
+import type { ProfileResponse } from '../../../../types/api-responses'
+
+usePageTitle('Sandbox')
+
+const selected = ref<number[]>([1, 3])
+
+const base: ProfileResponse = {
+  id: 1,
+  slug: 'alice-smith-1',
+  name: 'Alice Smith',
+  email: 'alice@example.com',
+  user: undefined,
+  isGroup: false,
+  isMember: false,
+  cardStatus: undefined,
+  hoursLastFY: 10,
+  hoursThisFY: 42.5,
+  hoursAll: 97.5,
+  sessionsLastFY: 4,
+  sessionsThisFY: 18,
+  sessionsAll: 42,
+  records: [],
+}
+
+const standard: ProfileResponse = { ...base }
+
+const group: ProfileResponse = {
+  ...base,
+  id: 2,
+  slug: 'saturday-dig-2',
+  name: 'Saturday Dig',
+  isGroup: true,
+  isMember: false,
+  hoursThisFY: 312,
+  sessionsThisFY: 48,
+  hoursAll: 600,
+  sessionsAll: 96,
+}
+
+const member: ProfileResponse = {
+  ...base,
+  id: 3,
+  slug: 'bob-jones-3',
+  name: 'Bob Jones',
+  isMember: true,
+  hoursThisFY: 27,
+  sessionsThisFY: 11,
+}
+
+const cardAccepted: ProfileResponse = {
+  ...base,
+  id: 4,
+  slug: 'carol-white-4',
+  name: 'Carol White',
+  isMember: true,
+  cardStatus: 'Accepted',
+  hoursThisFY: 18,
+  sessionsThisFY: 7,
+}
+
+const cardInvited: ProfileResponse = {
+  ...base,
+  id: 5,
+  slug: 'dave-brown-5',
+  name: 'Dave Brown',
+  isMember: true,
+  cardStatus: 'Invited',
+  hoursThisFY: 15,
+  sessionsThisFY: 6,
+}
+
+const allBadges: ProfileResponse = {
+  ...base,
+  id: 9,
+  slug: 'helen-ford-9',
+  name: 'Helen Ford',
+  isMember: true,
+  cardStatus: 'Accepted',
+  hoursThisFY: 56,
+  sessionsThisFY: 22,
+}
+
+const zeroHours: ProfileResponse = {
+  ...base,
+  id: 6,
+  slug: 'eve-green-6',
+  name: 'Eve Green',
+  hoursThisFY: 0,
+  sessionsThisFY: 0,
+  hoursAll: 0,
+  sessionsAll: 0,
+}
+
+const noEmail: ProfileResponse = {
+  ...base,
+  id: 8,
+  slug: 'grace-hall-8',
+  name: 'Grace Hall',
+  email: undefined,
+  hoursThisFY: 8.5,
+  sessionsThisFY: 3,
+}
+
+const mockProfiles: ProfileResponse[] = [standard, group, member, cardAccepted, cardInvited]
+</script>
+
+<style scoped>
+.demo { outline: 1px solid var(--color-border); }
+.plsr-note { font-size: 0.85rem; color: var(--color-text-muted); margin-top: 0.5rem; }
+</style>

--- a/frontend/src/pages/sandbox/SandboxProfileListResults.vue
+++ b/frontend/src/pages/sandbox/SandboxProfileListResults.vue
@@ -1,0 +1,104 @@
+<template>
+  <DefaultLayout>
+    <div class="sandbox">
+      <RouterLink to="/sandbox" class="back">← Sandbox</RouterLink>
+      <h1>ProfileListResults</h1>
+      <p class="sandbox-warning">Static mocked data — no API calls. Checkbox selection works locally.</p>
+
+      <h2>Rolling FY — canSelect: true (admin checkboxes)</h2>
+      <div class="demo">
+        <ProfileListResults
+          :profiles="mockProfiles"
+          :selected="selected"
+          :can-select="true"
+          fy="rolling"
+          @update:selected="selected = $event"
+        />
+      </div>
+      <p class="plsr-note">Selected IDs: {{ selected.length ? selected.join(', ') : '(none)' }}</p>
+
+      <h2>All FY — canSelect: false (read-only view)</h2>
+      <div class="demo">
+        <ProfileListResults
+          :profiles="mockProfiles"
+          :selected="[]"
+          :can-select="false"
+          fy="all"
+        />
+      </div>
+
+      <h2>Loading state</h2>
+      <div class="demo">
+        <ProfileListResults
+          :profiles="[]"
+          :selected="[]"
+          :can-select="true"
+          :loading="true"
+          fy="rolling"
+        />
+      </div>
+
+      <h2>Empty state (no results)</h2>
+      <div class="demo">
+        <ProfileListResults
+          :profiles="[]"
+          :selected="[]"
+          :can-select="true"
+          :loading="false"
+          fy="rolling"
+        />
+      </div>
+    </div>
+  </DefaultLayout>
+</template>
+
+<script setup lang="ts">
+import '../../styles/sandbox.css'
+import { ref } from 'vue'
+import DefaultLayout from '../../layouts/DefaultLayout.vue'
+import ProfileListResults from '../../components/profiles/ProfileListResults.vue'
+import { usePageTitle } from '../../composables/usePageTitle'
+import type { ProfileResponse } from '../../../../types/api-responses'
+
+usePageTitle('Sandbox')
+
+const selected = ref<number[]>([])
+
+const mockProfiles: ProfileResponse[] = [
+  {
+    id: 1, slug: 'alice-smith-1', name: 'Alice Smith', email: 'alice@example.com',
+    isGroup: false, isMember: false, cardStatus: undefined,
+    hoursLastFY: 10, hoursThisFY: 42.5, hoursAll: 97.5,
+    sessionsLastFY: 4, sessionsThisFY: 18, sessionsAll: 42, records: [],
+  },
+  {
+    id: 2, slug: 'bob-jones-2', name: 'Bob Jones', email: 'bob@example.com',
+    isGroup: false, isMember: true, cardStatus: 'Accepted',
+    hoursLastFY: 20, hoursThisFY: 27, hoursAll: 130,
+    sessionsLastFY: 8, sessionsThisFY: 11, sessionsAll: 56, records: [],
+  },
+  {
+    id: 3, slug: 'carol-white-3', name: 'Carol White', email: 'carol@example.com',
+    isGroup: false, isMember: true, cardStatus: 'Invited',
+    hoursLastFY: 5, hoursThisFY: 15, hoursAll: 45,
+    sessionsLastFY: 2, sessionsThisFY: 6, sessionsAll: 18, records: [],
+  },
+  {
+    id: 4, slug: 'saturday-dig-4', name: 'Saturday Dig', email: undefined,
+    isGroup: true, isMember: false, cardStatus: undefined,
+    hoursLastFY: 120, hoursThisFY: 312, hoursAll: 600,
+    sessionsLastFY: 12, sessionsThisFY: 48, sessionsAll: 96, records: [],
+  },
+  {
+    id: 5, slug: 'dave-brown-5', name: 'Dave Brown', email: 'dave@example.com',
+    isGroup: false, isMember: false, cardStatus: undefined,
+    hoursLastFY: 0, hoursThisFY: 0, hoursAll: 0,
+    sessionsLastFY: 0, sessionsThisFY: 0, sessionsAll: 0, records: [],
+  },
+]
+</script>
+
+<style scoped>
+.demo { outline: 1px solid var(--color-border); }
+.plsr-note { font-size: 0.85rem; color: var(--color-text-muted); margin-top: 0.5rem; }
+</style>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -62,6 +62,8 @@ export const router = createRouter({
     { path: '/sandbox/filter-components', component: () => import('../pages/sandbox/SandboxFilterComponents.vue') },
     { path: '/sandbox/session-term-list', component: () => import('../pages/sandbox/SandboxSessionTermList.vue') },
     { path: '/sandbox/profile-record-list', component: () => import('../pages/sandbox/SandboxProfileRecordList.vue') },
+    { path: '/sandbox/profile-list-item', component: () => import('../pages/sandbox/SandboxProfileListItem.vue') },
+    { path: '/sandbox/profile-list-results', component: () => import('../pages/sandbox/SandboxProfileListResults.vue') },
   ]
 })
 

--- a/frontend/src/stores/profileList.ts
+++ b/frontend/src/stores/profileList.ts
@@ -7,12 +7,18 @@ export const useProfileListStore = defineStore('profiles', () => {
   const loading = ref(false)
   const error = ref<string | null>(null)
 
-  async function fetch() {
+  async function fetch(fy?: string, group?: string) {
     if (loading.value) return
     loading.value = true
     error.value = null
     try {
-      const res = await window.fetch('/api/profiles')
+      const params = new URLSearchParams()
+      if (fy === 'rolling') params.set('fy', 'rolling')
+      else if (fy && fy.startsWith('FY')) params.set('fy', fy)
+      // 'all' → omit fy param; API always returns hoursAll regardless
+      if (group) params.set('group', group)
+      const query = params.toString()
+      const res = await window.fetch(`/api/profiles${query ? `?${query}` : ''}`)
       if (!res.ok) throw new Error(`Failed to load profiles (${res.status})`)
       const json: { data: ProfileResponse[] } = await res.json()
       profiles.value = json.data

--- a/frontend/src/stores/profileList.ts
+++ b/frontend/src/stores/profileList.ts
@@ -4,11 +4,16 @@ import type { ProfileResponse } from '../../../types/api-responses'
 
 export const useProfileListStore = defineStore('profiles', () => {
   const profiles = ref<ProfileResponse[]>([])
-  const loading = ref(false)
+  const loading = ref(true)
   const error = ref<string | null>(null)
 
+  let abortController: AbortController | null = null
+
   async function fetch(fy?: string, group?: string) {
-    if (loading.value) return
+    // Cancel any in-flight request before starting a new one
+    abortController?.abort()
+    abortController = new AbortController()
+
     loading.value = true
     error.value = null
     try {
@@ -18,11 +23,12 @@ export const useProfileListStore = defineStore('profiles', () => {
       // 'all' → omit fy param; API always returns hoursAll regardless
       if (group) params.set('group', group)
       const query = params.toString()
-      const res = await window.fetch(`/api/profiles${query ? `?${query}` : ''}`)
+      const res = await window.fetch(`/api/profiles${query ? `?${query}` : ''}`, { signal: abortController.signal })
       if (!res.ok) throw new Error(`Failed to load profiles (${res.status})`)
       const json: { data: ProfileResponse[] } = await res.json()
       profiles.value = json.data
     } catch (e) {
+      if (e instanceof DOMException && e.name === 'AbortError') return
       error.value = e instanceof Error ? e.message : 'Unknown error'
       console.error('[profileList store]', error.value)
     } finally {


### PR DESCRIPTION
ProfileListFilter, ProfileListActions, ProfileListResults, ProfileListItem, ProfileBulkRecordsModal (issue #1 step 8)

- Always-visible filter bar with FY, group, search, sort, type, hours and record filters
- Admin checkboxes with select all/deselect all; custom sand/green checkbox styling
- Bulk records modal owned by page; action bar emits add-records upward
- CSV and Add Records both enabled/disabled by selection only (no FY restriction)
- Refactored SessionListActions to emit add-tags instead of owning SessionAddTagsModal internally; SessionListPage now owns the modal
- Sandbox pages for ProfileListItem (all badge/state variants + checkbox demo) and ProfileListResults (all states)
- Member threshold highlight concept removed entirely from codebase