### PR TITLE
feat(#123): auth gates, 404/403 pages, and catch-all route

### DIFF
--- a/frontend/src/components/profiles/ProfileListResults.vue
+++ b/frontend/src/components/profiles/ProfileListResults.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="plr-section">
     <LoadingSpinner v-if="loading" />
+    <div v-else-if="error" class="plr-state plr-state--error">{{ error }}</div>
     <div v-else-if="!profiles.length" class="plr-empty">No profiles found.</div>
     <template v-else>
       <div v-if="canSelect && selected" class="plr-select-row">
@@ -38,6 +39,7 @@ import type { ProfileResponse } from '../../../../types/api-responses'
 const props = defineProps<{
   profiles: ProfileResponse[]
   loading?: boolean
+  error?: string | null
   selected?: number[]
   canSelect: boolean
   fy: string
@@ -73,6 +75,9 @@ function toggle(id: number) {
 
 <style scoped>
 .plr-section { padding: 0; }
+
+.plr-state { padding: 1.5rem; color: var(--color-text-muted); font-size: 0.9rem; }
+.plr-state--error { color: var(--color-dtv-red); }
 
 .plr-empty { padding: 1.5rem; color: var(--color-text-muted); font-size: 0.9rem; }
 

--- a/frontend/src/pages/ForbiddenPage.vue
+++ b/frontend/src/pages/ForbiddenPage.vue
@@ -1,0 +1,40 @@
+<template>
+  <TaskLayout>
+    <FormCard title="Access denied">
+      <p class="fb-message">
+        You don't have permission to view this page.
+        <a href="mailto:admin@deantrailvolunteers.org.uk" class="fb-link">Contact us</a>
+        if you think this is a mistake.
+      </p>
+      <FormSubmitRow>
+        <FormButton href="/">Go to home page</FormButton>
+      </FormSubmitRow>
+    </FormCard>
+  </TaskLayout>
+</template>
+
+<script setup lang="ts">
+import TaskLayout from '../layouts/TaskLayout.vue'
+import FormCard from '../components/forms/FormCard.vue'
+import FormButton from '../components/forms/FormButton.vue'
+import FormSubmitRow from '../components/forms/FormSubmitRow.vue'
+import { usePageTitle } from '../composables/usePageTitle'
+
+usePageTitle('Access denied')
+</script>
+
+<style scoped>
+.fb-message {
+  font-size: 0.9rem;
+  color: var(--color-dtv-dark);
+  opacity: 0.7;
+  text-align: center;
+  margin: 0 0 0.5rem;
+  line-height: 1.5;
+}
+
+.fb-link {
+  color: var(--color-dtv-green-dark);
+  opacity: 1;
+}
+</style>

--- a/frontend/src/pages/GroupDetailPage.vue
+++ b/frontend/src/pages/GroupDetailPage.vue
@@ -1,5 +1,14 @@
 <template>
-  <DefaultLayout>
+  <TaskLayout v-if="store.httpStatus === 404">
+    <FormCard title="Group not found">
+      <p class="gd-task-message">This group doesn't exist.</p>
+      <FormSubmitRow>
+        <FormButton href="/groups">Back to groups</FormButton>
+      </FormSubmitRow>
+    </FormCard>
+  </TaskLayout>
+
+  <DefaultLayout v-else>
     <h1 v-if="store.group" class="sr-only">{{ store.group.displayName || store.group.key }}</h1>
     <div v-if="store.loading" class="gd-loading">Loading…</div>
     <div v-else-if="store.error" class="gd-error">{{ store.error }}</div>
@@ -53,6 +62,10 @@ import { usePageTitle } from '../composables/usePageTitle'
 import PageHeader from '../components/PageHeader.vue'
 import { useViewer } from '../composables/useViewer'
 import DefaultLayout from '../layouts/DefaultLayout.vue'
+import TaskLayout from '../layouts/TaskLayout.vue'
+import FormCard from '../components/forms/FormCard.vue'
+import FormButton from '../components/forms/FormButton.vue'
+import FormSubmitRow from '../components/forms/FormSubmitRow.vue'
 import LayoutColumns from '../components/LayoutColumns.vue'
 import CalendarWidget from '../components/CalendarWidget.vue'
 import MediaCarousel from '../components/MediaCarousel.vue'
@@ -235,4 +248,12 @@ watch(() => route.params.key, key => {
 <style scoped>
 .gd-loading { padding: 2rem; color: var(--color-text-muted); }
 .gd-error { padding: 2rem; color: var(--color-dtv-red); }
+
+.gd-task-message {
+  font-size: 0.9rem;
+  color: var(--color-dtv-dark);
+  opacity: 0.7;
+  text-align: center;
+  margin: 0 0 0.5rem;
+}
 </style>

--- a/frontend/src/pages/NotFoundPage.vue
+++ b/frontend/src/pages/NotFoundPage.vue
@@ -1,0 +1,34 @@
+<template>
+  <TaskLayout>
+    <FormCard title="Page not found">
+      <p class="nf-message">This page doesn't exist.</p>
+      <FormSubmitRow>
+        <FormButton href="/">Go to home page</FormButton>
+        <FormButton v-if="viewer.isPublic" href="/login" variant="outline">Sign in</FormButton>
+      </FormSubmitRow>
+    </FormCard>
+  </TaskLayout>
+</template>
+
+<script setup lang="ts">
+import TaskLayout from '../layouts/TaskLayout.vue'
+import FormCard from '../components/forms/FormCard.vue'
+import FormButton from '../components/forms/FormButton.vue'
+import FormSubmitRow from '../components/forms/FormSubmitRow.vue'
+import { useViewer } from '../composables/useViewer'
+import { usePageTitle } from '../composables/usePageTitle'
+
+usePageTitle('Page not found')
+
+const viewer = useViewer()
+</script>
+
+<style scoped>
+.nf-message {
+  font-size: 0.9rem;
+  color: var(--color-dtv-dark);
+  opacity: 0.7;
+  text-align: center;
+  margin: 0 0 0.5rem;
+}
+</style>

--- a/frontend/src/pages/ProfileDetailPage.vue
+++ b/frontend/src/pages/ProfileDetailPage.vue
@@ -16,7 +16,8 @@
     <FormCard title="Profile not found">
       <p class="pd-task-message">This profile doesn't exist.</p>
       <FormSubmitRow>
-        <FormButton href="/profiles">Back to profiles</FormButton>
+        <FormButton v-if="viewer.isTrusted" href="/profiles">Back to profiles</FormButton>
+        <FormButton v-else href="/">Go to home page</FormButton>
       </FormSubmitRow>
     </FormCard>
   </TaskLayout>

--- a/frontend/src/pages/ProfileDetailPage.vue
+++ b/frontend/src/pages/ProfileDetailPage.vue
@@ -1,5 +1,27 @@
 <template>
-  <DefaultLayout>
+  <TaskLayout v-if="store.httpStatus === 403">
+    <FormCard title="Access denied">
+      <p class="pd-task-message">
+        You don't have permission to view this profile.
+        <a href="mailto:admin@deantrailvolunteers.org.uk" class="pd-task-link">Contact us</a>
+        if you think this is a mistake.
+      </p>
+      <FormSubmitRow>
+        <FormButton href="/">Go to home page</FormButton>
+      </FormSubmitRow>
+    </FormCard>
+  </TaskLayout>
+
+  <TaskLayout v-else-if="store.httpStatus === 404">
+    <FormCard title="Profile not found">
+      <p class="pd-task-message">This profile doesn't exist.</p>
+      <FormSubmitRow>
+        <FormButton href="/profiles">Back to profiles</FormButton>
+      </FormSubmitRow>
+    </FormCard>
+  </TaskLayout>
+
+  <DefaultLayout v-else>
     <div v-if="store.loading" class="pd-loading">Loading…</div>
     <div v-else-if="store.error" class="pd-error">{{ store.error }}</div>
     <template v-else-if="store.profile">
@@ -72,6 +94,10 @@
 import { ref, computed, watch, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
 import DefaultLayout from '../layouts/DefaultLayout.vue'
+import TaskLayout from '../layouts/TaskLayout.vue'
+import FormCard from '../components/forms/FormCard.vue'
+import FormButton from '../components/forms/FormButton.vue'
+import FormSubmitRow from '../components/forms/FormSubmitRow.vue'
 import DebugData from '../components/DebugData.vue'
 import PageHeader from '../components/PageHeader.vue'
 import ProfileEntryList from '../components/profiles/ProfileEntryList.vue'
@@ -330,4 +356,18 @@ async function onEditEntry(id: number, data: EditData | null) {
 }
 .pd-email a { color: inherit; }
 .pd-email a:hover { color: var(--color-dtv-green); }
+
+.pd-task-message {
+  font-size: 0.9rem;
+  color: var(--color-dtv-dark);
+  opacity: 0.7;
+  text-align: center;
+  margin: 0 0 0.5rem;
+  line-height: 1.5;
+}
+
+.pd-task-link {
+  color: var(--color-dtv-green-dark);
+  opacity: 1;
+}
 </style>

--- a/frontend/src/pages/ProfileListPage.vue
+++ b/frontend/src/pages/ProfileListPage.vue
@@ -20,6 +20,7 @@
     <ProfileListResults
       :profiles="filtered"
       :loading="store.loading"
+      :error="store.error"
       :selected="selected"
       :can-select="profile.isAdmin"
       :fy="fy"

--- a/frontend/src/pages/SessionDetailPage.vue
+++ b/frontend/src/pages/SessionDetailPage.vue
@@ -1,5 +1,14 @@
 <template>
-  <DefaultLayout :padded="false">
+  <TaskLayout v-if="store.httpStatus === 404">
+    <FormCard title="Session not found">
+      <p class="sd-task-message">This session doesn't exist.</p>
+      <FormSubmitRow>
+        <FormButton href="/sessions">Back to sessions</FormButton>
+      </FormSubmitRow>
+    </FormCard>
+  </TaskLayout>
+
+  <DefaultLayout v-else :padded="false">
     <h1 v-if="store.session" class="sr-only">{{ store.session.groupName }}, {{ formatDate(store.session.date) }}</h1>
     <div v-if="store.loading && !store.session" class="text-gray-400 p-6">Loading…</div>
     <div v-else-if="store.error" class="text-red-500 p-6">{{ store.error }}</div>
@@ -188,6 +197,10 @@ import type { EntryResponse } from '../../../types/api-responses'
 import type { GroupItem, SessionSaveData } from './modals/SessionEditModal.vue'
 import { useRoute, useRouter } from 'vue-router'
 import DefaultLayout from '../layouts/DefaultLayout.vue'
+import TaskLayout from '../layouts/TaskLayout.vue'
+import FormCard from '../components/forms/FormCard.vue'
+import FormButton from '../components/forms/FormButton.vue'
+import FormSubmitRow from '../components/forms/FormSubmitRow.vue'
 import LayoutColumns from '../components/LayoutColumns.vue'
 import DebugData from '../components/DebugData.vue'
 import { useSessionDetailStore } from '../stores/sessionDetail'
@@ -540,3 +553,13 @@ watch(() => [route.params.groupKey, route.params.date], () => {
   fetchMedia(route.params.groupKey as string, route.params.date as string)
 })
 </script>
+
+<style scoped>
+.sd-task-message {
+  font-size: 0.9rem;
+  color: var(--color-dtv-dark);
+  opacity: 0.7;
+  text-align: center;
+  margin: 0 0 0.5rem;
+}
+</style>

--- a/frontend/src/pages/sandbox/SandboxErrorPages.vue
+++ b/frontend/src/pages/sandbox/SandboxErrorPages.vue
@@ -1,0 +1,82 @@
+<template>
+  <DefaultLayout>
+    <div class="sandbox">
+      <RouterLink to="/sandbox" class="back">← Sandbox</RouterLink>
+      <h1>Error Pages</h1>
+
+      <!-- NotFoundPage — public (sign-in button shown) -->
+      <h2>NotFoundPage — public user</h2>
+      <div class="task-body">
+        <FormCard title="Page not found">
+          <p class="ep-message">This page doesn't exist.</p>
+          <FormSubmitRow>
+            <FormButton href="/">Go to home page</FormButton>
+            <FormButton href="/login" variant="outline">Sign in</FormButton>
+          </FormSubmitRow>
+        </FormCard>
+      </div>
+
+      <!-- NotFoundPage — authenticated (no sign-in button) -->
+      <h2>NotFoundPage — authenticated user</h2>
+      <div class="task-body">
+        <FormCard title="Page not found">
+          <p class="ep-message">This page doesn't exist.</p>
+          <FormSubmitRow>
+            <FormButton href="/">Go to home page</FormButton>
+          </FormSubmitRow>
+        </FormCard>
+      </div>
+
+      <!-- ForbiddenPage -->
+      <h2>ForbiddenPage</h2>
+      <div class="task-body">
+        <FormCard title="Access denied">
+          <p class="ep-message">
+            You don't have permission to view this page.
+            <a href="mailto:admin@deantrailvolunteers.org.uk" class="ep-link">Contact us</a>
+            if you think this is a mistake.
+          </p>
+          <FormSubmitRow>
+            <FormButton href="/">Go to home page</FormButton>
+          </FormSubmitRow>
+        </FormCard>
+      </div>
+
+    </div>
+  </DefaultLayout>
+</template>
+
+<script setup lang="ts">
+import '../../styles/sandbox.css'
+import { usePageTitle } from '../../composables/usePageTitle'
+import DefaultLayout from '../../layouts/DefaultLayout.vue'
+import FormCard from '../../components/forms/FormCard.vue'
+import FormButton from '../../components/forms/FormButton.vue'
+import FormSubmitRow from '../../components/forms/FormSubmitRow.vue'
+
+usePageTitle('Error Pages — Sandbox')
+</script>
+
+<style scoped>
+.task-body {
+  max-width: 26rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.ep-message {
+  font-size: 0.9rem;
+  color: var(--color-dtv-dark);
+  opacity: 0.7;
+  text-align: center;
+  margin: 0 0 0.5rem;
+  line-height: 1.5;
+}
+
+.ep-link {
+  color: var(--color-dtv-green-dark);
+  opacity: 1;
+}
+</style>

--- a/frontend/src/pages/sandbox/SandboxIndex.vue
+++ b/frontend/src/pages/sandbox/SandboxIndex.vue
@@ -17,15 +17,22 @@
       </section>
 
       <section>
-        <h2>Forms and Modals</h2>
+        <h2>Modals and Forms</h2>
         <nav>
           <RouterLink to="/sandbox/modal-layout">ModalLayout</RouterLink>
           <RouterLink to="/sandbox/modals">All Modals</RouterLink>
           <RouterLink to="/sandbox/form-components">Form Layout and Components</RouterLink>
           <RouterLink to="/sandbox/flash-message">FlashMessage</RouterLink>
+        </nav>
+      </section>
+
+      <section>
+        <h2>Task Pages</h2>
+        <nav>
           <RouterLink to="/sandbox/login-page">LoginPage</RouterLink>
           <RouterLink to="/sandbox/consent-page">ConsentPage</RouterLink>
           <RouterLink to="/sandbox/upload-page">UploadPage</RouterLink>
+          <RouterLink to="/sandbox/error-pages">Error Pages</RouterLink>
         </nav>
       </section>
 

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,5 +1,12 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import { ensureAuth, user } from '../composables/useAuth'
+
+declare module 'vue-router' {
+  interface RouteMeta {
+    requiresTrusted?: boolean  // Admin / Check In / Read Only only
+    requiresAuth?: boolean     // Any authenticated user (self-service included)
+  }
+}
 import HomePage from '../pages/HomePage.vue'
 import GroupListPage from '../pages/GroupListPage.vue'
 import PrivacyPage from '../pages/PrivacyPage.vue'
@@ -39,9 +46,11 @@ export const router = createRouter({
     { path: '/terms', component: TermsPage },
     { path: '/login', component: LoginPage },
     { path: '/admin', component: AdminPage },
-    { path: '/profiles', component: ProfileListPage },
-    { path: '/profiles/:slug', component: ProfileDetailPage },
-    { path: '/profiles/:slug/consent', component: () => import('../pages/ConsentPage.vue') },
+    { path: '/not-found', component: () => import('../pages/NotFoundPage.vue') },
+    { path: '/forbidden', component: () => import('../pages/ForbiddenPage.vue') },
+    { path: '/profiles', component: ProfileListPage, meta: { requiresTrusted: true } },
+    { path: '/profiles/:slug', component: ProfileDetailPage, meta: { requiresAuth: true } },
+    { path: '/profiles/:slug/consent', component: () => import('../pages/ConsentPage.vue'), meta: { requiresAuth: true } },
     { path: '/upload', component: () => import('../pages/UploadPage.vue') },
     { path: '/sandbox', component: () => import('../pages/sandbox/SandboxIndex.vue') },
     { path: '/sandbox/app-button', component: () => import('../pages/sandbox/SandboxAppButton.vue') },
@@ -74,10 +83,19 @@ export const router = createRouter({
     { path: '/sandbox/login-page', component: () => import('../pages/sandbox/SandboxLoginPage.vue') },
     { path: '/sandbox/consent-page', component: () => import('../pages/sandbox/SandboxConsentPage.vue') },
     { path: '/sandbox/upload-page', component: () => import('../pages/sandbox/SandboxUploadPage.vue') },
+    { path: '/sandbox/error-pages', component: () => import('../pages/sandbox/SandboxErrorPages.vue') },
+    { path: '/:pathMatch(.*)*', component: () => import('../pages/NotFoundPage.vue') },
   ]
 })
 
 router.beforeEach(async (to) => {
+  if (to.meta.requiresTrusted || to.meta.requiresAuth) {
+    await ensureAuth()
+    if (!user.value) return '/not-found'
+    if (to.meta.requiresTrusted && user.value.role === 'selfservice') return '/forbidden'
+    return
+  }
+
   if (!to.path.startsWith('/sandbox')) return
   if (import.meta.env.DEV) return
   await ensureAuth()

--- a/frontend/src/stores/groupDetail.ts
+++ b/frontend/src/stores/groupDetail.ts
@@ -6,13 +6,16 @@ export const useGroupDetailStore = defineStore('groupDetail', () => {
   const group = ref<GroupDetailResponse | null>(null)
   const loading = ref(false)
   const error = ref<string | null>(null)
+  const httpStatus = ref<number | null>(null)
 
   async function fetch(key: string) {
     loading.value = true
     error.value = null
+    httpStatus.value = null
     group.value = null
     try {
       const res = await window.fetch(`/api/groups/${key}`)
+      httpStatus.value = res.status
       if (!res.ok) throw new Error(`Failed to load group (${res.status})`)
       const json: { data: GroupDetailResponse } = await res.json()
       group.value = json.data
@@ -24,5 +27,5 @@ export const useGroupDetailStore = defineStore('groupDetail', () => {
     }
   }
 
-  return { group, loading, error, fetch }
+  return { group, loading, error, httpStatus, fetch }
 })

--- a/frontend/src/stores/profileDetail.ts
+++ b/frontend/src/stores/profileDetail.ts
@@ -1,18 +1,27 @@
 import { ref } from 'vue'
 import { defineStore } from 'pinia'
+import { useRouter } from 'vue-router'
 import type { ProfileDetailResponse } from '../../../types/api-responses'
 
 export const useProfileDetailStore = defineStore('profileDetail', () => {
   const profile = ref<ProfileDetailResponse | null>(null)
   const loading = ref(false)
   const error = ref<string | null>(null)
+  const httpStatus = ref<number | null>(null)
 
   async function fetch(slug: string) {
+    const router = useRouter()
     loading.value = true
     error.value = null
+    httpStatus.value = null
     profile.value = null
     try {
       const res = await window.fetch(`/api/profiles/${slug}`)
+      httpStatus.value = res.status
+      if (res.status === 401) {
+        router.push(`/login?returnTo=${encodeURIComponent(window.location.pathname)}`)
+        return
+      }
       if (!res.ok) throw new Error(`Failed to load profile (${res.status})`)
       const json: { data: ProfileDetailResponse } = await res.json()
       profile.value = json.data
@@ -24,5 +33,5 @@ export const useProfileDetailStore = defineStore('profileDetail', () => {
     }
   }
 
-  return { profile, loading, error, fetch }
+  return { profile, loading, error, httpStatus, fetch }
 })

--- a/frontend/src/stores/profileList.ts
+++ b/frontend/src/stores/profileList.ts
@@ -1,5 +1,6 @@
 import { ref } from 'vue'
 import { defineStore } from 'pinia'
+import { useRouter } from 'vue-router'
 import type { ProfileResponse } from '../../../types/api-responses'
 
 export const useProfileListStore = defineStore('profiles', () => {
@@ -10,6 +11,8 @@ export const useProfileListStore = defineStore('profiles', () => {
   let abortController: AbortController | null = null
 
   async function fetch(fy?: string, group?: string) {
+    const router = useRouter()
+
     // Cancel any in-flight request before starting a new one
     abortController?.abort()
     abortController = new AbortController()
@@ -24,6 +27,10 @@ export const useProfileListStore = defineStore('profiles', () => {
       if (group) params.set('group', group)
       const query = params.toString()
       const res = await window.fetch(`/api/profiles${query ? `?${query}` : ''}`, { signal: abortController.signal })
+      if (res.status === 401) {
+        router.push(`/login?returnTo=${encodeURIComponent(window.location.pathname)}`)
+        return
+      }
       if (!res.ok) throw new Error(`Failed to load profiles (${res.status})`)
       const json: { data: ProfileResponse[] } = await res.json()
       profiles.value = json.data

--- a/frontend/src/stores/sessionDetail.ts
+++ b/frontend/src/stores/sessionDetail.ts
@@ -6,13 +6,16 @@ export const useSessionDetailStore = defineStore('sessionDetail', () => {
   const session = ref<SessionDetailResponse | null>(null)
   const loading = ref(false)
   const error = ref<string | null>(null)
+  const httpStatus = ref<number | null>(null)
 
   async function fetch(groupKey: string, date: string) {
     loading.value = true
     error.value = null
+    httpStatus.value = null
     session.value = null
     try {
       const res = await window.fetch(`/api/sessions/${groupKey}/${date}`)
+      httpStatus.value = res.status
       if (!res.ok) throw new Error(`Failed to load session (${res.status})`)
       const json = await res.json()
       const d = json.data
@@ -25,5 +28,5 @@ export const useSessionDetailStore = defineStore('sessionDetail', () => {
     }
   }
 
-  return { session, loading, error, fetch }
+  return { session, loading, error, httpStatus, fetch }
 })

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -82,7 +82,7 @@
   }
 
   html, body {
-    background-color: theme(--color-dtv-dark);
+    background-color: theme(--color-dtv-light);
     font-family: theme(--font-head);
     min-height: 100vh;
   }


### PR DESCRIPTION
Router
- Declare requiresTrusted / requiresAuth route meta (RouteMeta augmentation)
- Tag /profiles (trusted), /profiles/:slug and /profiles/:slug/consent (auth)
- Guard redirects public → /not-found, self-service on trusted route → /forbidden
- Add catch-all /:pathMatch(.*)*  → NotFoundPage for all unmatched routes

New pages (TaskLayout)
- NotFoundPage: "Page not found" — home CTA always, sign-in CTA for public users
- ForbiddenPage: "Access denied" — home CTA + admin contact link

Store hardening
- profileDetail, profileList: 401 redirects to /login?returnTo=... (stale-session safety)
- profileDetail, groupDetail, sessionDetail: httpStatus tracked so pages can branch on 404 vs other errors

Page error states
- ProfileDetailPage: explicit 403 and 404 inline states (TaskLayout); no silent empty fallthrough
- GroupDetailPage, SessionDetailPage: inline 404 states
- ProfileListResults: error prop added (matches groups pattern); ProfileListPage passes store.error

Sandbox
- /sandbox/error-pages: shows all NotFoundPage and ForbiddenPage variants
- Sandbox index: split "Forms and Modals" into "Modals and Forms" and "Task Pages"

Style
- Body background changed from #000204 to --color-dtv-light (eliminates black flash on route transitions)