### PR TITLE
Urgent list fixes

### DIFF
--- a/frontend/src/components/profiles/ProfileListItem.vue
+++ b/frontend/src/components/profiles/ProfileListItem.vue
@@ -16,8 +16,9 @@
       </span>
     </span>
     <span class="pli-meta">
-      <span class="pli-stat">{{ displaySessions }} <span class="pli-stat-label">sessions</span></span>
-      <span class="pli-stat">{{ displayHoursFormatted }} <span class="pli-stat-label">hours</span></span>
+      <span class="pli-stat pli-stat--full">{{ displaySessions }} <span class="pli-stat-label">sessions</span></span>
+      <span class="pli-stat pli-stat--full">{{ displayHoursFormatted }} <span class="pli-stat-label">hours</span></span>
+      <span class="pli-stat pli-stat--compact"><span class="pli-compact-sessions">{{ displaySessions }}</span> · {{ displayHoursFormatted }}h</span>
     </span>
   </RouterLink>
 </template>
@@ -94,11 +95,17 @@ const displayHoursFormatted = computed(() =>
 
 .pli-stat { white-space: nowrap; }
 .pli-stat-label { color: var(--color-text-muted); }
+.pli-stat--full:first-child { color: var(--color-dtv-gold-dark); font-weight: 600; }
+.pli-stat--full:first-child .pli-stat-label { color: var(--color-dtv-gold-dark); }
 
 .svg-green { filter: invert(40%) sepia(80%) saturate(400%) hue-rotate(90deg) brightness(90%); }
 .svg-orange { filter: invert(65%) sepia(80%) saturate(600%) hue-rotate(5deg) brightness(95%); }
 
+.pli-stat--compact { display: none; }
+.pli-compact-sessions { color: var(--color-dtv-gold-dark); font-weight: 600; }
+
 @media (width < 48em) {
-  .pli-meta { gap: 0.5rem; }
+  .pli-stat--full { display: none; }
+  .pli-stat--compact { display: inline; }
 }
 </style>

--- a/frontend/src/components/profiles/ProfileListResults.vue
+++ b/frontend/src/components/profiles/ProfileListResults.vue
@@ -92,10 +92,12 @@ function toggle(id: number) {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  padding-left: 1.5rem;
+  padding: 0 1.5rem;
 }
 
-.plr-item :deep(.pli-wrap) { padding-left: 0; flex: 1; }
+/* Own all horizontal padding here — zero pli-wrap's own to prevent doubling */
+.plr-item :deep(.pli-wrap) { padding-left: 0; padding-right: 0; flex: 1; min-width: 0; }
+
 
 .plr-checkbox {
   flex-shrink: 0;

--- a/frontend/src/components/sessions/SessionEntryList.vue
+++ b/frontend/src/components/sessions/SessionEntryList.vue
@@ -8,7 +8,7 @@
         <span v-if="entries.length" class="sel-count">({{ checkedCount }} / {{ entries.length }})</span>
       </h2>
       <div v-if="allowEdit" class="sel-actions">
-        <AppButton label="Refresh" icon="refresh" mode="icon-responsive" @click="emit('refreshRequest')" />
+        <AppButton label="Refresh" icon="refresh" mode="icon-responsive" :working="refreshWorking" @click="emit('refreshRequest')" />
         <AppButton label="Set Hours" icon="clock" mode="icon-responsive" :disabled="eligibleCount === 0" @click="showSetHours = true" />
         <AppButton label="Add" icon="add" mode="icon-responsive" @click="showAdd = true" />
       </div>
@@ -83,6 +83,7 @@ const props = defineProps<{
   allowEdit: boolean
   profiles: PickerProfile[]
   workingId?: number | null
+  refreshWorking?: boolean
 }>()
 
 const emit = defineEmits<{

--- a/frontend/src/pages/ConsentPage.vue
+++ b/frontend/src/pages/ConsentPage.vue
@@ -83,9 +83,9 @@ onMounted(async () => {
   if (res.status === 401) { router.push(`/login?returnTo=${encodeURIComponent(route.fullPath)}`); return }
   if (res.status === 403) { loadError.value = 'You do not have permission to collect consent for this profile.'; loading.value = false; return }
   if (!res.ok) { loadError.value = 'Could not load profile. Please try again.'; loading.value = false; return }
-  const data = await res.json()
-  profileId.value = data.id
-  profileName.value = data.name ?? 'this volunteer'
+  const json = await res.json()
+  profileId.value = json.data.id
+  profileName.value = json.data.name ?? 'this volunteer'
   loading.value = false
 })
 

--- a/frontend/src/pages/ProfileListPage.vue
+++ b/frontend/src/pages/ProfileListPage.vue
@@ -2,32 +2,30 @@
   <DefaultLayout>
     <h1 class="sr-only">Profiles</h1>
     <PageHeader>Volunteers</PageHeader>
-    <div class="px-6 pb-6">
-      <ProfileListFilter
-        :profiles="store.profiles"
-        :groups="groupsStore.groups"
-        :record-options="recordOptions"
-        @filtered="filtered = $event"
-        @fy-change="onFyChange"
-        @group-change="onGroupChange"
-      />
-      <ProfileListActions
-        :filtered-profiles="filtered"
-        :selected="selected"
-        :can-bulk-edit="profile.isAdmin"
-        :fy="fy"
-        @add-records="showBulkModal = true"
-        @update:selected="selected = $event"
-      />
-      <ProfileListResults
-        :profiles="filtered"
-        :loading="store.loading"
-        :selected="selected"
-        :can-select="profile.isAdmin"
-        :fy="fy"
-        @update:selected="selected = $event"
-      />
-    </div>
+    <ProfileListFilter
+      :profiles="store.profiles"
+      :groups="groupsStore.groups"
+      :record-options="recordOptions"
+      @filtered="filtered = $event"
+      @fy-change="onFyChange"
+      @group-change="onGroupChange"
+    />
+    <ProfileListActions
+      :filtered-profiles="filtered"
+      :selected="selected"
+      :can-bulk-edit="profile.isAdmin"
+      :fy="fy"
+      @add-records="showBulkModal = true"
+      @update:selected="selected = $event"
+    />
+    <ProfileListResults
+      :profiles="filtered"
+      :loading="store.loading"
+      :selected="selected"
+      :can-select="profile.isAdmin"
+      :fy="fy"
+      @update:selected="selected = $event"
+    />
 
     <ProfileBulkRecordsModal
       v-if="showBulkModal"

--- a/frontend/src/pages/SessionDetailPage.vue
+++ b/frontend/src/pages/SessionDetailPage.vue
@@ -309,8 +309,18 @@ function load() {
   store.fetch(route.params.groupKey as string, route.params.date as string)
 }
 
-function onRefreshRequest() {
-  store.fetch(route.params.groupKey as string, store.session!.date)
+async function onRefreshRequest() {
+  const groupKey = route.params.groupKey as string
+  const date = store.session!.date
+  try {
+    const res = await fetch(`/api/sessions/${encodeURIComponent(groupKey)}/${encodeURIComponent(date)}/refresh`, {
+      method: 'POST',
+    })
+    if (!res.ok) console.error('[SessionDetailPage] refresh failed', res.status)
+  } catch (e) {
+    console.error('[SessionDetailPage] refresh error', e)
+  }
+  store.fetch(groupKey, date)
 }
 
 async function onEntryUpdate(entry: EntryItem, checkedIn: boolean, hours: number) {

--- a/frontend/src/pages/SessionDetailPage.vue
+++ b/frontend/src/pages/SessionDetailPage.vue
@@ -163,6 +163,7 @@
             :allow-edit="profile.isOperational"
             :profiles="profiles"
             :working-id="workingId"
+            :refresh-working="refreshWorking"
             @refresh-request="onRefreshRequest"
             @update="onEntryUpdate"
             @set-hours="onSetHours"
@@ -230,6 +231,7 @@ const coverItem    = computed<MediaItem | null>(() =>
 )
 const profiles = ref<PickerProfile[]>([])
 const workingId = ref<number | null>(null)
+const refreshWorking = ref(false)
 const entryListRef = ref<InstanceType<typeof SessionEntryList> | null>(null)
 const tagWorking = ref(false)
 const tagError = ref<string | undefined>()
@@ -310,6 +312,8 @@ function load() {
 }
 
 async function onRefreshRequest() {
+  if (refreshWorking.value) return
+  refreshWorking.value = true
   const groupKey = route.params.groupKey as string
   const date = store.session!.date
   try {
@@ -319,6 +323,8 @@ async function onRefreshRequest() {
     if (!res.ok) console.error('[SessionDetailPage] refresh failed', res.status)
   } catch (e) {
     console.error('[SessionDetailPage] refresh error', e)
+  } finally {
+    refreshWorking.value = false
   }
   store.fetch(groupKey, date)
 }

--- a/frontend/src/pages/sandbox/SandboxConsentPage.vue
+++ b/frontend/src/pages/sandbox/SandboxConsentPage.vue
@@ -1,0 +1,156 @@
+<template>
+  <DefaultLayout>
+    <div class="sandbox">
+      <RouterLink to="/sandbox" class="back">← Sandbox</RouterLink>
+      <h1>ConsentPage</h1>
+
+      <!-- Loading -->
+      <h2>Loading</h2>
+      <div class="task-body">
+        <FormCard title="Collect Consent">
+          <p class="status-text">Loading…</p>
+        </FormCard>
+      </div>
+
+      <!-- Error -->
+      <h2>Load error</h2>
+      <div class="task-body">
+        <AlertBanner message="You do not have permission to collect consent for this profile." type="error" />
+      </div>
+
+      <!-- Form -->
+      <h2>Form</h2>
+      <div class="task-body">
+        <FormCard title="Collect Consent" subtitle="Collecting consent for Jane Smith">
+          <FormCheckboxItem
+            v-model="privacyConsent"
+            label="I agree to my personal data being stored and used for volunteer coordination."
+            description="This includes your name, email address, and session attendance records."
+            :required="true"
+          />
+          <FormCheckboxItem
+            v-model="photoConsent"
+            label="I agree to photos and videos of me being used in DTV communications."
+            description="Photos may appear on social media, newsletters, and the DTV website."
+          />
+          <a href="/privacy" target="_blank" class="privacy-link">Read our privacy policy</a>
+          <FormSubmitRow>
+            <FormButton :disabled="!privacyConsent">Save consent</FormButton>
+          </FormSubmitRow>
+        </FormCard>
+      </div>
+
+      <!-- Working -->
+      <h2>Saving…</h2>
+      <div class="task-body">
+        <FormCard title="Collect Consent" subtitle="Collecting consent for Jane Smith">
+          <FormCheckboxItem
+            :model-value="true"
+            label="I agree to my personal data being stored and used for volunteer coordination."
+            description="This includes your name, email address, and session attendance records."
+            :required="true"
+          />
+          <FormCheckboxItem
+            :model-value="false"
+            label="I agree to photos and videos of me being used in DTV communications."
+            description="Photos may appear on social media, newsletters, and the DTV website."
+          />
+          <a href="/privacy" target="_blank" class="privacy-link">Read our privacy policy</a>
+          <FormSubmitRow>
+            <FormButton :working="true">Saving…</FormButton>
+          </FormSubmitRow>
+        </FormCard>
+      </div>
+
+      <!-- Submit error -->
+      <h2>Submit error</h2>
+      <div class="task-body">
+        <FormCard title="Collect Consent" subtitle="Collecting consent for Jane Smith">
+          <FormCheckboxItem
+            :model-value="true"
+            label="I agree to my personal data being stored and used for volunteer coordination."
+            description="This includes your name, email address, and session attendance records."
+            :required="true"
+          />
+          <FormCheckboxItem
+            :model-value="false"
+            label="I agree to photos and videos of me being used in DTV communications."
+            description="Photos may appear on social media, newsletters, and the DTV website."
+          />
+          <a href="/privacy" target="_blank" class="privacy-link">Read our privacy policy</a>
+          <FormSubmitRow>
+            <FormButton>Save consent</FormButton>
+            <p class="form-error">Could not save consent. Please try again.</p>
+          </FormSubmitRow>
+        </FormCard>
+      </div>
+
+      <!-- Success -->
+      <h2>Success</h2>
+      <div class="task-body">
+        <FormCard title="Consent recorded">
+          <p class="status-text">Consent has been saved for <strong>Jane Smith</strong>.</p>
+          <FormSubmitRow>
+            <FormButton href="/profiles/jane-smith-1">Back to profile</FormButton>
+          </FormSubmitRow>
+        </FormCard>
+      </div>
+
+    </div>
+  </DefaultLayout>
+</template>
+
+<script setup lang="ts">
+import '../../styles/sandbox.css'
+import { ref } from 'vue'
+import { usePageTitle } from '../../composables/usePageTitle'
+import DefaultLayout from '../../layouts/DefaultLayout.vue'
+import FormCard from '../../components/forms/FormCard.vue'
+import FormCheckboxItem from '../../components/forms/FormCheckboxItem.vue'
+import FormSubmitRow from '../../components/forms/FormSubmitRow.vue'
+import FormButton from '../../components/forms/FormButton.vue'
+import AlertBanner from '../../components/forms/AlertBanner.vue'
+
+usePageTitle('Sandbox — ConsentPage')
+
+const privacyConsent = ref(false)
+const photoConsent = ref(false)
+</script>
+
+<style scoped>
+.task-body {
+  max-width: 26rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.status-text {
+  font-size: 0.9rem;
+  color: var(--color-dtv-dark);
+  opacity: 0.7;
+  margin: 0;
+  text-align: center;
+  line-height: 1.5;
+}
+
+.status-text strong {
+  opacity: 1;
+  font-weight: 700;
+}
+
+.privacy-link {
+  display: block;
+  margin-top: 0.75rem;
+  font-size: 0.85rem;
+  color: var(--color-dtv-green-dark);
+}
+
+.form-error {
+  font-size: 0.875rem;
+  color: var(--color-dtv-dirt);
+  text-align: center;
+  margin: 0;
+}
+</style>

--- a/frontend/src/pages/sandbox/SandboxIndex.vue
+++ b/frontend/src/pages/sandbox/SandboxIndex.vue
@@ -23,6 +23,9 @@
           <RouterLink to="/sandbox/modals">All Modals</RouterLink>
           <RouterLink to="/sandbox/form-components">Form Layout and Components</RouterLink>
           <RouterLink to="/sandbox/flash-message">FlashMessage</RouterLink>
+          <RouterLink to="/sandbox/login-page">LoginPage</RouterLink>
+          <RouterLink to="/sandbox/consent-page">ConsentPage</RouterLink>
+          <RouterLink to="/sandbox/upload-page">UploadPage</RouterLink>
         </nav>
       </section>
 

--- a/frontend/src/pages/sandbox/SandboxLoginPage.vue
+++ b/frontend/src/pages/sandbox/SandboxLoginPage.vue
@@ -1,0 +1,221 @@
+<template>
+  <DefaultLayout>
+    <div class="sandbox">
+      <RouterLink to="/sandbox" class="back">← Sandbox</RouterLink>
+      <h1>LoginPage</h1>
+
+      <!-- Both cards (magic + Microsoft) -->
+      <h2>Cards — magic + Microsoft</h2>
+      <div class="task-body">
+        <FormCard title="Volunteer Sign In" subtitle="View your volunteer profile, register for sessions, and upload photos.">
+          <FormInput v-model="email" type="email" placeholder="your@email.com" autocomplete="email" />
+          <FormSubmitRow>
+            <FormButton :disabled="!emailValid">Send sign-in link</FormButton>
+          </FormSubmitRow>
+        </FormCard>
+        <FormCard title="DTV Teams Account" subtitle="For dig leads, coordinators and admins — use your @dtv.org.uk Microsoft account.">
+          <FormSubmitRow>
+            <FormButton color="var(--color-dtv-gold)" href="/auth/login">
+              <img src="/icons/microsoft.svg" width="18" height="18" alt="" class="svg-white" />
+              Continue with Microsoft
+            </FormButton>
+          </FormSubmitRow>
+        </FormCard>
+      </div>
+
+      <!-- Microsoft only (magic disabled) -->
+      <h2>Cards — Microsoft only</h2>
+      <div class="task-body">
+        <FormCard title="DTV Teams Account" subtitle="For dig leads, coordinators and admins — use your @dtv.org.uk Microsoft account.">
+          <FormSubmitRow>
+            <FormButton color="var(--color-dtv-gold)" href="/auth/login">
+              <img src="/icons/microsoft.svg" width="18" height="18" alt="" class="svg-white" />
+              Continue with Microsoft
+            </FormButton>
+          </FormSubmitRow>
+        </FormCard>
+      </div>
+
+      <!-- Reason banner -->
+      <h2>Reason banner — not approved</h2>
+      <div class="task-body">
+        <AlertBanner message="We don't have an account for jane@example.com. Contact your group organiser to get set up." />
+        <FormCard title="Volunteer Sign In" subtitle="View your volunteer profile, register for sessions, and upload photos.">
+          <FormInput v-model="emailReason" type="email" placeholder="your@email.com" autocomplete="email" />
+          <FormSubmitRow>
+            <FormButton :disabled="!emailReasonValid">Send sign-in link</FormButton>
+          </FormSubmitRow>
+        </FormCard>
+        <FormCard title="DTV Teams Account" subtitle="For dig leads, coordinators and admins — use your @dtv.org.uk Microsoft account.">
+          <FormSubmitRow>
+            <FormButton color="var(--color-dtv-gold)" href="/auth/login">
+              <img src="/icons/microsoft.svg" width="18" height="18" alt="" class="svg-white" />
+              Continue with Microsoft
+            </FormButton>
+          </FormSubmitRow>
+        </FormCard>
+      </div>
+
+      <!-- Reason banner — expired link -->
+      <h2>Reason banner — expired link</h2>
+      <div class="task-body">
+        <AlertBanner message="That sign-in link has expired or is invalid — enter your email below to get a new one." type="info" />
+        <FormCard title="Volunteer Sign In" subtitle="View your volunteer profile, register for sessions, and upload photos.">
+          <FormInput v-model="emailExpired" type="email" placeholder="your@email.com" autocomplete="email" />
+          <FormSubmitRow>
+            <FormButton :disabled="!emailExpiredValid">Send sign-in link</FormButton>
+          </FormSubmitRow>
+        </FormCard>
+        <FormCard title="DTV Teams Account" subtitle="For dig leads, coordinators and admins — use your @dtv.org.uk Microsoft account.">
+          <FormSubmitRow>
+            <FormButton color="var(--color-dtv-gold)" href="/auth/login">
+              <img src="/icons/microsoft.svg" width="18" height="18" alt="" class="svg-white" />
+              Continue with Microsoft
+            </FormButton>
+          </FormSubmitRow>
+        </FormCard>
+      </div>
+
+      <!-- Sending -->
+      <h2>Sending…</h2>
+      <div class="task-body">
+        <FormCard title="Volunteer Sign In" subtitle="View your volunteer profile, register for sessions, and upload photos.">
+          <FormInput :model-value="'jane@example.com'" type="email" placeholder="your@email.com" :disabled="true" />
+          <FormSubmitRow>
+            <FormButton :working="true">Sending…</FormButton>
+          </FormSubmitRow>
+        </FormCard>
+        <FormCard title="DTV Teams Account" subtitle="For dig leads, coordinators and admins — use your @dtv.org.uk Microsoft account.">
+          <FormSubmitRow>
+            <FormButton color="var(--color-dtv-gold)" href="/auth/login">
+              <img src="/icons/microsoft.svg" width="18" height="18" alt="" class="svg-white" />
+              Continue with Microsoft
+            </FormButton>
+          </FormSubmitRow>
+        </FormCard>
+      </div>
+
+      <!-- Send error -->
+      <h2>Send error</h2>
+      <div class="task-body">
+        <FormCard title="Volunteer Sign In" subtitle="View your volunteer profile, register for sessions, and upload photos.">
+          <FormInput v-model="emailError" type="email" placeholder="your@email.com" autocomplete="email" />
+          <FormSubmitRow>
+            <FormButton :disabled="!emailErrorValid">Send sign-in link</FormButton>
+            <p class="form-error">Something went wrong. Please try again.</p>
+          </FormSubmitRow>
+        </FormCard>
+        <FormCard title="DTV Teams Account" subtitle="For dig leads, coordinators and admins — use your @dtv.org.uk Microsoft account.">
+          <FormSubmitRow>
+            <FormButton color="var(--color-dtv-gold)" href="/auth/login">
+              <img src="/icons/microsoft.svg" width="18" height="18" alt="" class="svg-white" />
+              Continue with Microsoft
+            </FormButton>
+          </FormSubmitRow>
+        </FormCard>
+      </div>
+
+      <!-- Sent confirmation -->
+      <h2>Sent confirmation</h2>
+      <div class="task-body">
+        <FormCard title="Check your email">
+          <p class="sent-body">A sign-in link is on its way — click it to continue. The link expires in:</p>
+          <div class="sent-countdown">14:35</div>
+          <p class="sent-body">Already clicked the link? If you're signed in you can close this tab.</p>
+          <FormSubmitRow>
+            <button class="form-btn--link">Didn't receive the link? Back to Login</button>
+            <p class="sent-contact">Continuing problems? <a href="mailto:admin@deantrailvolunteers.org.uk">Contact us</a></p>
+          </FormSubmitRow>
+        </FormCard>
+      </div>
+
+    </div>
+  </DefaultLayout>
+</template>
+
+<script setup lang="ts">
+import '../../styles/sandbox.css'
+import { ref, computed } from 'vue'
+import { usePageTitle } from '../../composables/usePageTitle'
+import DefaultLayout from '../../layouts/DefaultLayout.vue'
+import FormCard from '../../components/forms/FormCard.vue'
+import FormInput from '../../components/forms/FormInput.vue'
+import FormSubmitRow from '../../components/forms/FormSubmitRow.vue'
+import FormButton from '../../components/forms/FormButton.vue'
+import AlertBanner from '../../components/forms/AlertBanner.vue'
+
+usePageTitle('Sandbox — LoginPage')
+
+const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+const email = ref('')
+const emailValid = computed(() => emailRegex.test(email.value.trim()))
+
+const emailReason = ref('jane@example.com')
+const emailReasonValid = computed(() => emailRegex.test(emailReason.value.trim()))
+
+const emailExpired = ref('')
+const emailExpiredValid = computed(() => emailRegex.test(emailExpired.value.trim()))
+
+const emailError = ref('jane@example.com')
+const emailErrorValid = computed(() => emailRegex.test(emailError.value.trim()))
+</script>
+
+<style scoped>
+.task-body {
+  max-width: 26rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.form-btn--link {
+  background: none;
+  border: none;
+  color: var(--color-dtv-green-dark);
+  font-size: 0.85rem;
+  font-weight: 700;
+  text-decoration: underline;
+  cursor: pointer;
+  padding: 0;
+  text-align: center;
+}
+
+.form-error {
+  font-size: 0.875rem;
+  color: var(--color-dtv-dirt);
+  text-align: center;
+  margin: 0;
+}
+
+.sent-body {
+  font-size: 0.9rem;
+  color: var(--color-dtv-dark);
+  opacity: 0.7;
+  text-align: center;
+  margin: 0 0 0.5rem;
+  line-height: 1.5;
+}
+
+.sent-countdown {
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: var(--color-dtv-green);
+  letter-spacing: 0.1em;
+  text-align: center;
+  margin: 0.75rem 0;
+}
+
+.sent-contact {
+  font-size: 0.8rem;
+  color: var(--color-dtv-dark);
+  opacity: 0.5;
+  text-align: center;
+  margin: 0;
+}
+
+.sent-contact a {
+  color: inherit;
+}
+</style>

--- a/frontend/src/pages/sandbox/SandboxUploadPage.vue
+++ b/frontend/src/pages/sandbox/SandboxUploadPage.vue
@@ -1,0 +1,297 @@
+<template>
+  <DefaultLayout>
+    <div class="sandbox">
+      <RouterLink to="/sandbox" class="back">← Sandbox</RouterLink>
+      <h1>UploadPage</h1>
+
+      <!-- Loading -->
+      <h2>Loading</h2>
+      <div class="task-body">
+        <FormCard title="Upload Photos">
+          <p class="status-text">Loading…</p>
+        </FormCard>
+      </div>
+
+      <!-- Error: no entry ID -->
+      <h2>Error — no entry ID</h2>
+      <div class="task-body">
+        <FormCard title="Link not found">
+          <p class="status-text">No entry ID was provided. Please use the Upload button from your entry.</p>
+        </FormCard>
+      </div>
+
+      <!-- Error: wrong account (with action) -->
+      <h2>Error — wrong account</h2>
+      <div class="task-body">
+        <FormCard title="Wrong account">
+          <p class="status-text">This upload link belongs to a different account. Please sign in with the correct account.</p>
+          <FormSubmitRow>
+            <FormButton href="/login">Sign in</FormButton>
+          </FormSubmitRow>
+        </FormCard>
+      </div>
+
+      <!-- Error: not found -->
+      <h2>Error — link not found</h2>
+      <div class="task-body">
+        <FormCard title="Link not found">
+          <p class="status-text">This upload link could not be found. It may have been removed.</p>
+        </FormCard>
+      </div>
+
+      <!-- Form: empty -->
+      <h2>Form — no files</h2>
+      <div class="task-body">
+        <FormCard title="Upload for Jane Smith" subtitle="Sheepskull · 5 Apr 2026">
+          <div class="drop-zone">
+            <span class="drop-zone-label">Tap or drag to add photos &amp; videos</span>
+            <span class="drop-zone-hint">JPG, PNG, WebP, HEIC, MP4, MOV · max 15 MB each · up to 10 files</span>
+          </div>
+          <FormSubmitRow>
+            <FormButton :disabled="true">Upload</FormButton>
+          </FormSubmitRow>
+        </FormCard>
+      </div>
+
+      <!-- Form: files selected -->
+      <h2>Form — files selected</h2>
+      <div class="task-body">
+        <FormCard title="Upload for Jane Smith" subtitle="Sheepskull · 5 Apr 2026">
+          <div class="drop-zone drop-zone--has-files">
+            <span class="drop-zone-label drop-zone-label--small">3 files selected — tap to add more</span>
+            <span class="drop-zone-hint">JPG, PNG, WebP, HEIC, MP4, MOV · max 15 MB each · up to 10 files</span>
+          </div>
+          <ul class="file-list">
+            <li v-for="f in pendingFiles" :key="f.name" class="file-item">
+              <span class="file-name">{{ f.name }}</span>
+              <span class="file-status file-status--pending">Pending</span>
+            </li>
+          </ul>
+          <FormSubmitRow>
+            <FormButton>Upload</FormButton>
+          </FormSubmitRow>
+        </FormCard>
+      </div>
+
+      <!-- Form: uploading -->
+      <h2>Uploading…</h2>
+      <div class="task-body">
+        <FormCard title="Upload for Jane Smith" subtitle="Sheepskull · 5 Apr 2026">
+          <div class="drop-zone drop-zone--has-files">
+            <span class="drop-zone-label drop-zone-label--small">3 files selected — tap to add more</span>
+            <span class="drop-zone-hint">JPG, PNG, WebP, HEIC, MP4, MOV · max 15 MB each · up to 10 files</span>
+          </div>
+          <ul class="file-list">
+            <li class="file-item">
+              <span class="file-name">IMG_0042.jpg</span>
+              <span class="file-status file-status--ok">✓ Done</span>
+            </li>
+            <li class="file-item">
+              <span class="file-name">IMG_0043.jpg</span>
+              <span class="file-status file-status--uploading">Uploading…</span>
+            </li>
+            <li class="file-item">
+              <span class="file-name">IMG_0044.jpg</span>
+              <span class="file-status file-status--pending">Pending</span>
+            </li>
+          </ul>
+          <FormSubmitRow>
+            <FormButton :working="true">Uploading 2 of 3…</FormButton>
+          </FormSubmitRow>
+        </FormCard>
+      </div>
+
+      <!-- Form: partial failure -->
+      <h2>Partial failure</h2>
+      <div class="task-body">
+        <FormCard title="Upload for Jane Smith" subtitle="Sheepskull · 5 Apr 2026">
+          <div class="drop-zone drop-zone--has-files">
+            <span class="drop-zone-label drop-zone-label--small">3 files selected — tap to add more</span>
+            <span class="drop-zone-hint">JPG, PNG, WebP, HEIC, MP4, MOV · max 15 MB each · up to 10 files</span>
+          </div>
+          <ul class="file-list">
+            <li class="file-item">
+              <span class="file-name">IMG_0042.jpg</span>
+              <span class="file-status file-status--ok">✓ Done</span>
+            </li>
+            <li class="file-item">
+              <span class="file-name">IMG_0043.jpg</span>
+              <span class="file-status file-status--error">✕ Failed</span>
+            </li>
+            <li class="file-item">
+              <span class="file-name">IMG_0044.jpg</span>
+              <span class="file-status file-status--ok">✓ Done</span>
+            </li>
+          </ul>
+          <FormSubmitRow>
+            <FormButton>Upload</FormButton>
+            <p class="form-error">You can only upload to your own entries.</p>
+          </FormSubmitRow>
+        </FormCard>
+      </div>
+
+      <!-- Form: over limit -->
+      <h2>Over limit</h2>
+      <div class="task-body">
+        <FormCard title="Upload for Jane Smith" subtitle="Sheepskull · 5 Apr 2026">
+          <div class="drop-zone drop-zone--has-files">
+            <span class="drop-zone-label drop-zone-label--small">11 files selected — tap to add more</span>
+            <span class="drop-zone-hint">JPG, PNG, WebP, HEIC, MP4, MOV · max 15 MB each · up to 10 files</span>
+          </div>
+          <ul class="file-list">
+            <li v-for="f in overLimitFiles" :key="f.name" class="file-item">
+              <span class="file-name">{{ f.name }}</span>
+              <span class="file-status file-status--pending">Pending</span>
+            </li>
+          </ul>
+          <p class="form-error">Maximum 10 files. Please remove some and try again.</p>
+          <FormSubmitRow>
+            <FormButton :disabled="true">Upload</FormButton>
+          </FormSubmitRow>
+        </FormCard>
+      </div>
+
+      <!-- Success -->
+      <h2>Success</h2>
+      <div class="task-body">
+        <FormCard title="Photos uploaded">
+          <p class="status-text"><strong>3</strong> files uploaded successfully.</p>
+          <p class="status-note">Photos are reviewed before appearing publicly.</p>
+          <FormSubmitRow>
+            <FormButton href="/sessions/sheepskull/2026-04-05">View session gallery</FormButton>
+          </FormSubmitRow>
+        </FormCard>
+      </div>
+
+    </div>
+  </DefaultLayout>
+</template>
+
+<script setup lang="ts">
+import '../../styles/sandbox.css'
+import { usePageTitle } from '../../composables/usePageTitle'
+import DefaultLayout from '../../layouts/DefaultLayout.vue'
+import FormCard from '../../components/forms/FormCard.vue'
+import FormSubmitRow from '../../components/forms/FormSubmitRow.vue'
+import FormButton from '../../components/forms/FormButton.vue'
+
+usePageTitle('Sandbox — UploadPage')
+
+const pendingFiles = [
+  { name: 'IMG_0042.jpg' },
+  { name: 'IMG_0043.jpg' },
+  { name: 'IMG_0044.jpg' },
+]
+
+const overLimitFiles = Array.from({ length: 11 }, (_, i) => ({ name: `IMG_00${42 + i}.jpg` }))
+</script>
+
+<style scoped>
+.task-body {
+  max-width: 26rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.status-text {
+  font-size: 0.9rem;
+  color: var(--color-dtv-dark);
+  opacity: 0.7;
+  margin: 0 0 0.25rem;
+  text-align: center;
+  line-height: 1.5;
+}
+
+.status-text strong {
+  opacity: 1;
+  font-weight: 700;
+}
+
+.status-note {
+  font-size: 0.8rem;
+  color: var(--color-dtv-dark);
+  opacity: 0.5;
+  text-align: center;
+  margin: 0;
+}
+
+.drop-zone {
+  border: 2px dashed var(--color-dtv-sand-dark);
+  padding: 1.5rem 1rem;
+  text-align: center;
+  cursor: pointer;
+  margin-bottom: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.drop-zone--has-files {
+  border-style: solid;
+  border-color: var(--color-dtv-sand-dark);
+}
+
+.drop-zone-label {
+  font-size: 0.95rem;
+  color: var(--color-dtv-dark);
+}
+
+.drop-zone-label--small {
+  font-weight: 600;
+}
+
+.drop-zone-hint {
+  font-size: 0.78rem;
+  color: var(--color-dtv-dark);
+  opacity: 0.5;
+}
+
+.file-list {
+  list-style: none;
+  margin: 0 0 0.25rem;
+  padding: 0;
+}
+
+.file-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0;
+  border-bottom: 1px solid var(--color-dtv-sand);
+  font-size: 0.85rem;
+}
+
+.file-item:last-child {
+  border-bottom: none;
+}
+
+.file-name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--color-dtv-dark);
+}
+
+.file-status {
+  flex-shrink: 0;
+  font-weight: 600;
+  font-size: 0.8rem;
+}
+
+.file-status--pending   { color: var(--color-dtv-dark); opacity: 0.4; }
+.file-status--uploading { color: var(--color-dtv-gold-dark); }
+.file-status--ok        { color: var(--color-dtv-green-dark); }
+.file-status--error     { color: var(--color-dtv-dirt); }
+
+.form-error {
+  font-size: 0.875rem;
+  color: var(--color-dtv-dirt);
+  text-align: center;
+  margin: 0;
+}
+</style>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -71,6 +71,9 @@ export const router = createRouter({
     { path: '/sandbox/profile-group-list', component: () => import('../pages/sandbox/SandboxProfileGroupList.vue') },
     { path: '/sandbox/profile-group-item', component: () => import('../pages/sandbox/SandboxProfileGroupItem.vue') },
     { path: '/sandbox/flash-message', component: () => import('../pages/sandbox/SandboxFlashMessage.vue') },
+    { path: '/sandbox/login-page', component: () => import('../pages/sandbox/SandboxLoginPage.vue') },
+    { path: '/sandbox/consent-page', component: () => import('../pages/sandbox/SandboxConsentPage.vue') },
+    { path: '/sandbox/upload-page', component: () => import('../pages/sandbox/SandboxUploadPage.vue') },
   ]
 })
 


### PR DESCRIPTION
- Mobile (<48em): replace split "15 sessions / 50 hours" with "15 · 50h", session count in dtv-gold-dark/600
- Desktop: session count and "sessions" label coloured dtv-gold-dark/600 to match
- Fix name truncation (min-width: 0 on pli-wrap via deep selector)
- ProfileListResults owns all horizontal padding (0 1.5rem on plr-item); zeroes pli-wrap's own horizontal padding to prevent doubling

- onRefreshRequest POSTs to /api/sessions/:group/:date/refresh before re-fetching the store — adds regulars, syncs Eventbrite, tags #NoPhoto and #FirstAider