### PR TITLE
#99 mobile + loading of lists

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -354,7 +354,7 @@ dtv-tracker-app/
 │           ├── GroupDetailPage.vue    # Group detail with stats, sessions, regulars
 │           ├── SessionsPage.vue       # Sessions listing with filters and action bar
 │           ├── SessionDetailPage.vue  # Session detail — sign-up (public) and check-in (operational)
-│           ├── ProfileListPage.vue    # Profiles listing (stub + DebugData)
+│           ├── ProfileListPage.vue    # Profiles listing with filters, sort, bulk records, CSV export
 │           ├── ProfileDetailPage.vue  # Profile detail — page title, PageHeader, entry list, debug data
 │           ├── AdminPage.vue          # Admin actions (sync, cache, exports)
 │           └── sessions/             # Page-specific components for SessionDetailPage

--- a/frontend/src/components/LoadingSpinner.vue
+++ b/frontend/src/components/LoadingSpinner.vue
@@ -1,0 +1,26 @@
+<template>
+  <div class="ls-wrap" role="status" aria-live="polite">
+    <img src="/icons/gear.svg" class="ls-gear svg-black" alt="" />
+    <span class="sr-only">Loading</span>
+  </div>
+</template>
+
+<style scoped>
+.ls-wrap {
+  display: flex;
+  justify-content: center;
+  padding: 3rem 0;
+}
+
+.ls-gear {
+  width: 2rem;
+  height: 2rem;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+</style>

--- a/frontend/src/components/groups/GroupListFilter.vue
+++ b/frontend/src/components/groups/GroupListFilter.vue
@@ -123,7 +123,7 @@ async function addGroup() {
 <style scoped>
 .gf-wrap {
   background: var(--color-dtv-sand);
-  padding: 1rem 1.25rem;
+  padding: 1rem 1.5rem;
   margin-bottom: 1.5rem;
 }
 

--- a/frontend/src/components/groups/GroupListResults.vue
+++ b/frontend/src/components/groups/GroupListResults.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="loading" class="gr-state">Loading groups…</div>
+  <LoadingSpinner v-if="loading" />
   <div v-else-if="error" class="gr-state gr-state--error">{{ error }}</div>
   <div v-else-if="!groups.length" class="gr-state">No groups found.</div>
   <div v-else class="gr-grid">
@@ -10,6 +10,7 @@
 <script setup lang="ts">
 import GroupCard from './GroupCard.vue'
 import type { GroupWithStats } from './GroupListFilter.vue'
+import LoadingSpinner from '../LoadingSpinner.vue'
 
 defineProps<{
   groups: GroupWithStats[]
@@ -26,6 +27,7 @@ defineProps<{
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 1.5rem;
+  padding: 0 1.5rem;
 }
 @media (width < 48em) { .gr-grid { grid-template-columns: 1fr; } }
 

--- a/frontend/src/components/profiles/ProfileListFilter.vue
+++ b/frontend/src/components/profiles/ProfileListFilter.vue
@@ -64,8 +64,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   filtered: [profiles: ProfileResponse[]]
-  'fy-change': [fy: string]
-  'group-change': [group: string]
+  'filters-change': [filters: { fy: string; group: string }]
 }>()
 
 const route = useRoute()
@@ -79,10 +78,9 @@ const hoursFilter = ref((route.query.hours as string)        || '')
 const recordType  = ref((route.query.recordType as string)   || '')
 const recordStatus = ref((route.query.recordStatus as string) || '')
 
-// FY and group changes require a store re-fetch — emit upward
+// FY and group changes require a store re-fetch — emit upward as a single event
 // immediate: true ensures deep-linked query params are emitted on first load
-watch(fy, val => emit('fy-change', val), { immediate: true })
-watch(group, val => emit('group-change', val), { immediate: true })
+watch([fy, group], ([newFy, newGroup]) => emit('filters-change', { fy: newFy, group: newGroup }), { immediate: true })
 
 // Clear record status when record type is cleared
 watch(recordType, val => { if (!val) recordStatus.value = '' })

--- a/frontend/src/components/profiles/ProfileListResults.vue
+++ b/frontend/src/components/profiles/ProfileListResults.vue
@@ -95,16 +95,18 @@ function toggle(id: number) {
   gap: 0.5rem;
 }
 
-.plr-item:hover { background: var(--color-dtv-sand-light); }
+/* Hover only on pointer devices — avoids sticky hover on touch */
+@media (hover: hover) {
+  .plr-item:hover { background: var(--color-dtv-sand-light); }
+  .plr-item:hover :deep(.pli-wrap) { background: inherit; }
+  .plr-item:hover .plr-checkbox:not(:checked) { background: var(--color-dtv-light); border-color: transparent; }
+}
 
-/* pli-wrap as first child (no checkbox) — needs full horizontal padding */
-.plr-item :deep(.pli-wrap:first-child) { padding: 0 1.5rem; flex: 1; min-width: 0; }
+/* pli-wrap as first child (no checkbox) — override horizontal padding only; vertical comes from pli-wrap itself */
+.plr-item :deep(.pli-wrap:first-child) { padding-left: 1.5rem; padding-right: 1.5rem; flex: 1; min-width: 0; }
 
 /* pli-wrap after checkbox — checkbox provides left offset, keep right padding */
 .plr-item :deep(.pli-wrap:not(:first-child)) { padding-left: 0; padding-right: 1.5rem; flex: 1; min-width: 0; }
-
-/* Suppress pli-wrap's own hover — parent row handles it */
-.plr-item :deep(.pli-wrap:hover) { background: inherit; }
 
 .plr-checkbox {
   flex-shrink: 0;
@@ -116,8 +118,6 @@ function toggle(id: number) {
   background: var(--color-dtv-sand);
   cursor: pointer;
 }
-
-.plr-item:hover .plr-checkbox { background: var(--color-dtv-light); }
 
 .plr-checkbox:checked {
   background: var(--color-dtv-green);

--- a/frontend/src/components/profiles/ProfileListResults.vue
+++ b/frontend/src/components/profiles/ProfileListResults.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="plr-section">
-    <div v-if="loading" class="plr-empty">Loading…</div>
-    <div v-else-if="!profiles.length" class="plr-empty">No volunteers found.</div>
+    <LoadingSpinner v-if="loading" />
+    <div v-else-if="!profiles.length" class="plr-empty">No profiles found.</div>
     <template v-else>
       <div v-if="canSelect && selected" class="plr-select-row">
         <button class="plr-select-all" @click="toggleSelectAll">
@@ -31,6 +31,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import ProfileListItem from './ProfileListItem.vue'
+import LoadingSpinner from '../LoadingSpinner.vue'
 import type { ProfileResponse } from '../../../../types/api-responses'
 
 
@@ -73,7 +74,7 @@ function toggle(id: number) {
 <style scoped>
 .plr-section { padding: 0; }
 
-.plr-empty { padding: 1.5rem 0; color: var(--color-text-muted); font-size: 0.9rem; }
+.plr-empty { padding: 1.5rem; color: var(--color-text-muted); font-size: 0.9rem; }
 
 .plr-select-row {
   padding: 0.5rem 1.5rem;
@@ -92,15 +93,22 @@ function toggle(id: number) {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0 1.5rem;
 }
 
-/* Own all horizontal padding here — zero pli-wrap's own to prevent doubling */
-.plr-item :deep(.pli-wrap) { padding-left: 0; padding-right: 0; flex: 1; min-width: 0; }
+.plr-item:hover { background: var(--color-dtv-sand-light); }
 
+/* pli-wrap as first child (no checkbox) — needs full horizontal padding */
+.plr-item :deep(.pli-wrap:first-child) { padding: 0 1.5rem; flex: 1; min-width: 0; }
+
+/* pli-wrap after checkbox — checkbox provides left offset, keep right padding */
+.plr-item :deep(.pli-wrap:not(:first-child)) { padding-left: 0; padding-right: 1.5rem; flex: 1; min-width: 0; }
+
+/* Suppress pli-wrap's own hover — parent row handles it */
+.plr-item :deep(.pli-wrap:hover) { background: inherit; }
 
 .plr-checkbox {
   flex-shrink: 0;
+  margin-left: 1.5rem;
   appearance: none;
   width: 20px; height: 20px;
   border-radius: 0;
@@ -108,6 +116,8 @@ function toggle(id: number) {
   background: var(--color-dtv-sand);
   cursor: pointer;
 }
+
+.plr-item:hover .plr-checkbox { background: var(--color-dtv-light); }
 
 .plr-checkbox:checked {
   background: var(--color-dtv-green);

--- a/frontend/src/components/sessions/SessionListResults.vue
+++ b/frontend/src/components/sessions/SessionListResults.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="sr-section">
-    <div v-if="loading" class="sr-empty">Loading…</div>
+    <LoadingSpinner v-if="loading" />
     <div v-else-if="!sessions.length" class="sr-empty">No sessions found.</div>
     <template v-else>
       <!-- Select all — admin only -->
@@ -31,6 +31,7 @@ import { computed } from 'vue'
 import { useViewer } from '../../composables/useViewer'
 import type { Session } from '../../types/session'
 import SessionCard from './SessionCard.vue'
+import LoadingSpinner from '../LoadingSpinner.vue'
 
 const props = defineProps<{
   sessions: Session[]
@@ -65,9 +66,8 @@ function toggle(id: number) {
 .sr-empty { padding: 1.5rem 0; color: var(--color-text-muted); font-size: 0.9rem; }
 
 .sr-select-row {
-  padding: 0.5rem 0;
+  padding: 0.5rem 1.5rem;
   border-bottom: 1px solid var(--color-surface-hover);
-  margin-bottom: 1rem;
 }
 
 .sr-select-all {
@@ -80,7 +80,7 @@ function toggle(id: number) {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 1.5rem;
-  padding: 1.5rem 0;
+  padding: 1.5rem;
 }
 @media (width < 48em) { .sr-grid { grid-template-columns: 1fr; } }
 

--- a/frontend/src/pages/GroupListPage.vue
+++ b/frontend/src/pages/GroupListPage.vue
@@ -2,7 +2,7 @@
   <DefaultLayout>
     <h1 class="sr-only">Groups</h1>
     <PageHeader>Groups</PageHeader>
-    <div class="px-6 pb-6">
+    <div class="pb-6">
       <GroupListFilter
         :groups="groupsStore.groups"
         :sessions="sessionsStore.sessions"

--- a/frontend/src/pages/ProfileListPage.vue
+++ b/frontend/src/pages/ProfileListPage.vue
@@ -1,14 +1,13 @@
 <template>
   <DefaultLayout>
     <h1 class="sr-only">Profiles</h1>
-    <PageHeader>Volunteers</PageHeader>
+    <PageHeader>Profiles</PageHeader>
     <ProfileListFilter
       :profiles="store.profiles"
       :groups="groupsStore.groups"
       :record-options="recordOptions"
       @filtered="filtered = $event"
-      @fy-change="onFyChange"
-      @group-change="onGroupChange"
+      @filters-change="onFiltersChange"
     />
     <ProfileListActions
       :filtered-profiles="filtered"
@@ -54,7 +53,7 @@ import { useProfileListStore } from '../stores/profileList'
 import { useGroupListStore } from '../stores/groupList'
 import type { ProfileResponse } from '../../../types/api-responses'
 
-usePageTitle('Volunteers')
+usePageTitle('Profiles')
 
 const profile = useViewer()
 const store = useProfileListStore()
@@ -77,14 +76,10 @@ const individualSelectedCount = computed(() =>
   }).length
 )
 
-function onFyChange(val: string) {
-  fy.value = val
-  store.fetch(val, group.value)
-}
-
-function onGroupChange(val: string) {
-  group.value = val
-  store.fetch(fy.value, val)
+function onFiltersChange({ fy: newFy, group: newGroup }: { fy: string; group: string }) {
+  fy.value = newFy
+  group.value = newGroup
+  store.fetch(newFy, newGroup)
 }
 
 async function onBulkSave(payload: BulkRecordPayload) {
@@ -114,7 +109,7 @@ async function onBulkSave(payload: BulkRecordPayload) {
 
 onMounted(async () => {
   groupsStore.fetch()
-  // Initial profiles fetch is driven by the immediate fy/group watchers in ProfileListFilter
+  // Initial profiles fetch is driven by the immediate filters-change watcher in ProfileListFilter
   try {
     const res = await fetch('/api/records/options')
     if (res.ok) {

--- a/frontend/src/pages/SessionListPage.vue
+++ b/frontend/src/pages/SessionListPage.vue
@@ -2,7 +2,7 @@
   <DefaultLayout>
     <h1 class="sr-only">Sessions</h1>
     <PageHeader>Sessions</PageHeader>
-    <div class="px-6 pb-6">
+    <div class="pb-6">
       <SessionListFilter :sessions="store.sessions" @filtered="filtered = $event" />
       <SessionListActions
         :sessions="filtered"

--- a/frontend/src/pages/sandbox/SandboxIcons.vue
+++ b/frontend/src/pages/sandbox/SandboxIcons.vue
@@ -43,7 +43,8 @@ const groups = [
   {
     label: 'Badges',
     prefix: 'badges/',
-    icons: ['card', 'child', 'csr', 'dig', 'diglead', 'firstaider', 'group', 'late', 'member', 'new', 'nophoto', 'regular'],
+    icons: ['card', 'child', 'csr', 'dig', 'diglead', 'firstaider', 'group', 'late',
+      'member', 'new', 'nophoto', 'regular'],
   },
   {
     label: 'Brands',
@@ -57,7 +58,7 @@ const groups = [
       'add', 'burger', 'checkboxes', 'clock', 'close',
       'delete', 'download', 'edit',
       'filter', 'gear', 'locked', 'logout',
-      'profile', 'refresh', 'register', 'regular', 'return',
+      'profile', 'refresh', 'register', 'return',
       'save', 'settings', 'share', 'sort', 'tick', 'trash', 'upload', 'uploadphoto',
     ],
   },

--- a/frontend/src/stores/groupList.ts
+++ b/frontend/src/stores/groupList.ts
@@ -6,11 +6,10 @@ export { GroupResponse }
 
 export const useGroupListStore = defineStore('groups', () => {
   const groups = ref<GroupResponse[]>([])
-  const loading = ref(false)
+  const loading = ref(true)
   const error = ref<string | null>(null)
 
   async function fetch() {
-    if (loading.value) return
     loading.value = true
     error.value = null
     try {

--- a/frontend/src/stores/sessionList.ts
+++ b/frontend/src/stores/sessionList.ts
@@ -57,7 +57,7 @@ function mapSession(r: SessionResponse, profileStats: { sessionIds?: number[]; r
 export const useSessionListStore = defineStore('sessions', () => {
   const viewer = useViewer()
   const raw = ref<SessionResponse[]>([])
-  const loading = ref(false)
+  const loading = ref(true)
   const error = ref<string | null>(null)
 
   const sessions = computed(() =>
@@ -65,7 +65,6 @@ export const useSessionListStore = defineStore('sessions', () => {
   )
 
   async function fetch() {
-    if (loading.value) return
     loading.value = true
     error.value = null
     try {


### PR DESCRIPTION
fix(#99): loading spinner, filter flush, profile double-fetch

- Add LoadingSpinner (spinning gear) to session/group/profile list results
- Fix profile loading flash: combine fy+group watchers in ProfileListFilter
  into single filters-change event — prevents double store.fetch() on mount
- Fix sessions/groups loading flash: initialise loading=true, remove guard
- Remove px-6 from SessionListPage/GroupListPage so filter bars sit flush
  to viewport; results grids own their own horizontal padding
- Align GroupListFilter padding to 1.5rem (was 1.25rem)
- Profile list page: title/empty state → "Profiles"; row hover stretches
  full width, checkbox lightens on hover
- Sessions select-all row: add 1.5rem horizontal padding to match profiles
