### PR TITLE
feat(#129): replace BroadcastChannel with dual login options

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -50,7 +50,7 @@ Feature-complete volunteer tracking application with:
 - Profile detail with FY stats, FY bar chart (click to filter by year, click again to deselect; starts unselected), group hours (always visible; hours update for selected FY), entries with inline hours editing, group filter, records, regulars ([public/profile-detail.html](public/profile-detail.html))
 - Entry edit page with tag buttons, auto-fields, volunteer email (mailto link, auth users only), delete, Upload button (check-in+) ([public/entry-detail.html](public/entry-detail.html))
 - Add entry page with volunteer search and create ([public/add-entry.html](public/add-entry.html))
-- Unified sign-in page: magic link email (volunteer self-service, shown when `MAIL_SENDER` is configured) and Microsoft (trusted users) options; on successful magic link send, login cards are replaced by a sent-confirmation section with 15-minute countdown and "Back to Login" link; reason codes (`not-approved`, `not-found`, `invalid-state`) shown as warning banners ([public/login.html](public/login.html))
+- Unified sign-in page: two self-service options (shown when `MAIL_SENDER` is configured) and Microsoft (trusted users); method selector (radio group) lets volunteers choose "Send login link" or "Use verification code"; magic link sent card shows confirmation code (usability only) and "close this window" copy; verification code sent card shows code entry input with countdown; reason codes (`not-approved`, `not-found`, `invalid-state`) shown as warning banners ([public/login.html](public/login.html))
 - Volunteer media upload page (authenticated): context loaded from `?entryId=` param; ownership enforced for self-service users ([public/upload.html](public/upload.html))
 - Consent collection page: served at `/profiles/:slug/consent.html`; accessible to check-in, admin, and self-service (own profile only); fetches profile by slug, shows privacy (required) and photo (optional) consent checkboxes plus privacy policy link; submits to `POST /api/profiles/:id/consent` which upserts both records dated today ([public/consent.html](public/consent.html))
 - Media library page (authenticated): lists all sessions with photos as an Embla horizontal carousel using session cover images; clicking a session navigates to its gallery ([public/media/index.html](public/media/index.html))
@@ -416,7 +416,8 @@ dtv-tracker-app/
 │   └── auth/
 │       ├── index.ts               # Auth router: mounts dtv + magic routers; /providers, /me, /logout (clears dtv-auth cookie)
 │       ├── dtv.ts                 # DTV Account (Entra ID / Microsoft) login + callback
-│       └── magic.ts               # Magic link email login: POST /send (15min JWT) + GET /callback (createAuthToken → dtv-auth cookie)
+│       ├── magic.ts               # Magic link email login: POST /send (15min JWT + confirmation code) + GET /callback (direct redirect with flash)
+│       └── verify.ts              # Verification code login: POST /send (4-digit code, in-memory 15min) + POST /check (verifies, sets cookie) + GET /callback (email button link)
 ├── middleware/
 │   ├── auth.ts                    # Cookie auth middleware: reads dtv-auth cookie → validateAuthToken → req.session.user (selfservice)
 │   ├── require-auth.ts            # Auth guard middleware
@@ -506,7 +507,7 @@ dtv-tracker-app/
 - [x] PWA web manifest and icons for Add to Home Screen (Chrome on Android)
 - [x] Volunteer media upload via authenticated entry ID (check-in+ clicks Upload on entry detail; navigates to `/upload.html?entryId=:id`; self-service volunteers can also upload from their profile or session page); accepts photos (JPG, PNG, WebP, HEIC) and short videos (MP4, MOV); max 10 files, 10 MB each
 - [x] Upload completion screen: shows file count, review notice; link to session gallery
-- [x] Self-service volunteer login via magic link email — `Profile.Email` field controls access (set by admin/check-in); supports comma-separated list so one profile can match multiple email addresses (e.g. personal + old address); volunteers can view their own profile only, register for future sessions, and upload photos to their own entries; other volunteers' data is blocked at both middleware and handler level
+- [x] Self-service volunteer login via two email methods (magic link + verification code) — `Profile.Email` field controls access (set by admin/check-in); supports comma-separated list so one profile can match multiple email addresses; volunteers can view their own profile only, register for future sessions, and upload photos to their own entries; other volunteers' data is blocked at both middleware and handler level; global rate limit (`EMAIL_RATE_LIMIT_PER_HOUR`, default 60) across both methods
 - [x] Volunteer sign-up for sessions (self-service role): own profile only, future sessions only, duplicate prevention
 - [x] Self-service privacy hardening: regulars list hidden on group pages (shows "You are a regular" message if applicable); profile slugs require numeric ID suffix to prevent path confusion; `GET /api/tags/hours-by-taxonomy?profile=` requires authentication; media `name`/`webUrl` (contain uploader PII) stripped from public API responses
 - [x] Magic link auth: 128-bit random token, SHA-256 hash stored in SharePoint Logins list; 72h TTL; multi-device (each token valid independently); `dtv-auth` cookie read by `middleware/auth.ts` on every request; `passport`, Google OAuth, and Facebook OAuth fully removed
@@ -559,7 +560,8 @@ npm run frontend:build:staging   # Staging build served at /v2/ on live site (ba
 - Always read [docs/sharepoint-schema.md](docs/sharepoint-schema.md) for the complete field definitions before working with SharePoint data
 - The app calculates all derived values (hours, registrations, membership) from source data at query time.
 - The `Code` field on the Entries list is no longer used for uploads (the code-based upload system was replaced by authenticated entry-ID-based upload). The field is left in SharePoint but no longer read or written.
-- `MAIL_SENDER` env var enables magic link email login (optional — the Volunteer Sign In card is hidden when not set). Must be the UPN/address of a mailbox the Azure app has `Mail.Send` permission for. Emails sent via Graph API (`POST /v1.0/users/{sender}/sendMail`); reuses existing app credentials. Add `Mail.Send` application permission in the Azure app registration and grant admin consent.
+- `MAIL_SENDER` env var enables self-service email login (optional — the Volunteer Sign In card is hidden when not set). Must be the UPN/address of a mailbox the Azure app has `Mail.Send` permission for. Emails sent via Graph API (`POST /v1.0/users/{sender}/sendMail`); reuses existing app credentials. Add `Mail.Send` application permission in the Azure app registration and grant admin consent.
+- `EMAIL_RATE_LIMIT_PER_HOUR` env var: global cap on authentication emails sent across all self-service login methods (default `60`). Returns 429 on breach.
 - `AUTH_BASIC_TTL_HOURS` env var: lifetime of `dtv-auth` cookie tokens (default `72`). Tokens are stored as SHA-256 hashes in the SharePoint Logins list (GUID `e3b5c7fb-313a-44b4-9363-a4e4d2b65a57`). Emergency revocation: clear all items from the Logins list.
 - `MEDIA_LIBRARY_DRIVE_ID` env var required for photo uploads (Graph API Drive ID of the SharePoint Media document library).
 - `TAXONOMY_TERM_SET_ID` env var: GUID of the SharePoint Term Store term set for session tagging. **Required** — tags will not appear without it.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,5 +1,32 @@
 # Development Progress
 
+## Session: 2026-04-13 (Login revised — remove BroadcastChannel, add verification code)
+
+### Completed Tasks
+
+#### Login revised approach ✓ (closes #129)
+
+Removed BroadcastChannel entirely and introduced two selectable login methods for self-service volunteers.
+
+**Backend:**
+- `services/email-rate-limiter.ts` — new shared in-memory rate limiter; `EMAIL_RATE_LIMIT_PER_HOUR` env var (default 60); 429 on breach with user-facing message
+- `routes/auth/magic.ts` — added rate limiting; callback now does a direct `res.redirect(destWithFlash)` instead of serving an intermediate HTML page; `escapeHtml` helper removed (no longer needed); BroadcastChannel script removed
+- `routes/auth/verify.ts` — new router: `POST /auth/verify/send` (4-digit code, in-memory store, 15min TTL, email button links to login page with code pre-filled); `POST /auth/verify/check` (verifies code, max 5 attempts, sets dtv-auth cookie, returns flashName)
+- `routes/auth/index.ts` — mounts verifyRouter; providers endpoint now returns `{ magic, verify }` (both true when `MAIL_SENDER` is set)
+
+**Frontend (Vue v2):**
+- `LoginPage.vue` — BroadcastChannel logic removed completely; method selector (radio group) shown when both `magic` and `verify` are available; `sendLoginEmail()` branches to correct endpoint by method; magic link sent card shows confirmation code + static "close this window" copy (no countdown display); verification code sent card shows code entry input + countdown + verify button + error display; `checkCode()` POSTs to `/auth/verify/check` and navigates on success
+
+**Copy:**
+- 429: "We've sent too many sign-in emails recently. Please wait a while and try again."
+- Code expired: "That code has expired or could not be found. Request a new code and try again."
+- Wrong code: "That code does not match. Check the 4 digits and try again."
+- Too many attempts: "Too many incorrect attempts. Request a new code to continue."
+
+**v1 (`public/login.html`) not changed — frozen.**
+
+---
+
 ## Session: 2026-04-09 (ProfileEntryList, FyFilter Rolling, session action bar)
 
 ### Completed Tasks

--- a/frontend/src/pages/LoginPage.vue
+++ b/frontend/src/pages/LoginPage.vue
@@ -1,5 +1,15 @@
 <template>
-  <TaskLayout>
+  <!-- Magic link sent — stripped-back page, no header/footer, nothing else to click -->
+  <div v-if="method === 'link' && sent && !expired" class="close-tab-page">
+    <div class="close-tab-card">
+      <p class="close-tab-body">DTV Tracker sent you a log-in link. This link expires at:</p>
+      <div class="close-tab-code">{{ expiryTime }}</div>
+      <p class="close-tab-body">You can close this window and return to your original tab.</p>
+    </div>
+  </div>
+
+  <!-- All other states in the normal layout -->
+  <TaskLayout v-else>
     <h1 class="sr-only">Login</h1>
 
     <div class="login-stack">
@@ -10,22 +20,34 @@
       <!-- Login cards -->
       <template v-if="!sent">
 
-        <!-- Volunteer sign-in (magic link) -->
+        <!-- Volunteer sign-in (magic link / verification code) -->
         <FormCard
-          v-if="magicEnabled"
+          v-if="magicEnabled || verifyEnabled"
           title="Self-service log-in"
           subtitle="View your volunteer profile, manage your sessions, and upload photos."
         >
+          <!-- Method selector — only shown when both options are available -->
+          <div v-if="magicEnabled && verifyEnabled" class="method-selector">
+            <label class="method-option">
+              <input type="radio" v-model="method" value="link" class="method-radio" />
+              <span>Send login link</span>
+            </label>
+            <label class="method-option">
+              <input type="radio" v-model="method" value="code" class="method-radio" />
+              <span>Use verification code</span>
+            </label>
+          </div>
+
           <FormInput
             v-model="email"
             type="email"
             placeholder="your@email.com"
             autocomplete="email"
             :disabled="sending"
-            @enter="sendMagicLink"
+            @enter="sendLoginEmail"
           />
           <FormSubmitRow>
-            <FormButton :disabled="!emailValid || sending" :working="sending" @click="sendMagicLink">
+            <FormButton :disabled="!emailValid || sending" :working="sending" @click="sendLoginEmail">
               {{ sending ? 'Sending…' : 'Send log-in email' }}
             </FormButton>
             <p v-if="magicError" class="form-error">{{ magicError }}</p>
@@ -51,16 +73,28 @@
       <FormCard v-else-if="expired" title="This log-in link has expired">
         <p class="sent-body">Click below to send a new log-in email.</p>
         <FormSubmitRow>
-          <FormButton :working="sending" @click="sendMagicLink">Send a new log-in email</FormButton>
+          <FormButton :working="sending" @click="sendLoginEmail">Send a new log-in email</FormButton>
         </FormSubmitRow>
       </FormCard>
 
-      <!-- Sent confirmation -->
-      <FormCard v-else title="Check your email">
-        <p class="sent-body">We've sent you a log-in link and a confirmation code.</p>
-        <div class="sent-code">{{ confirmCode }}</div>
-        <p class="sent-body sent-expiry">This link expires in {{ countdown }}.</p>
-        <p class="sent-body">Already clicked the link? You can close this tab if you are now logged in.</p>
+      <!-- Verification code entry (method === 'code' && sent && !expired) -->
+      <FormCard v-else title="Enter your verification code">
+        <p class="sent-body">We've sent a verification code to your email. Enter it below — it expires in {{ countdown }}.</p>
+        <FormInput
+          v-model="verifyInput"
+          type="text"
+          placeholder="1234"
+          autocomplete="one-time-code"
+          inputmode="numeric"
+          :disabled="verifying"
+          @enter="checkCode"
+        />
+        <FormSubmitRow>
+          <FormButton :disabled="!verifyInput.trim() || verifying" :working="verifying" @click="checkCode">
+            Verify code
+          </FormButton>
+          <p v-if="verifyError" class="form-error">{{ verifyError }}</p>
+        </FormSubmitRow>
         <FormSubmitRow>
           <button class="form-btn--link" @click="backToLogin">
             Didn't receive the email? Back to log-in
@@ -91,45 +125,21 @@ const email = ref('')
 const sending = ref(false)
 const magicError = ref('')
 const sent = ref(false)
+const method = ref<'link' | 'code'>('link')
 const magicEnabled = ref(false)
+const verifyEnabled = ref(false)
 const reasonMessage = ref('')
 const countdownSeconds = ref(0)
-const confirmCode = ref('')
+const expiryTime = ref('')
+const verifyInput = ref('')
+const verifyError = ref('')
+const verifying = ref(false)
 let countdownTimer: ReturnType<typeof setInterval> | null = null
 
 const returnTo = computed(() => {
   const r = route.query.returnTo as string | undefined
   return r?.startsWith('/') ? r : undefined
 })
-
-let broadcastChannel: BroadcastChannel | null = null
-let hasHandledAuthSuccess = false
-
-function closeBroadcastChannel() {
-  broadcastChannel?.close()
-  broadcastChannel = null
-}
-
-function openBroadcastChannel() {
-  closeBroadcastChannel()
-  if (typeof BroadcastChannel === 'undefined') return
-
-  broadcastChannel = new BroadcastChannel('dtv-auth')
-  broadcastChannel.onmessage = (e) => {
-    if (hasHandledAuthSuccess) return
-    if (e.data?.type !== 'auth-success') return
-
-    hasHandledAuthSuccess = true
-    closeBroadcastChannel()
-
-    const flashName = typeof e.data?.flashName === 'string' ? e.data.flashName : ''
-    const dest = returnTo.value || '/'
-    let destWithNotice = dest.includes('?') ? `${dest}&flashKey=signed-in` : `${dest}?flashKey=signed-in`
-    if (flashName) destWithNotice += `&flashName=${encodeURIComponent(flashName)}`
-
-    window.location.href = destWithNotice
-  }
-}
 
 const emailValid = computed(() => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.value.trim()))
 
@@ -150,31 +160,66 @@ const reasons: Record<string, (email?: string) => string> = {
   'invalid-state': () => 'That sign-in link has expired or is invalid — enter your email below to get a new one.',
 }
 
-async function sendMagicLink() {
+async function sendLoginEmail() {
   if (!email.value.trim()) return
   sending.value = true
   magicError.value = ''
+
+  const endpoint = method.value === 'code' ? '/auth/verify/send' : '/auth/magic/send'
+
   try {
-    const res = await fetch('/auth/magic/send', {
+    const res = await fetch(endpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ destination: email.value.trim(), returnTo: returnTo.value }),
     })
     if (res.ok) {
-      const data = await res.json()
-      confirmCode.value = data.code ?? ''
+      if (method.value === 'link') {
+        const data = await res.json()
+        expiryTime.value = data.expiresAt ?? ''
+      }
       sent.value = true
       startCountdown(15 * 60)
-      openBroadcastChannel()
     } else if (res.status === 429) {
-      magicError.value = 'Too many attempts — please try again later.'
+      const data = await res.json().catch(() => ({}))
+      magicError.value = data.error || 'Too many attempts — please try again later.'
     } else {
-      magicError.value = 'Something went wrong. Please try again.'
+      const data = await res.json().catch(() => ({}))
+      magicError.value = data.error || 'Something went wrong. Please try again.'
     }
   } catch {
     magicError.value = 'Could not send email. Please check your connection and try again.'
   } finally {
     sending.value = false
+  }
+}
+
+async function checkCode() {
+  if (!verifyInput.value.trim()) return
+  verifying.value = true
+  verifyError.value = ''
+
+  try {
+    const res = await fetch('/auth/verify/check', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: email.value.trim(), code: verifyInput.value.trim() }),
+    })
+    if (res.ok) {
+      const data = await res.json()
+      const flashName = data.flashName ?? ''
+      const dest = returnTo.value || '/'
+      let destWithFlash = dest.includes('?') ? `${dest}&flashKey=signed-in` : `${dest}?flashKey=signed-in`
+      if (flashName) destWithFlash += `&flashName=${encodeURIComponent(flashName)}`
+      window.location.href = destWithFlash
+    } else {
+      const data = await res.json().catch(() => ({}))
+      verifyError.value = data.error || 'Verification failed. Please try again.'
+    }
+  } catch {
+    verifyError.value = 'Could not verify code. Please check your connection and try again.'
+  } finally {
+    verifying.value = false
   }
 }
 
@@ -189,33 +234,106 @@ function startCountdown(seconds: number) {
 
 function backToLogin() {
   sent.value = false
+  verifyInput.value = ''
+  verifyError.value = ''
   if (countdownTimer) clearInterval(countdownTimer)
-  closeBroadcastChannel()
 }
 
 onMounted(async () => {
-  fetch('/auth/providers').then(r => r.json()).then(p => { magicEnabled.value = !!p.magic }).catch(() => {})
+  fetch('/auth/providers').then(r => r.json()).then(p => {
+    magicEnabled.value = !!p.magic
+    verifyEnabled.value = !!p.verify
+  }).catch(() => {})
 
   const reason = route.query.reason as string | undefined
   if (reason && reasons[reason]) {
-    const emailParam = route.query.email as string | undefined
-    reasonMessage.value = reasons[reason](emailParam)
+    const reasonEmail = route.query.email as string | undefined
+    reasonMessage.value = reasons[reason](reasonEmail)
+  }
+
+  // Pre-fill from verification code email button (?method=code&email=...&code=...)
+  const methodParam = route.query.method as string | undefined
+  const prefillCode = route.query.code as string | undefined
+  const prefillEmail = route.query.email as string | undefined
+  if (methodParam === 'code' && prefillCode && prefillEmail) {
+    method.value = 'code'
+    email.value = prefillEmail
+    verifyInput.value = prefillCode
+    sent.value = true
+    startCountdown(15 * 60)
   }
 })
 
 onUnmounted(() => {
   if (countdownTimer) clearInterval(countdownTimer)
-  closeBroadcastChannel()
 })
 </script>
 
 <style scoped>
+/* Close-tab page — full screen, no app chrome */
+.close-tab-page {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f5f5f5;
+  padding: 1rem;
+  box-sizing: border-box;
+}
+
+.close-tab-card {
+  background: white;
+  border-radius: 8px;
+  padding: 2rem;
+  text-align: center;
+  max-width: 360px;
+  width: 100%;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.close-tab-body {
+  color: #555;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  margin: 0 0 0.5rem;
+}
+
+.close-tab-code {
+  font-size: 3rem;
+  font-weight: 700;
+  color: var(--color-dtv-green);
+  letter-spacing: 0.15em;
+  margin: 0.75rem 0;
+}
+
+/* Login stack */
 .login-stack {
   display: flex;
   flex-direction: column;
   gap: 1rem;
 }
 
+.method-selector {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.method-option {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.9rem;
+  color: var(--color-dtv-dark);
+  cursor: pointer;
+}
+
+.method-radio {
+  accent-color: var(--color-dtv-green);
+  width: 1.1rem;
+  height: 1.1rem;
+  cursor: pointer;
+}
 
 .form-btn--link {
   background: none;
@@ -243,20 +361,6 @@ onUnmounted(() => {
   text-align: center;
   margin: 0 0 0.5rem;
   line-height: 1.5;
-}
-
-.sent-code {
-  font-size: 3rem;
-  font-weight: 700;
-  color: var(--color-dtv-green);
-  letter-spacing: 0.15em;
-  text-align: center;
-  margin: 0.75rem 0;
-}
-
-.sent-expiry {
-  font-size: 0.8rem;
-  opacity: 0.5;
 }
 
 .sent-contact {

--- a/routes/auth/index.ts
+++ b/routes/auth/index.ts
@@ -2,11 +2,13 @@ import express, { Request, Response, Router } from 'express';
 /// <reference path="../../types/express-session.d.ts" />
 import dtvRouter from './dtv';
 import magicRouter from './magic';
+import verifyRouter from './verify';
 
 const router: Router = express.Router();
 
 router.use(dtvRouter);
 router.use(magicRouter);
+router.use(verifyRouter);
 
 // GET /auth/logout — clear app session and cookie, return to homepage
 router.get('/logout', (req: Request, res: Response) => {
@@ -20,7 +22,7 @@ router.get('/logout', (req: Request, res: Response) => {
 
 // GET /auth/providers — which self-service login methods are configured
 router.get('/providers', (_req: Request, res: Response) => {
-  res.json({ magic: !!process.env.MAIL_SENDER });
+  res.json({ magic: !!process.env.MAIL_SENDER, verify: !!process.env.MAIL_SENDER });
 });
 
 // GET /auth/me — return current user info (no auth required)

--- a/routes/auth/magic.ts
+++ b/routes/auth/magic.ts
@@ -4,12 +4,9 @@ import jwt from 'jsonwebtoken';
 import { sendEmail } from '../../services/graph-mail';
 import { resolvePersonalSession } from '../../services/personal-auth';
 import { createAuthToken } from '../../services/auth-store';
+import { checkEmailRateLimit } from '../../services/email-rate-limiter';
 
 const router: Router = express.Router();
-
-function escapeHtml(str: string): string {
-  return str.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-}
 
 const AUTH_TTL_MS = parseInt(process.env.AUTH_BASIC_TTL_HOURS || '72', 10) * 60 * 60 * 1000;
 
@@ -36,9 +33,17 @@ router.post('/magic/send', async (req: Request, res: Response) => {
     return;
   }
 
-  const code = String(Math.floor(1000 + Math.random() * 9000));
+  if (!checkEmailRateLimit()) {
+    res.status(429).json({ error: "We've sent too many sign-in emails recently. Please wait a while and try again." });
+    return;
+  }
+
   const secret = process.env.SESSION_SECRET || 'dev-secret-change-in-production';
-  const token = jwt.sign({ email, code }, secret, { expiresIn: '15m' });
+  const token = jwt.sign({ email }, secret, { expiresIn: '15m' });
+
+  const tz = process.env.SHAREPOINT_TIMEZONE || 'Europe/London';
+  const expiresAt = new Date(Date.now() + 15 * 60 * 1000)
+    .toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit', timeZone: tz });
 
   const returnTo = req.body?.returnTo;
   const safeReturnTo = typeof returnTo === 'string' && returnTo.startsWith('/') && returnTo.length <= 200
@@ -52,21 +57,20 @@ router.post('/magic/send', async (req: Request, res: Response) => {
     : `${callbackBase}?token=${token}`;
 
   try {
-    const html = `<p>Your confirmation code is <strong style="font-size:1.2em">${code}</strong></p>
-                  <p>Click the log-in link below to confirm your email and continue to DTV Tracker.</p>
-                  <p><a href="${callbackUrl}" style="display:inline-block;padding:12px 24px;background:#4FAF4A;color:white;border-radius:6px;text-decoration:none;font-weight:600;">Log in with ${code}</a></p>
-                  <p style="color:#888;font-size:0.85em">This link expires in 15 minutes.</p>
-                  <p style="color:#888;font-size:0.85em">If you did not request this, or do not recognise the code, you can safely ignore this email.</p>`;
-    const text = `Your confirmation code is ${code}\n\nClick this link to log in to DTV Tracker (expires in 15 minutes):\n\n${callbackUrl}\n\nIf you did not request this, or do not recognise the code, you can safely ignore this email.`;
-    await sendEmail(email, `DTV Tracker confirmation code ${code}`, html, text);
-    res.json({ ok: true, code });
+    const html = `<p>Your link expires at <strong style="font-size:1.5em;letter-spacing:0.05em">${expiresAt}</strong></p>
+                  <p>Click the log-in link below to continue to DTV Tracker.</p>
+                  <p><a href="${callbackUrl}" style="display:inline-block;padding:12px 24px;background:#4FAF4A;color:white;border-radius:6px;text-decoration:none;font-weight:600;">Log in to DTV Tracker</a></p>
+                  <p style="color:#888;font-size:0.85em">If you did not request this, you can safely ignore this email.</p>`;
+    const text = `Your link expires at ${expiresAt}.\n\nClick this link to log in to DTV Tracker:\n\n${callbackUrl}\n\nIf you did not request this, you can safely ignore this email.`;
+    await sendEmail(email, `DTV Tracker sign-in link — expires ${expiresAt}`, html, text);
+    res.json({ ok: true, expiresAt });
   } catch (err: any) {
     console.error('[Magic] sendEmail error:', err.message);
     res.status(500).json({ error: 'Failed to send log-in email. Please try again.' });
   }
 });
 
-// GET /auth/magic/callback — verify JWT, resolve profile, create auth token, set cookie
+// GET /auth/magic/callback — verify JWT, resolve profile, create auth token, set cookie, redirect
 router.get('/magic/callback', async (req: Request, res: Response) => {
   const token = req.query.token as string | undefined;
   if (!token) {
@@ -81,12 +85,10 @@ router.get('/magic/callback', async (req: Request, res: Response) => {
   delete req.session.returnTo;
 
   let email: string;
-  let code: string;
   try {
     const secret = process.env.SESSION_SECRET || 'dev-secret-change-in-production';
-    const payload = jwt.verify(token, secret) as { email: string; code?: string };
+    const payload = jwt.verify(token, secret) as { email: string };
     email = payload.email;
-    code = payload.code ?? '';
   } catch {
     res.redirect('/login.html?reason=invalid-state');
     return;
@@ -111,41 +113,10 @@ router.get('/magic/callback', async (req: Request, res: Response) => {
   const destWithFlash = dest.includes('?')
     ? `${dest}&flashKey=signed-in&flashName=${encodeURIComponent(displayName)}`
     : `${dest}?flashKey=signed-in&flashName=${encodeURIComponent(displayName)}`;
+
   setAuthCookie(res, rawToken);
   res.setHeader('Cache-Control', 'no-store');
-  const safeDest = escapeHtml(encodeURI(destWithFlash));
-  res.send(`<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Log-in confirmed — DTV Tracker</title>
-  <style>
-    body { font-family: sans-serif; display: flex; align-items: center; justify-content: center;
-           min-height: 100vh; margin: 0; background: #f5f5f5; }
-    .card { background: white; border-radius: 8px; padding: 2rem; text-align: center;
-            max-width: 360px; box-shadow: 0 2px 8px rgba(0,0,0,.1); }
-    h1 { color: #2d6a27; font-size: 1.4rem; margin: 0 0 0.75rem; }
-    p { color: #555; font-size: 0.95rem; margin: 0 0 1rem; line-height: 1.5; }
-    .subtle { font-size: 0.85rem; color: #888; }
-    a { color: #2d6a27; }
-  </style>
-</head>
-<body>
-  <div class="card">
-    <h1>Log-in confirmed: ${escapeHtml(code)}</h1>
-    <p>You are now logged in. You can close this window and return to your original tab.</p>
-    <p class="subtle">Original tab unavailable? Open DTV Tracker <a href="${safeDest}">here</a>.</p>
-  </div>
-  <script>
-    if (typeof BroadcastChannel !== 'undefined') {
-      const ch = new BroadcastChannel('dtv-auth');
-      ch.postMessage({ type: 'auth-success', source: 'magic-link', ts: Date.now(), flashName: ${JSON.stringify(displayName)} });
-      ch.close();
-    }
-  <\/script>
-</body>
-</html>`);
+  res.redirect(destWithFlash);
 });
 
 export = router;

--- a/routes/auth/magic.ts
+++ b/routes/auth/magic.ts
@@ -4,7 +4,7 @@ import jwt from 'jsonwebtoken';
 import { sendEmail } from '../../services/graph-mail';
 import { resolvePersonalSession } from '../../services/personal-auth';
 import { createAuthToken } from '../../services/auth-store';
-import { checkEmailRateLimit } from '../../services/email-rate-limiter';
+import { isEmailRateLimited, recordEmailSent } from '../../services/email-rate-limiter';
 
 const router: Router = express.Router();
 
@@ -33,7 +33,7 @@ router.post('/magic/send', async (req: Request, res: Response) => {
     return;
   }
 
-  if (!checkEmailRateLimit()) {
+  if (isEmailRateLimited()) {
     res.status(429).json({ error: "We've sent too many sign-in emails recently. Please wait a while and try again." });
     return;
   }
@@ -63,6 +63,7 @@ router.post('/magic/send', async (req: Request, res: Response) => {
                   <p style="color:#888;font-size:0.85em">If you did not request this, you can safely ignore this email.</p>`;
     const text = `Your link expires at ${expiresAt}.\n\nClick this link to log in to DTV Tracker:\n\n${callbackUrl}\n\nIf you did not request this, you can safely ignore this email.`;
     await sendEmail(email, `DTV Tracker sign-in link — expires ${expiresAt}`, html, text);
+    recordEmailSent();
     res.json({ ok: true, expiresAt });
   } catch (err: any) {
     console.error('[Magic] sendEmail error:', err.message);

--- a/routes/auth/verify.ts
+++ b/routes/auth/verify.ts
@@ -3,7 +3,7 @@ import express, { Request, Response, Router } from 'express';
 import { sendEmail } from '../../services/graph-mail';
 import { resolvePersonalSession } from '../../services/personal-auth';
 import { createAuthToken } from '../../services/auth-store';
-import { checkEmailRateLimit } from '../../services/email-rate-limiter';
+import { isEmailRateLimited, recordEmailSent } from '../../services/email-rate-limiter';
 
 const router: Router = express.Router();
 
@@ -79,12 +79,16 @@ router.post('/verify/send', async (req: Request, res: Response) => {
     return;
   }
 
-  if (!checkEmailRateLimit()) {
+  if (isEmailRateLimited()) {
     res.status(429).json({ error: "We've sent too many sign-in emails recently. Please wait a while and try again." });
     return;
   }
 
   const code = String(Math.floor(1000 + Math.random() * 9000));
+  // One code per email — delete any previous entry (expired or not) before storing the new one.
+  // Expired entries for abandoned requests stay in the map until the same email sends again or
+  // /check is called; at volunteer-app scale this is acceptable without a sweep timer.
+  codeStore.delete(email);
   codeStore.set(email, { code, expires: Date.now() + CODE_TTL_MS, attempts: 0 });
 
   const returnTo = req.body?.returnTo;
@@ -109,6 +113,7 @@ router.post('/verify/send', async (req: Request, res: Response) => {
                   <p style="color:#888;font-size:0.85em">If you did not request this, you can safely ignore this email.</p>`;
     const text = `Your verification code is ${code}\n\nThis code expires in 15 minutes. Return to DTV Tracker and enter your code, or use this link:\n\n${callbackUrl}\n\nIf you did not request this, you can safely ignore this email.`;
     await sendEmail(email, `DTV Tracker verification code ${code}`, html, text);
+    recordEmailSent();
     res.json({ ok: true });
   } catch (err: any) {
     console.error('[Verify] sendEmail error:', err.message);

--- a/routes/auth/verify.ts
+++ b/routes/auth/verify.ts
@@ -1,0 +1,138 @@
+import express, { Request, Response, Router } from 'express';
+/// <reference path="../../types/express-session.d.ts" />
+import { sendEmail } from '../../services/graph-mail';
+import { resolvePersonalSession } from '../../services/personal-auth';
+import { createAuthToken } from '../../services/auth-store';
+import { checkEmailRateLimit } from '../../services/email-rate-limiter';
+
+const router: Router = express.Router();
+
+interface CodeEntry { code: string; expires: number; attempts: number }
+const codeStore = new Map<string, CodeEntry>();
+const MAX_ATTEMPTS = 5;
+const CODE_TTL_MS = 15 * 60 * 1000;
+const AUTH_TTL_MS = parseInt(process.env.AUTH_BASIC_TTL_HOURS || '72', 10) * 60 * 60 * 1000;
+
+function setAuthCookie(res: Response, rawToken: string): void {
+  res.cookie('dtv-auth', rawToken, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    maxAge: AUTH_TTL_MS,
+  });
+}
+
+type CodeCheckResult =
+  | { ok: true; displayName: string }
+  | { ok: false; status: number; error: string };
+
+async function resolveVerifyCode(email: string, code: string, userAgent?: string, res?: Response): Promise<CodeCheckResult> {
+  const entry = codeStore.get(email);
+  if (!entry || Date.now() > entry.expires) {
+    codeStore.delete(email);
+    return { ok: false, status: 401, error: 'That code has expired or could not be found. Request a new code and try again.' };
+  }
+
+  entry.attempts++;
+  if (entry.attempts > MAX_ATTEMPTS) {
+    codeStore.delete(email);
+    return { ok: false, status: 401, error: 'Too many incorrect attempts. Request a new code to continue.' };
+  }
+
+  if (entry.code !== code) {
+    return { ok: false, status: 401, error: 'That code does not match. Check the 4 digits and try again.' };
+  }
+
+  codeStore.delete(email);
+
+  const result = await resolvePersonalSession(email, '', '');
+  if (!result.ok) {
+    return { ok: false, status: 401, error: 'No account found for that email address.' };
+  }
+
+  let rawToken: string;
+  try {
+    rawToken = await createAuthToken(result.sessionUser.profileId!, userAgent);
+  } catch (err: any) {
+    console.error('[Verify] createAuthToken error:', err.message);
+    return { ok: false, status: 500, error: 'Login failed. Please try again.' };
+  }
+
+  if (res) {
+    setAuthCookie(res, rawToken);
+    res.setHeader('Cache-Control', 'no-store');
+  }
+  return { ok: true, displayName: result.sessionUser.displayName };
+}
+
+// POST /auth/verify/send — generate a 4-digit code, store it, send it by email
+// Body: { destination: string, returnTo?: string }
+router.post('/verify/send', async (req: Request, res: Response) => {
+  const email = (req.body?.destination as string || '').trim().toLowerCase();
+  if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    res.status(400).json({ error: 'A valid email address is required' });
+    return;
+  }
+
+  if (!process.env.MAIL_SENDER) {
+    res.status(503).json({ error: 'Verification code login is not configured on this server' });
+    return;
+  }
+
+  if (!checkEmailRateLimit()) {
+    res.status(429).json({ error: "We've sent too many sign-in emails recently. Please wait a while and try again." });
+    return;
+  }
+
+  const code = String(Math.floor(1000 + Math.random() * 9000));
+  codeStore.set(email, { code, expires: Date.now() + CODE_TTL_MS, attempts: 0 });
+
+  const returnTo = req.body?.returnTo;
+  const safeReturnTo = typeof returnTo === 'string' && returnTo.startsWith('/') && returnTo.length <= 200
+    ? returnTo : null;
+
+  // Link in the email opens the login page with code pre-filled — user reviews and hits enter.
+  // FRONTEND_URL is set in local dev (points to Vite); otherwise derive from request host.
+  // /v2 prefix is needed in SITE_MODE=v1 (migration); not needed in v2 mode or local dev.
+  const base = process.env.FRONTEND_URL || `${req.protocol}://${req.get('host')}`;
+  const sitePrefix = process.env.FRONTEND_URL ? '' : (process.env.SITE_MODE === 'v2' ? '' : '/v2');
+  const loginUrl = `${base}${sitePrefix}/login`;
+  const callbackUrl = safeReturnTo
+    ? `${loginUrl}?method=code&email=${encodeURIComponent(email)}&code=${code}&returnTo=${encodeURIComponent(safeReturnTo)}`
+    : `${loginUrl}?method=code&email=${encodeURIComponent(email)}&code=${code}`;
+
+  try {
+    const html = `<p style="font-size:2em;font-weight:700;letter-spacing:0.1em">${code}</p>
+                  <p>Your verification code expires in 15 minutes.</p>
+                  <p>Return to DTV Tracker and enter your code, or click the button below.</p>
+                  <p><a href="${callbackUrl}" style="display:inline-block;padding:12px 24px;background:#4FAF4A;color:white;border-radius:6px;text-decoration:none;font-weight:600;">Log in with ${code}</a></p>
+                  <p style="color:#888;font-size:0.85em">If you did not request this, you can safely ignore this email.</p>`;
+    const text = `Your verification code is ${code}\n\nThis code expires in 15 minutes. Return to DTV Tracker and enter your code, or use this link:\n\n${callbackUrl}\n\nIf you did not request this, you can safely ignore this email.`;
+    await sendEmail(email, `DTV Tracker verification code ${code}`, html, text);
+    res.json({ ok: true });
+  } catch (err: any) {
+    console.error('[Verify] sendEmail error:', err.message);
+    res.status(500).json({ error: 'Failed to send verification email. Please try again.' });
+  }
+});
+
+// POST /auth/verify/check — verify a code entered in the browser tab
+// Body: { email: string, code: string }
+router.post('/verify/check', async (req: Request, res: Response) => {
+  const email = (req.body?.email as string || '').trim().toLowerCase();
+  const code = (req.body?.code as string || '').trim();
+
+  if (!email || !code) {
+    res.status(400).json({ error: 'Email and code are required' });
+    return;
+  }
+
+  const result = await resolveVerifyCode(email, code, req.headers['user-agent'], res);
+  if (result.ok) {
+    res.json({ ok: true, flashName: result.displayName });
+  } else {
+    res.status(result.status).json({ error: result.error });
+  }
+});
+
+export = router;

--- a/services/email-rate-limiter.ts
+++ b/services/email-rate-limiter.ts
@@ -2,11 +2,18 @@ const LIMIT = parseInt(process.env.EMAIL_RATE_LIMIT_PER_HOUR || '60', 10);
 let windowStart = Date.now();
 let count = 0;
 
-/** Returns false (and does NOT increment) if the hourly limit has been reached. */
-export function checkEmailRateLimit(): boolean {
-  const now = Date.now();
-  if (now - windowStart > 3_600_000) { windowStart = now; count = 0; }
-  if (count >= LIMIT) return false;
+function resetIfExpired() {
+  if (Date.now() - windowStart > 3_600_000) { windowStart = Date.now(); count = 0; }
+}
+
+/** Returns false if the hourly limit has already been reached. Does not increment. */
+export function isEmailRateLimited(): boolean {
+  resetIfExpired();
+  return count >= LIMIT;
+}
+
+/** Record one successfully sent email against the quota. */
+export function recordEmailSent(): void {
+  resetIfExpired();
   count++;
-  return true;
 }

--- a/services/email-rate-limiter.ts
+++ b/services/email-rate-limiter.ts
@@ -1,0 +1,12 @@
+const LIMIT = parseInt(process.env.EMAIL_RATE_LIMIT_PER_HOUR || '60', 10);
+let windowStart = Date.now();
+let count = 0;
+
+/** Returns false (and does NOT increment) if the hourly limit has been reached. */
+export function checkEmailRateLimit(): boolean {
+  const now = Date.now();
+  if (now - windowStart > 3_600_000) { windowStart = now; count = 0; }
+  if (count >= LIMIT) return false;
+  count++;
+  return true;
+}


### PR DESCRIPTION
Magic link: callback redirects directly to destination (no intermediate page). Sent tab shows expiry time (e.g. 09:15) in large text matching the email subject, so volunteers can confirm it's the right email. No header/footer on the sent tab — dead-end by design.

Verification code: new POST /auth/verify/send + /check endpoints. 4-digit code stored server-side (15min TTL, max 5 attempts). Email button links to login page with code pre-filled — user just hits enter. GET /auth/verify/callback removed (unused, unnecessary attack surface).

Both methods share a rate limiter (EMAIL_RATE_LIMIT_PER_HOUR, default 60). Method selector (radio group) shown on login page when both are available.