### PR TITLE
Add Entries page with AccompanyingAdult modal support (#157)

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -321,14 +321,16 @@ dtv-tracker-app/
 │       │   ├── groupList.ts        # Groups listing store
 │       │   ├── groupDetail.ts      # Group detail store
 │       │   ├── profileList.ts      # Profiles listing store
-│       │   └── profileDetail.ts    # Profile detail store (fetch by slug)
+│       │   ├── profileDetail.ts    # Profile detail store (fetch by slug)
+│       │   └── entryList.ts        # Entries listing store — fetch(params) with q + accompanyingAdult filters
 │       ├── types/
 │       │   ├── session.ts          # Session frontend domain type (mapped from SessionResponse)
 │       │   ├── entry.ts            # EntryItem, EntryProfileSummary, EntrySessionSummary
 │       │   └── media.ts            # Media types
 │       ├── utils/
-│       │   ├── tagIcons.ts         # TagIcon type, TAG_ICONS list, iconsForEntry(), iconsFromNotes()
-│       │   └── breakpoints.ts      # belowBreakpointMd() — reads --breakpoint-md from CSS at runtime
+│       │   ├── tagIcons.ts             # TagIcon type, TAG_ICONS list, iconsForEntry(), iconsFromNotes()
+│       │   ├── breakpoints.ts          # belowBreakpointMd() — reads --breakpoint-md from CSS at runtime
+│       │   └── fetchSessionAdults.ts   # Fetches non-child adults from a session via GET /api/sessions/:groupKey/:date; used by EntryEditModal callers
 │       ├── components/
 │       │   ├── LayoutColumns.vue   # Responsive 2-col / 3-col grid layout
 │       │   ├── SessionList.vue     # Session list with grouped dates and status tabs
@@ -337,6 +339,10 @@ dtv-tracker-app/
 │       │   ├── EntryCard.vue       # Entry row: check/hours control + title link/button + tag icons
 │       │   ├── EntryList.vue       # Layout wrapper for EntryCard rows (responsive grid)
 │       │   ├── EntryTagPicker.vue  # Tag toggle buttons (type=tag only); v-model binds to Notes string
+│       │   ├── entries/EntryListItem.vue     # Presentational entry row: volunteer name, tag icons, date, group, checked-in border; `selected` drives background colour only
+│       │   ├── entries/EntryListFilter.vue   # Filter bar: notes search (debounced) + AccompanyingAdult dropdown; emits `filtered`
+│       │   ├── entries/EntryListResults.vue  # List with loading/error/empty states, checkbox overlay (admin), edit button; emits `update:selected`, `editEntry`
+│       │   ├── entries/EntryListActions.vue  # Action bar: entry count + total hours + selected count
 │       │   ├── sessions/SessionCard.vue        # Session summary card
 │       │   ├── sessions/SessionEntryList.vue   # Session entry workflow: check-in, hours, edit/add/set-hours modals; emits up to page
 │       │   ├── sessions/SessionListFilter.vue  # Sessions filter bar: search, FY, group, tag
@@ -356,6 +362,7 @@ dtv-tracker-app/
 │           ├── SessionDetailPage.vue  # Session detail — sign-up (public) and check-in (operational)
 │           ├── ProfileListPage.vue    # Profiles listing with filters, sort, bulk records, CSV export
 │           ├── ProfileDetailPage.vue  # Profile detail — page title, PageHeader, entry list, debug data
+│           ├── EntriesPage.vue        # Admin-only entries listing: filter by notes/accompanying adult, checkbox select, edit modal with profile+session nav
 │           ├── AdminPage.vue          # Admin actions (sync, cache, exports)
 │           └── sessions/             # Page-specific components for SessionDetailPage
 │               ├── SessionHeaderCard.vue   # Group name / date-time-location / description
@@ -405,7 +412,7 @@ dtv-tracker-app/
 │   ├── api.ts                     # Router mounting all route modules
 │   ├── groups.ts                  # Groups CRUD endpoints
 │   ├── sessions.ts                # Sessions CRUD + CSV exports
-│   ├── entries.ts                 # Entries CRUD
+│   ├── entries.ts                 # Entries CRUD + GET /entries (admin — all entries with filters)
 │   ├── profiles.ts                # Profiles CRUD + records + transfer (+ regulars via sub-routes)
 │   ├── regulars.ts                # Regulars management
 │   ├── stats.ts                   # Dashboard stats, cache, config
@@ -522,6 +529,8 @@ dtv-tracker-app/
 - [x] Consent collection page at `/profiles/:slug/consent.html` — check-in and admin users see "Collect Consent" button on profile Records section; page presents privacy (required) and photo (optional) checkboxes with privacy policy link; on submit upserts both records with today's date via `POST /api/profiles/:id/consent`; self-service users can also access for their own profile (e.g. via entry detail consent button)
 - [x] Entry detail consent button — shown next to Upload when volunteer has no Accepted Privacy Consent; visible to check-in, admin, and self-service; hidden once consent is signed; uses `.checkin-or-selfservice` CSS class
 - [x] Standalone media gallery pages (`/media/`): authenticated library listing all sessions with photos (cover carousel) and per-session gallery (Embla + lightbox); breadcrumbs wired in `common.js`; Embla loaded from CDN; `MediaGallery` class in `public/media/embla/gallery.js`
+- [x] Entries page (admin-only, Vue): lists all entries across all sessions; filter by notes text and AccompanyingAdult (empty/not-empty); checkbox selection; edit modal opens with "View Profile" and "View Session" nav buttons; `GET /api/entries` endpoint (admin-only)
+- [x] AccompanyingAdult dropdown in EntryEditModal: shown when `sessionAdults` prop provided; enabled only when `#Child` is in notes; populates with non-child adults from the same session via `fetchSessionAdults` utility; clearing `#Child` resets selection; `accompanyingAdultId` included in PATCH payload and store state
 
 ## Planned Features
 

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -142,6 +142,7 @@ Self-service users **cannot** access:
 
 | Method | Endpoint | Purpose |
 |--------|----------|---------|
+| GET | `/entries` | All entries listing (admin-only) |
 | GET | `/sessions/export` | CSV export (GDPR) |
 | GET | `/records/export` | CSV export (GDPR) |
 | POST | `/groups` | Create group |

--- a/docs/test-script.md
+++ b/docs/test-script.md
@@ -230,6 +230,26 @@ Run with `npm run dev` at http://localhost:3000. Log in via Microsoft Entra ID.
 - [ ] Shows "Done: X created, Y updated", auto-closes, reloads list
 - [ ] Upsert: same type updates existing records, doesn't duplicate
 
+### H24b. Entries page (admin)
+
+- [ ] Admin: "Entries" nav link visible in header; non-admin users (Check In, Read Only, Self-Service, Public) do not see the link
+- [ ] Navigate to `/entries` as admin → `GET /api/entries` called; entries list loads with totals ("N entries · H hours")
+- [ ] Navigate to `/entries` as non-admin → 403 (API blocked by `require-admin.ts`)
+- [ ] Notes search: type 3+ chars → results filter to entries whose notes contain the search term (case-insensitive)
+- [ ] AccompanyingAdult filter: "Not empty" → only entries with an accompanying adult shown; "Empty" → only entries without
+- [ ] Both filters combined: notes search + accompanying adult filter narrow results together
+- [ ] Clearing filters restores full list
+- [ ] Select All checkbox: selects all visible entries; Deselect All clears selection; count shown in action bar
+- [ ] Clicking an entry row (non-edit mode) navigates to the session detail page
+- [ ] "Edit" button on a row opens the `EntryEditModal`
+- [ ] Edit modal: "View Profile" button visible and navigates to the profile detail page
+- [ ] Edit modal: "View Session" button visible and navigates to the session detail page
+- [ ] Edit modal: AccompanyingAdult dropdown shown only when `#Child` is in notes; populated with non-child adults from that session
+- [ ] AccompanyingAdult dropdown hidden (FormRow disabled) when `#Child` absent; clearing `#Child` from notes resets `accompanyingAdultId` to null
+- [ ] Save: `PATCH /api/entries/:id` called with `{ checkedIn, count, hours, notes, accompanyingAdultId }`; list updates in-place (no full reload)
+- [ ] Save with changed notes that no longer match current filter: entry is removed from the visible list immediately
+- [ ] Delete: confirmation dialog → `DELETE /api/entries/:id` → entry removed from list
+
 ### H30. Bulk tag sessions / CSV download
 - [ ] Sessions page → Advanced → check 2–3 session cards → "Add Tags (N)" and "Download CSV" buttons become enabled
 - [ ] Click "Add Tags (N)" → tag tree picker opens (same modal as session detail)

--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -22,6 +22,7 @@
           <RouterLink to="/sessions" @click="open = false" class="text-white font-bold uppercase tracking-wide text-sm py-3 border-b border-white/10 hover:text-dtv-green transition-colors">Sessions</RouterLink>
           <RouterLink to="/groups" @click="open = false" class="text-white font-bold uppercase tracking-wide text-sm py-3 border-b border-white/10 hover:text-dtv-green transition-colors">Groups</RouterLink>
           <RouterLink v-if="profile.isTrusted" to="/profiles" @click="open = false" class="text-white font-bold uppercase tracking-wide text-sm py-3 border-b border-white/10 hover:text-dtv-green transition-colors">Profiles</RouterLink>
+          <RouterLink v-if="profile.isAdmin" to="/entries" @click="open = false" class="text-white font-bold uppercase tracking-wide text-sm py-3 border-b border-white/10 hover:text-dtv-green transition-colors">Entries</RouterLink>
           <RouterLink v-if="profile.isAdmin" to="/admin" @click="open = false" class="text-white font-bold uppercase tracking-wide text-sm py-3 border-b border-white/10 hover:text-dtv-green transition-colors">Tools</RouterLink>
           <button @click="openAbout" class="text-white font-bold uppercase tracking-wide text-sm py-3 border-b border-white/10 hover:text-dtv-green transition-colors text-left">About</button>
           <RouterLink v-if="isDev || profile.isAdmin" to="/sandbox" @click="open = false" class="text-white font-bold uppercase tracking-wide text-sm py-3 border-b border-white/10 hover:text-dtv-green transition-colors">Sandbox</RouterLink>

--- a/frontend/src/components/RecentEntryList.vue
+++ b/frontend/src/components/RecentEntryList.vue
@@ -15,30 +15,12 @@
     <p v-else-if="!entries.length" class="rel-empty">No sign-ups in this period</p>
 
     <div v-else class="rel-list">
-      <RouterLink
+      <EntryListItem
         v-for="e in entries"
         :key="e.id"
+        :entry="mapEntry(e)"
         :to="sessionPath(e.groupKey, e.date)"
-        class="rel-row"
-        :class="{ 'rel-row--checked': e.checkedIn }"
-      >
-        <div class="rel-left">
-          <span class="rel-name">{{ e.volunteerName }}</span>
-          <span
-            v-for="icon in icons(e)"
-            :key="icon.alt"
-            class="rel-icon"
-            :class="icon.color ? 'icon-' + icon.color : ''"
-            :title="icon.alt"
-          >
-            <img :src="'/icons/' + icon.icon" :alt="icon.alt" />
-          </span>
-        </div>
-        <div class="rel-right">
-          <span class="rel-date">{{ formatDate(e.date) }}</span>
-          <span class="rel-group">{{ e.groupName }}</span>
-        </div>
-      </RouterLink>
+      />
     </div>
 
   </div>
@@ -46,23 +28,30 @@
 
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
-import { RouterLink } from 'vue-router'
-import type { RecentSignupResponse } from '../../../types/api-responses'
+import type { RecentSignupResponse, EntryListItemResponse } from '../../../types/api-responses'
 import { sessionPath } from '../router/index'
-import { iconsFromNotes } from '../utils/tagIcons'
-import type { TagIcon } from '../utils/tagIcons'
+import EntryListItem from './entries/EntryListItem.vue'
 
 const since = ref<string>('24h')
 const entries = ref<RecentSignupResponse[]>([])
 const loading = ref(false)
 const error = ref<string | null>(null)
 
-function icons(e: RecentSignupResponse): TagIcon[] {
-  return iconsFromNotes(e.notes)
-}
-
-function formatDate(date: string): string {
-  return new Date(date).toLocaleDateString('en-GB', { day: 'numeric', month: 'short' })
+function mapEntry(e: RecentSignupResponse): EntryListItemResponse {
+  return {
+    id: e.id,
+    volunteerName: e.volunteerName,
+    volunteerSlug: e.volunteerSlug,
+    date: e.date,
+    groupKey: e.groupKey,
+    groupName: e.groupName,
+    notes: e.notes,
+    checkedIn: e.checkedIn,
+    hours: 0,
+    count: 1,
+    isGroup: false,
+    hasAccompanyingAdult: false,
+  }
 }
 
 async function load() {
@@ -127,72 +116,5 @@ onMounted(load)
   display: flex;
   flex-direction: column;
   gap: 2px;
-}
-
-.rel-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.5rem;
-  padding: 0.5rem 1rem;
-  background: var(--color-dtv-sand);
-  text-decoration: none;
-  color: var(--color-text);
-  border-left: 4px solid transparent;
-}
-.rel-row--checked {
-  border-left-color: var(--color-dtv-green);
-}
-.rel-row:hover {
-  background: var(--color-dtv-sand-dark);
-}
-
-.rel-left {
-  display: flex;
-  align-items: center;
-  gap: 0.25rem;
-  min-width: 0;
-  flex: 1;
-}
-
-.rel-name {
-  font-size: 0.9rem;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  min-width: 0;
-  flex-shrink: 1;
-}
-
-.rel-icon {
-  display: inline-flex;
-  align-items: flex-start;
-  width: 0.875rem;
-  height: 0.875rem;
-  flex-shrink: 0;
-  align-self: flex-start;
-}
-.rel-icon img {
-  width: 100%;
-  height: 100%;
-  object-fit: contain;
-}
-
-.rel-right {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  flex-shrink: 0;
-  font-size: 0.85rem;
-  color: var(--color-text-muted);
-}
-
-.rel-date {
-  white-space: nowrap;
-}
-
-.rel-group {
-  white-space: nowrap;
-  font-weight: 500;
 }
 </style>

--- a/frontend/src/components/entries/EntryListActions.vue
+++ b/frontend/src/components/entries/EntryListActions.vue
@@ -1,0 +1,42 @@
+<template>
+  <div class="ela-bar">
+    <span class="ela-totals">
+      {{ entries.length }} {{ entries.length === 1 ? 'entry' : 'entries' }}
+      <template v-if="totalHours > 0"> · {{ totalHours }} hours</template>
+    </span>
+    <span v-if="selected.length" class="ela-selected">
+      {{ selected.length }} selected
+    </span>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { EntryListItemResponse } from '../../../../types/api-responses'
+
+const props = defineProps<{
+  entries: EntryListItemResponse[]
+  selected: number[]
+}>()
+
+const totalHours = computed(() =>
+  Math.round(props.entries.reduce((sum, e) => sum + e.hours, 0) * 10) / 10
+)
+</script>
+
+<style scoped>
+.ela-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 1rem;
+  background: var(--color-dtv-light);
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+.ela-selected {
+  font-weight: 600;
+  color: var(--color-text);
+}
+</style>

--- a/frontend/src/components/entries/EntryListFilter.vue
+++ b/frontend/src/components/entries/EntryListFilter.vue
@@ -16,7 +16,8 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, watch, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 
 export interface EntryFilterParams {
   q: string
@@ -25,8 +26,11 @@ export interface EntryFilterParams {
 
 const emit = defineEmits<{ filtered: [params: EntryFilterParams] }>()
 
-const q = ref('')
-const accompanyingAdult = ref('')
+const route = useRoute()
+const router = useRouter()
+
+const q = ref((route.query.q as string) || '')
+const accompanyingAdult = ref((route.query.accompanyingAdult as string) || '')
 
 let debounceTimer: ReturnType<typeof setTimeout> | null = null
 
@@ -38,6 +42,15 @@ function onTextInput() {
 function emitFiltered() {
   emit('filtered', { q: q.value, accompanyingAdult: accompanyingAdult.value })
 }
+
+onMounted(() => emitFiltered())
+
+watch([q, accompanyingAdult], ([newQ, newAdult]) => {
+  const query: Record<string, string> = {}
+  if (newQ)    query.q                  = newQ
+  if (newAdult) query.accompanyingAdult = newAdult
+  router.replace({ query })
+})
 </script>
 
 <style scoped>

--- a/frontend/src/components/entries/EntryListFilter.vue
+++ b/frontend/src/components/entries/EntryListFilter.vue
@@ -1,0 +1,72 @@
+<template>
+  <div class="elf-bar">
+    <input
+      v-model="q"
+      class="elf-input"
+      type="search"
+      placeholder="Search notes…"
+      @input="onTextInput"
+    />
+    <select v-model="accompanyingAdult" class="elf-select" @change="emitFiltered">
+      <option value="">All</option>
+      <option value="notempty">Has Accompanying Adult</option>
+      <option value="empty">No Accompanying Adult</option>
+    </select>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+
+export interface EntryFilterParams {
+  q: string
+  accompanyingAdult: string
+}
+
+const emit = defineEmits<{ filtered: [params: EntryFilterParams] }>()
+
+const q = ref('')
+const accompanyingAdult = ref('')
+
+let debounceTimer: ReturnType<typeof setTimeout> | null = null
+
+function onTextInput() {
+  if (debounceTimer) clearTimeout(debounceTimer)
+  debounceTimer = setTimeout(emitFiltered, 300)
+}
+
+function emitFiltered() {
+  emit('filtered', { q: q.value, accompanyingAdult: accompanyingAdult.value })
+}
+</script>
+
+<style scoped>
+.elf-bar {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  background: var(--color-dtv-light);
+  flex-wrap: wrap;
+}
+
+.elf-input {
+  flex: 1;
+  min-width: 10rem;
+  background: var(--color-dtv-sand);
+  border: none;
+  color: var(--color-text);
+  padding: 0.4rem 0.6rem;
+  font-family: inherit;
+  font-size: 0.9rem;
+}
+
+.elf-select {
+  background: var(--color-dtv-sand);
+  border: none;
+  color: var(--color-text);
+  padding: 0.4rem 0.6rem;
+  font-family: inherit;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+</style>

--- a/frontend/src/components/entries/EntryListItem.vue
+++ b/frontend/src/components/entries/EntryListItem.vue
@@ -1,0 +1,125 @@
+<template>
+  <div class="eli-row" :class="{ 'eli-row--checked': entry.checkedIn, 'eli-row--selected': selected }">
+    <component
+      :is="to ? RouterLink : 'div'"
+      v-bind="to ? { to } : {}"
+      class="eli-content"
+    >
+      <div class="eli-left">
+        <span class="eli-name">{{ entry.volunteerName ?? 'Unknown' }}</span>
+        <span
+          v-for="icon in icons"
+          :key="icon.alt"
+          class="eli-icon"
+          :class="icon.color ? 'icon-' + icon.color : ''"
+          :title="icon.alt"
+        >
+          <img :src="'/icons/' + icon.icon" :alt="icon.alt" />
+        </span>
+      </div>
+      <div class="eli-right">
+        <span class="eli-date">{{ formatDate(entry.date) }}</span>
+        <span class="eli-group">{{ entry.groupName }}</span>
+      </div>
+    </component>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { RouterLink } from 'vue-router'
+import type { RouteLocationRaw } from 'vue-router'
+import type { EntryListItemResponse } from '../../../../types/api-responses'
+import { iconsFromNotes } from '../../utils/tagIcons'
+
+const props = defineProps<{
+  entry: EntryListItemResponse
+  to?: RouteLocationRaw
+  selected?: boolean
+}>()
+
+const icons = computed(() => iconsFromNotes(props.entry.notes))
+
+function formatDate(date: string): string {
+  return new Date(date).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
+}
+</script>
+
+<style scoped>
+.eli-row {
+  display: flex;
+  align-items: stretch;
+  background: var(--color-dtv-sand);
+  border-left: 4px solid transparent;
+}
+.eli-row--checked {
+  border-left-color: var(--color-dtv-green);
+}
+.eli-row--selected {
+  background: var(--color-dtv-light);
+}
+
+.eli-content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  flex: 1;
+  min-width: 0;
+  text-decoration: none;
+  color: var(--color-text);
+}
+.eli-content:hover {
+  background: var(--color-dtv-sand-dark);
+}
+
+.eli-left {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  min-width: 0;
+  flex: 1;
+}
+
+.eli-name {
+  font-size: 0.9rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+  flex-shrink: 1;
+}
+
+.eli-icon {
+  display: inline-flex;
+  align-items: flex-start;
+  width: 0.875rem;
+  height: 0.875rem;
+  flex-shrink: 0;
+  align-self: flex-start;
+}
+.eli-icon img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.eli-right {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+.eli-date {
+  white-space: nowrap;
+}
+
+.eli-group {
+  white-space: nowrap;
+  font-weight: 500;
+}
+</style>

--- a/frontend/src/components/entries/EntryListResults.vue
+++ b/frontend/src/components/entries/EntryListResults.vue
@@ -1,0 +1,150 @@
+<template>
+  <div class="elr-wrap">
+
+    <p v-if="loading" class="elr-empty">Loading…</p>
+    <p v-else-if="error" class="elr-empty elr-empty--error">{{ error }}</p>
+    <p v-else-if="!entries.length" class="elr-empty">No entries found</p>
+
+    <template v-else>
+      <div v-if="allowSelect" class="elr-select-bar">
+        <button class="elr-select-btn" @click="selectAll">Select all</button>
+        <button class="elr-select-btn" @click="deselectAll">Deselect all</button>
+      </div>
+
+      <div class="elr-list">
+        <div
+          v-for="e in entries"
+          :key="e.id"
+          class="elr-item"
+          :class="{ 'elr-item--selectable': allowSelect }"
+        >
+          <input
+            v-if="allowSelect"
+            type="checkbox"
+            class="elr-checkbox"
+            :checked="selected.includes(e.id)"
+            @change="onSelect(e.id, !selected.includes(e.id))"
+          />
+          <button
+            v-if="allowEdit"
+            class="elr-edit-btn"
+            @click="emit('editEntry', e)"
+          >
+            <EntryListItem :entry="e" :selected="selected.includes(e.id)" />
+          </button>
+          <EntryListItem
+            v-else
+            :entry="e"
+            :to="entryPath(e.id)"
+            :selected="selected.includes(e.id)"
+          />
+        </div>
+      </div>
+    </template>
+
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { EntryListItemResponse } from '../../../../types/api-responses'
+import EntryListItem from './EntryListItem.vue'
+import { entryPath } from '../../router/index'
+
+const props = defineProps<{
+  entries: EntryListItemResponse[]
+  loading: boolean
+  error: string | null
+  selected: number[]
+  allowSelect?: boolean
+  allowEdit?: boolean
+}>()
+
+const emit = defineEmits<{
+  'update:selected': [ids: number[]]
+  'editEntry': [entry: EntryListItemResponse]
+}>()
+
+function onSelect(id: number, val: boolean) {
+  const next = val
+    ? [...props.selected, id]
+    : props.selected.filter(x => x !== id)
+  emit('update:selected', next)
+}
+
+function selectAll() {
+  emit('update:selected', props.entries.map(e => e.id))
+}
+
+function deselectAll() {
+  emit('update:selected', [])
+}
+</script>
+
+<style scoped>
+.elr-wrap {
+  background: var(--color-dtv-sand-light);
+}
+
+.elr-empty {
+  padding: 1rem;
+  font-size: 0.9rem;
+  color: var(--color-text-muted);
+}
+.elr-empty--error {
+  color: var(--color-dtv-dirt);
+}
+
+.elr-select-bar {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  background: var(--color-dtv-light);
+}
+
+.elr-select-btn {
+  background: none;
+  border: none;
+  font-family: inherit;
+  font-size: 0.85rem;
+  color: var(--color-dtv-green);
+  cursor: pointer;
+  padding: 0;
+  text-decoration: underline;
+}
+.elr-select-btn:hover { color: var(--color-dtv-green-dark); }
+
+.elr-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.elr-item {
+  position: relative;
+}
+
+.elr-checkbox {
+  position: absolute;
+  left: 0.75rem;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 1;
+  width: 1.25rem;
+  height: 1.25rem;
+  cursor: pointer;
+}
+
+.elr-item--selectable :deep(.eli-content) {
+  padding-left: 2.75rem;
+}
+
+.elr-edit-btn {
+  display: block;
+  width: 100%;
+  background: none;
+  border: none;
+  padding: 0;
+  text-align: left;
+  cursor: pointer;
+}
+</style>

--- a/frontend/src/components/groups/GroupListFilter.vue
+++ b/frontend/src/components/groups/GroupListFilter.vue
@@ -39,7 +39,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import FyFilter from '../FyFilter.vue'
 import { useGroupListStore } from '../../stores/groupList'
 import { groupPath } from '../../router/index'
@@ -54,10 +54,11 @@ export interface GroupWithStats extends GroupResponse {
 const props = defineProps<{ groups: GroupResponse[]; sessions: Session[]; canAddGroup: boolean }>()
 const emit = defineEmits<{ filtered: [groups: GroupWithStats[]] }>()
 
+const route = useRoute()
 const router = useRouter()
 const groupsStore = useGroupListStore()
 
-const fy = ref('rolling')
+const fy = ref((route.query.fy as string) || 'rolling')
 const showNew = ref(false)
 const newKey = ref('')
 const newName = ref('')
@@ -92,6 +93,10 @@ const filtered = computed<GroupWithStats[]>(() => {
 })
 
 watch(filtered, list => emit('filtered', list), { immediate: true })
+
+watch(fy, newFy => {
+  router.replace({ query: newFy ? { fy: newFy } : {} })
+})
 
 async function addGroup() {
   if (!newKey.value) return

--- a/frontend/src/components/profiles/ProfileEntryList.vue
+++ b/frontend/src/components/profiles/ProfileEntryList.vue
@@ -31,7 +31,7 @@
         :allow-edit="allowEdit ?? false"
         :working="workingId === e.id"
         @update="(c, h) => emit('update', e, c, h)"
-        @edit-entry="editingEntry = e"
+        @edit-entry="openEditModal(e)"
       />
     </EntryList>
 
@@ -39,9 +39,8 @@
       v-if="editingEntry"
       :entry="editingEntry"
       :title="cardTitle(editingEntry)"
-      view-label="View Session"
-      view-icon="calendar"
-      :view-to="sessionPath(editingEntry.session.groupKey, editingEntry.session.date)"
+      :session-click="() => router.push(sessionPath(editingEntry!.session.groupKey, editingEntry!.session.date))"
+      :session-adults="sessionAdults"
       :working="workingEdit"
       :error="editError"
       @close="closeEditModal"
@@ -54,14 +53,16 @@
 
 <script setup lang="ts">
 import { ref, computed } from 'vue'
+import { useRouter } from 'vue-router'
 import type { EntryItem } from '../../types/entry'
 import EntryList from '../EntryList.vue'
 import EntryCard from '../EntryCard.vue'
 import EntryEditModal from '../../pages/modals/EntryEditModal.vue'
 import { sessionPath } from '../../router/index'
 import { iconsForEntry } from '../../utils/tagIcons'
+import { fetchSessionAdults } from '../../utils/fetchSessionAdults'
 
-type EditData = { checkedIn: boolean; count: number; hours: number; notes: string }
+type EditData = { checkedIn: boolean; count: number; hours: number; notes: string; accompanyingAdultId: number | null }
 
 const props = defineProps<{
   entries: EntryItem[]
@@ -73,6 +74,8 @@ const emit = defineEmits<{
   update: [entry: EntryItem, checkedIn: boolean, hours: number]
   editEntry: [id: number, data: EditData | null]
 }>()
+
+const router = useRouter()
 
 const fy = ref('all')
 const groupKey = ref('')
@@ -135,6 +138,7 @@ const filteredEntries = computed(() => {
 })
 
 const editingEntry = ref<EntryItem | null>(null)
+const sessionAdults = ref<{ id: number; name: string }[]>([])
 const workingEdit = ref(false)
 const editError = ref('')
 
@@ -143,8 +147,14 @@ function cardTitle(e: EntryItem): string {
   return groupKey.value ? date : `${date} · ${e.session.groupName}`
 }
 
+async function openEditModal(e: EntryItem) {
+  editingEntry.value = e
+  sessionAdults.value = await fetchSessionAdults(e.session.groupKey, e.session.date)
+}
+
 function closeEditModal() {
   editingEntry.value = null
+  sessionAdults.value = []
   workingEdit.value = false
   editError.value = ''
 }

--- a/frontend/src/components/profiles/ProfileListFilter.vue
+++ b/frontend/src/components/profiles/ProfileListFilter.vue
@@ -51,7 +51,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
-import { useRoute } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import FyFilter from '../FyFilter.vue'
 import type { ProfileResponse } from '../../../../types/api-responses'
 import type { GroupResponse } from '../../../../types/api-responses'
@@ -68,6 +68,7 @@ const emit = defineEmits<{
 }>()
 
 const route = useRoute()
+const router = useRouter()
 
 const fy          = ref((route.query.fy as string)           || 'rolling')
 const group       = ref((route.query.group as string)        || '')
@@ -152,6 +153,19 @@ const filtered = computed<ProfileResponse[]>(() => {
 })
 
 watch(filtered, list => emit('filtered', list), { immediate: true })
+
+watch([fy, group, search, sort, type, hoursFilter, recordType, recordStatus], ([newFy, newGroup, newSearch, newSort, newType, newHours, newRecordType, newRecordStatus]) => {
+  const query: Record<string, string> = {}
+  if (newFy)           query.fy           = newFy
+  if (newGroup)        query.group        = newGroup
+  if (newSearch)       query.search       = newSearch
+  if (newSort && newSort !== 'az') query.sort = newSort
+  if (newType)         query.type         = newType
+  if (newHours)        query.hours        = newHours
+  if (newRecordType)   query.recordType   = newRecordType
+  if (newRecordStatus) query.recordStatus = newRecordStatus
+  router.replace({ query })
+})
 </script>
 
 <style scoped>

--- a/frontend/src/components/sessions/SessionEntryList.vue
+++ b/frontend/src/components/sessions/SessionEntryList.vue
@@ -33,9 +33,8 @@
     <EntryEditModal
       v-if="editingEntry"
       :entry="editingEntry"
-      view-label="View Profile"
-      view-icon="profile"
-      :view-to="editingEntry.profile.slug ? profilePath(editingEntry.profile.slug) : undefined"
+      :profile-click="editingEntry.profile.slug ? () => router.push(profilePath(editingEntry!.profile.slug!)) : undefined"
+      :session-adults="sessionAdults"
       :working="workingEdit"
       :error="editError"
       @close="closeEditModal"
@@ -67,6 +66,7 @@
 
 <script setup lang="ts">
 import { ref, computed } from 'vue'
+import { useRouter } from 'vue-router'
 import type { EntryItem } from '../../types/entry'
 import type { PickerProfile } from '../ProfilePicker.vue'
 import AppButton from '../AppButton.vue'
@@ -79,7 +79,7 @@ import { profilePath } from '../../router/index'
 import { iconsForEntry } from '../../utils/tagIcons'
 
 type AddPayload = { profileId: number } | { newName: string; newEmail: string }
-type EditData = { checkedIn: boolean; count: number; hours: number; notes: string }
+type EditData = { checkedIn: boolean; count: number; hours: number; notes: string; accompanyingAdultId: number | null }
 
 const props = defineProps<{
   entries: EntryItem[]
@@ -107,8 +107,15 @@ const editError = ref('')
 const addError = ref('')
 const setHoursError = ref('')
 
+const router = useRouter()
+
 const checkedCount = computed(() => props.entries.filter(e => e.checkedIn).length)
 const eligibleCount = computed(() => props.entries.filter(e => e.checkedIn && !e.hours).length)
+const sessionAdults = computed(() =>
+  props.entries
+    .filter(e => e.profileId && !e.profile.isGroup && !/\#child\b/i.test(e.notes ?? ''))
+    .map(e => ({ id: e.profileId!, name: e.profile.name }))
+)
 
 function closeEditModal() {
   editingEntry.value = null

--- a/frontend/src/components/sessions/SessionListFilter.vue
+++ b/frontend/src/components/sessions/SessionListFilter.vue
@@ -24,7 +24,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
-import { useRoute } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import FyFilter from '../FyFilter.vue'
 import TermPicker from '../TermPicker.vue'
 import { useTaxonomy } from '../../composables/useTaxonomy'
@@ -36,8 +36,9 @@ const emit = defineEmits<{ filtered: [sessions: Session[]] }>()
 const { tree: taxonomyTree, loading: taxonomyLoading } = useTaxonomy()
 
 const route = useRoute()
+const router = useRouter()
 const fy       = ref((route.query.fy as string) || 'future')
-const search   = ref('')
+const search   = ref((route.query.search as string) || '')
 const groupKey = ref((route.query.group as string) || '')
 const tagLabel = ref((route.query.tag as string) || '')
 
@@ -95,9 +96,23 @@ const availableTagLabels = computed(() => {
   return labels
 })
 
-const filtered = computed(() => applyTag(applyGroup(base.value)))
+const filtered = computed(() => {
+  const list = applyTag(applyGroup(base.value))
+  return fy.value === 'future'
+    ? [...list].sort((a, b) => a.date.localeCompare(b.date))
+    : list
+})
 
 watch(filtered, list => emit('filtered', list), { immediate: true })
+
+watch([fy, search, groupKey, tagLabel], ([newFy, newSearch, newGroup, newTag]) => {
+  const query: Record<string, string> = {}
+  if (newFy)     query.fy     = newFy
+  if (newSearch) query.search = newSearch
+  if (newGroup)  query.group  = newGroup
+  if (newTag)    query.tag    = newTag
+  router.replace({ query })
+})
 </script>
 
 <style scoped>

--- a/frontend/src/pages/EntriesPage.vue
+++ b/frontend/src/pages/EntriesPage.vue
@@ -33,7 +33,6 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
-import { onMounted } from 'vue'
 import { useEntryListStore } from '../stores/entryList'
 import type { EntryListItemResponse } from '../../../types/api-responses'
 import type { EntryItem } from '../types/entry'
@@ -58,8 +57,6 @@ const sessionAdults = ref<{ id: number; name: string }[]>([])
 const editWorking = ref(false)
 const editError = ref<string | undefined>()
 const currentFilter = ref<EntryFilterParams>({ q: '', accompanyingAdult: '' })
-
-onMounted(() => store.fetch())
 
 function onFiltered(params: EntryFilterParams) {
   currentFilter.value = params

--- a/frontend/src/pages/EntriesPage.vue
+++ b/frontend/src/pages/EntriesPage.vue
@@ -1,0 +1,160 @@
+<template>
+  <DefaultLayout>
+    <h1 class="sr-only">Entries</h1>
+    <PageHeader>Entries</PageHeader>
+    <EntryListFilter @filtered="onFiltered" />
+    <EntryListActions :entries="store.entries" :selected="selected" />
+    <EntryListResults
+      :entries="store.entries"
+      :loading="store.loading"
+      :error="store.error"
+      :selected="selected"
+      allow-select
+      allow-edit
+      @update:selected="selected = $event"
+      @edit-entry="onEditEntry"
+    />
+
+    <EntryEditModal
+      v-if="editingEntry"
+      :entry="editingEntry"
+      :profile-click="editingEntry.profile.slug ? () => router.push(profilePath(editingEntry!.profile.slug!)) : undefined"
+      :session-click="() => router.push(sessionPath(editingEntry!.session.groupKey, editingEntry!.session.date))"
+      :session-adults="sessionAdults"
+      :working="editWorking"
+      :error="editError"
+      @close="closeEditModal"
+      @save="onSave"
+      @delete="onDelete"
+    />
+  </DefaultLayout>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { onMounted } from 'vue'
+import { useEntryListStore } from '../stores/entryList'
+import type { EntryListItemResponse } from '../../../types/api-responses'
+import type { EntryItem } from '../types/entry'
+import type { EntryFilterParams } from '../components/entries/EntryListFilter.vue'
+import DefaultLayout from '../layouts/DefaultLayout.vue'
+import PageHeader from '../components/PageHeader.vue'
+import EntryListFilter from '../components/entries/EntryListFilter.vue'
+import EntryListActions from '../components/entries/EntryListActions.vue'
+import EntryListResults from '../components/entries/EntryListResults.vue'
+import EntryEditModal from './modals/EntryEditModal.vue'
+import { profilePath, sessionPath } from '../router/index'
+import { fetchSessionAdults } from '../utils/fetchSessionAdults'
+
+type EditData = { checkedIn: boolean; count: number; hours: number; notes: string; accompanyingAdultId: number | null }
+
+const store = useEntryListStore()
+const router = useRouter()
+
+const selected = ref<number[]>([])
+const editingEntry = ref<EntryItem | null>(null)
+const sessionAdults = ref<{ id: number; name: string }[]>([])
+const editWorking = ref(false)
+const editError = ref<string | undefined>()
+const currentFilter = ref<EntryFilterParams>({ q: '', accompanyingAdult: '' })
+
+onMounted(() => store.fetch())
+
+function onFiltered(params: EntryFilterParams) {
+  currentFilter.value = params
+  store.fetch(params)
+}
+
+function matchesFilter(entry: EntryListItemResponse, filter: EntryFilterParams): boolean {
+  if (filter.q && !(entry.notes ?? '').toLowerCase().includes(filter.q.toLowerCase())) return false
+  if (filter.accompanyingAdult === 'empty' && entry.hasAccompanyingAdult) return false
+  if (filter.accompanyingAdult === 'notempty' && !entry.hasAccompanyingAdult) return false
+  return true
+}
+
+function mapToEntryItem(e: EntryListItemResponse): EntryItem {
+  return {
+    id: e.id,
+    profileId: e.profileId,
+    checkedIn: e.checkedIn,
+    hours: e.hours,
+    count: e.count,
+    notes: e.notes,
+    accompanyingAdultId: e.accompanyingAdultId,
+    profile: {
+      name: e.volunteerName ?? 'Unknown',
+      slug: e.volunteerSlug,
+      isMember: false,
+      isGroup: e.isGroup,
+    },
+    session: {
+      groupKey: e.groupKey,
+      groupName: e.groupName,
+      date: e.date,
+    },
+  }
+}
+
+async function onEditEntry(e: EntryListItemResponse) {
+  editingEntry.value = mapToEntryItem(e)
+  sessionAdults.value = await fetchSessionAdults(e.groupKey, e.date)
+}
+
+function closeEditModal() {
+  editingEntry.value = null
+  sessionAdults.value = []
+  editWorking.value = false
+  editError.value = undefined
+}
+
+async function onSave(data: EditData) {
+  if (!editingEntry.value) return
+  editWorking.value = true
+  editError.value = undefined
+  try {
+    const res = await fetch(`/api/entries/${editingEntry.value.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+    if (!res.ok) throw new Error(`Save failed (${res.status})`)
+    const idx = store.entries.findIndex(e => e.id === editingEntry.value!.id)
+    if (idx !== -1) {
+      const stored = store.entries[idx]
+      stored.checkedIn = data.checkedIn
+      stored.hours = data.hours
+      stored.count = data.count
+      stored.notes = data.notes
+      stored.accompanyingAdultId = data.accompanyingAdultId ?? undefined
+      stored.hasAccompanyingAdult = data.accompanyingAdultId !== null
+      if (!matchesFilter(stored, currentFilter.value)) {
+        store.entries.splice(idx, 1)
+        selected.value = selected.value.filter(id => id !== editingEntry.value!.id)
+      }
+    }
+    closeEditModal()
+  } catch (e) {
+    console.error('[EntriesPage] save failed', e)
+    editError.value = 'Failed to save — please try again'
+    editWorking.value = false
+  }
+}
+
+async function onDelete() {
+  if (!editingEntry.value) return
+  editWorking.value = true
+  editError.value = undefined
+  try {
+    const res = await fetch(`/api/entries/${editingEntry.value.id}`, { method: 'DELETE' })
+    if (!res.ok) throw new Error(`Delete failed (${res.status})`)
+    store.entries.splice(store.entries.findIndex(e => e.id === editingEntry.value!.id), 1)
+    selected.value = selected.value.filter(id => id !== editingEntry.value!.id)
+    closeEditModal()
+  } catch (e) {
+    console.error('[EntriesPage] delete failed', e)
+    editError.value = 'Failed to delete — please try again'
+    editWorking.value = false
+  }
+}
+</script>

--- a/frontend/src/pages/SessionDetailPage.vue
+++ b/frontend/src/pages/SessionDetailPage.vue
@@ -254,10 +254,12 @@ const { tree: taxonomyTree, loading: taxonomyLoading } = useTaxonomy()
 function mapEntry(e: EntryResponse): EntryItem {
   return {
     id: e.id,
+    profileId: e.profileId,
     checkedIn: e.checkedIn,
     hours: e.hours,
     count: e.count,
     notes: e.notes,
+    accompanyingAdultId: e.accompanyingAdultId,
     profile: {
       name: e.profileName ?? e.volunteerName ?? 'Unknown',
       slug: e.profileSlug ?? e.volunteerSlug,
@@ -397,7 +399,7 @@ async function onAddEntry(payload: { profileId: number } | { newName: string; ne
   }
 }
 
-type EditData = { checkedIn: boolean; count: number; hours: number; notes: string }
+type EditData = { checkedIn: boolean; count: number; hours: number; notes: string; accompanyingAdultId: number | null }
 
 async function onEditEntry(id: number, data: EditData | null) {
   try {
@@ -420,6 +422,7 @@ async function onEditEntry(id: number, data: EditData | null) {
         stored.hours = data.hours
         stored.count = data.count
         stored.notes = data.notes
+        stored.accompanyingAdultId = data.accompanyingAdultId ?? undefined
       }
     }
     entryListRef.value?.onEditSuccess()

--- a/frontend/src/pages/modals/EntryAddModal.vue
+++ b/frontend/src/pages/modals/EntryAddModal.vue
@@ -2,7 +2,7 @@
   <ModalLayout
     title="Add Entry"
     action="Add"
-    action-icon="new"
+    action-icon="add"
     :action-disabled="!canAdd"
     :working="working"
     :error="error"
@@ -30,7 +30,7 @@
         />
       </FormRow>
 
-      <FormRow title="Add New">
+      <FormRow title="No match? Add new">
         <input type="checkbox" class="aem-checkbox" v-model="addNew" @change="onAddNewToggle" />
       </FormRow>
     </FormLayout>
@@ -58,6 +58,7 @@ const canAdd = computed(() => selectedProfile.value !== null || addNew.value)
 
 function onSelect(profile: PickerProfile | null) {
   selectedProfile.value = profile
+  emailInput.value = profile?.email ?? ''
 }
 
 function onAddNewToggle() {

--- a/frontend/src/pages/modals/EntryEditModal.vue
+++ b/frontend/src/pages/modals/EntryEditModal.vue
@@ -10,8 +10,9 @@
     @action="save"
     @delete="confirmDelete = true"
   >
-    <div v-if="viewLabel && viewTo" class="eem-actions">
-      <AppButton :label="viewLabel" :icon="viewIcon" @click="router.push(viewTo)" />
+    <div v-if="profileClick || sessionClick" class="eem-actions">
+      <AppButton v-if="profileClick" label="View Profile" icon="profile" @click="profileClick!()" />
+      <AppButton v-if="sessionClick" label="View Session" icon="register" @click="sessionClick!()" />
     </div>
 
     <FormLayout :disabled="working">
@@ -19,17 +20,29 @@
         <input type="checkbox" class="eem-checkbox" v-model="form.checkedIn" />
       </FormRow>
 
-      <FormRow title="Count">
+      <FormRow v-if="entry.profile.isGroup" title="Count">
         <input type="number" class="eem-input" v-model.number="form.count" min="1" />
       </FormRow>
 
-      <FormRow title="Hours">
-        <input type="number" class="eem-input" v-model.number="form.hours" min="0" step="0.5" />
+      <FormRow title="Hours" :disabled="!form.checkedIn">
+        <input type="number" class="eem-input" v-model.number="form.hours" min="0" step="0.5" :disabled="!form.checkedIn" />
       </FormRow>
 
       <FormRow title="Notes" :full-width="true">
         <textarea class="eem-textarea" v-model="form.notes" rows="2" />
         <EntryIconPicker v-model="form.notes" />
+      </FormRow>
+
+      <FormRow v-if="sessionAdults" title="Accompanying Adult" :disabled="!hasChild">
+        <select
+          class="eem-select"
+          :class="{ 'eem-select--placeholder': form.accompanyingAdultId === null }"
+          v-model="form.accompanyingAdultId"
+          :disabled="!hasChild"
+        >
+          <option :value="null">Select adult…</option>
+          <option v-for="a in sessionAdults" :key="a.id" :value="a.id">{{ a.name }}</option>
+        </select>
       </FormRow>
     </FormLayout>
   </ModalLayout>
@@ -43,9 +56,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, reactive, watch } from 'vue'
-import { useRouter } from 'vue-router'
-import type { RouteLocationRaw } from 'vue-router'
+import { ref, reactive, watch, computed } from 'vue'
 import type { EntryItem } from '../../types/entry'
 import ModalLayout from '../../components/ModalLayout.vue'
 import FormLayout from '../../components/FormLayout.vue'
@@ -54,14 +65,22 @@ import AppButton from '../../components/AppButton.vue'
 import EntryIconPicker from '../../components/EntryIconPicker.vue'
 import DeleteModal from './DeleteModal.vue'
 
-const props = defineProps<{ entry: EntryItem; working: boolean; error?: string; title?: string; viewLabel?: string; viewTo?: RouteLocationRaw; viewIcon?: string }>()
+const props = defineProps<{
+  entry: EntryItem
+  working: boolean
+  error?: string
+  title?: string
+  profileClick?: () => void
+  sessionClick?: () => void
+  sessionAdults?: { id: number; name: string }[]
+}>()
+
 const emit = defineEmits<{
   close: []
-  save: [data: { checkedIn: boolean; count: number; hours: number; notes: string }]
+  save: [data: { checkedIn: boolean; count: number; hours: number; notes: string; accompanyingAdultId: number | null }]
   delete: []
 }>()
 
-const router = useRouter()
 const confirmDelete = ref(false)
 
 const form = reactive({
@@ -69,17 +88,31 @@ const form = reactive({
   count: props.entry.count,
   hours: props.entry.hours,
   notes: props.entry.notes ?? '',
+  accompanyingAdultId: props.entry.accompanyingAdultId ?? null as number | null,
 })
+
+const hasChild = computed(() => /\#child\b/i.test(form.notes))
 
 watch(() => props.entry, (e) => {
   form.checkedIn = e.checkedIn
   form.count = e.count
   form.hours = e.hours
   form.notes = e.notes ?? ''
+  form.accompanyingAdultId = e.accompanyingAdultId ?? null
+})
+
+watch(hasChild, (val) => {
+  if (!val) form.accompanyingAdultId = null
 })
 
 function save() {
-  emit('save', { checkedIn: form.checkedIn, count: form.count, hours: form.hours, notes: form.notes })
+  emit('save', {
+    checkedIn: form.checkedIn,
+    count: form.count,
+    hours: form.hours,
+    notes: form.notes,
+    accompanyingAdultId: form.accompanyingAdultId,
+  })
 }
 
 function deleteEntry() {
@@ -89,7 +122,11 @@ function deleteEntry() {
 </script>
 
 <style scoped>
-.eem-actions { margin-bottom: 1.25rem; }
+.eem-actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1.25rem;
+}
 
 .eem-input {
   width: 5rem;
@@ -118,4 +155,17 @@ function deleteEntry() {
   resize: vertical;
   box-sizing: border-box;
 }
+
+.eem-select {
+  width: 100%;
+  background: var(--color-dtv-light);
+  border: none;
+  color: var(--color-text);
+  padding: 0.3rem 0.5rem;
+  font-family: inherit;
+  font-size: 0.95rem;
+  box-sizing: border-box;
+}
+.eem-select:disabled { color: var(--color-text-muted); }
+.eem-select--placeholder { color: var(--color-text-muted); }
 </style>

--- a/frontend/src/pages/sandbox/SandboxActionBars.vue
+++ b/frontend/src/pages/sandbox/SandboxActionBars.vue
@@ -70,6 +70,15 @@
         @delete-group="onGroupAction(actionsWithoutEbRef, 'delete-group')"
       />
 
+      <h2>EntryListActions — no selection</h2>
+      <EntryListActions :entries="mockEntries" :selected="[]" />
+
+      <h2>EntryListActions — 2 selected</h2>
+      <EntryListActions :entries="mockEntries" :selected="[1, 3]" />
+
+      <h2>EntryListActions — all selected</h2>
+      <EntryListActions :entries="mockEntries" :selected="mockEntries.map(e => e.id)" />
+
       <label class="fail-toggle">
         <input type="checkbox" v-model="failNext" /> Fail next action
       </label>
@@ -94,7 +103,8 @@ import SandboxBackLink from './SandboxBackLink.vue'
 import SessionDetailActions from '../../components/sessions/SessionDetailActions.vue'
 import SessionListActions from '../../components/sessions/SessionListActions.vue'
 import GroupDetailActions from '../../components/groups/GroupDetailActions.vue'
-import type { GroupDetailResponse, SessionDetailResponse } from '../../../../types/api-responses'
+import EntryListActions from '../../components/entries/EntryListActions.vue'
+import type { GroupDetailResponse, SessionDetailResponse, EntryListItemResponse } from '../../../../types/api-responses'
 import type { Session } from '../../types/session'
 
 const actionsWithEbRef = ref<InstanceType<typeof GroupDetailActions> | null>(null)
@@ -161,6 +171,13 @@ const mockSessions: Session[] = [
   { id: 2, date: '2025-01-24', groupName: 'Sheepskull', financialYear: '24/25', isBookable: false, limits: {}, registrations: 6,  hours: 24,   isRegistered: false, isAttended: false, isRegular: false },
   { id: 3, date: '2025-02-07', groupName: 'City Park',  financialYear: '24/25', isBookable: true,  limits: {}, registrations: 12, hours: 0,    isRegistered: false, isAttended: false, isRegular: false },
   { id: 4, date: '2025-02-21', groupName: 'City Park',  financialYear: '24/25', isBookable: false, limits: {}, registrations: 10, hours: 40.5, isRegistered: false, isAttended: false, isRegular: false },
+]
+
+const mockEntries: EntryListItemResponse[] = [
+  { id: 1, volunteerName: 'Alice Smith', date: '2026-04-08', groupKey: 'wed-dig', groupName: 'Wednesday Dig', checkedIn: true,  hours: 4,  count: 1, isGroup: false, hasAccompanyingAdult: false },
+  { id: 2, volunteerName: 'Bob Jones',   date: '2026-04-08', groupKey: 'wed-dig', groupName: 'Wednesday Dig', checkedIn: false, hours: 0,  count: 1, isGroup: false, hasAccompanyingAdult: false },
+  { id: 3, volunteerName: 'Carol White', date: '2026-03-20', groupKey: 'trail',   groupName: 'Trail Crew',    checkedIn: true,  hours: 5,  count: 1, isGroup: false, hasAccompanyingAdult: false },
+  { id: 4, volunteerName: 'Saturday Crew', date: '2026-03-20', groupKey: 'trail', groupName: 'Trail Crew',   checkedIn: true,  hours: 20, count: 6, isGroup: true,  hasAccompanyingAdult: false },
 ]
 
 const noneSelected = ref<number[]>([])

--- a/frontend/src/pages/sandbox/SandboxEntryListItem.vue
+++ b/frontend/src/pages/sandbox/SandboxEntryListItem.vue
@@ -1,0 +1,108 @@
+<template>
+  <DefaultLayout>
+    <div class="sandbox">
+      <SandboxBackLink />
+      <h1>EntryListItem</h1>
+      <p class="sandbox-warning">Static mocked data — no API calls.</p>
+
+      <h2>Standard (not checked in)</h2>
+      <div class="demo">
+        <EntryListItem :entry="standard" />
+      </div>
+
+      <h2>Checked in (green left border)</h2>
+      <div class="demo">
+        <EntryListItem :entry="checkedIn" />
+      </div>
+
+      <h2>Selected (light background)</h2>
+      <div class="demo">
+        <EntryListItem :entry="standard" :selected="true" />
+      </div>
+
+      <h2>Checked in + selected</h2>
+      <div class="demo">
+        <EntryListItem :entry="checkedIn" :selected="true" />
+      </div>
+
+      <h2>With tag icons (#Child #New)</h2>
+      <div class="demo">
+        <EntryListItem :entry="withTags" />
+      </div>
+
+      <h2>Group entry (isGroup: true)</h2>
+      <div class="demo">
+        <EntryListItem :entry="groupEntry" />
+      </div>
+
+      <h2>Unknown volunteer (no name)</h2>
+      <div class="demo">
+        <EntryListItem :entry="noName" />
+      </div>
+
+      <h2>As a link (to prop provided)</h2>
+      <div class="demo">
+        <EntryListItem :entry="standard" to="/entries/1" />
+      </div>
+
+      <h2>Long name (overflow truncation)</h2>
+      <div class="demo">
+        <EntryListItem :entry="longName" />
+      </div>
+    </div>
+  </DefaultLayout>
+</template>
+
+<script setup lang="ts">
+import '../../styles/sandbox.css'
+import DefaultLayout from '../../layouts/DefaultLayout.vue'
+import SandboxBackLink from './SandboxBackLink.vue'
+import EntryListItem from '../../components/entries/EntryListItem.vue'
+import { usePageTitle } from '../../composables/usePageTitle'
+import type { EntryListItemResponse } from '../../../../types/api-responses'
+
+usePageTitle('Sandbox')
+
+const base: EntryListItemResponse = {
+  id: 1,
+  profileId: 10,
+  volunteerName: 'Alice Smith',
+  volunteerSlug: 'alice-smith-10',
+  date: '2026-04-08',
+  groupKey: 'wed-dig',
+  groupName: 'Wednesday Dig',
+  notes: undefined,
+  checkedIn: false,
+  hours: 4,
+  count: 1,
+  isGroup: false,
+  hasAccompanyingAdult: false,
+}
+
+const standard: EntryListItemResponse = { ...base }
+
+const checkedIn: EntryListItemResponse = { ...base, id: 2, checkedIn: true }
+
+const withTags: EntryListItemResponse = {
+  ...base, id: 3, volunteerName: 'Bob Jones', notes: '#Child #New',
+}
+
+const groupEntry: EntryListItemResponse = {
+  ...base, id: 4, volunteerName: 'Saturday Crew', volunteerSlug: 'saturday-crew-20',
+  isGroup: true, count: 6, groupName: 'Trail Crew',
+}
+
+const noName: EntryListItemResponse = {
+  ...base, id: 5, volunteerName: undefined, volunteerSlug: undefined,
+}
+
+const longName: EntryListItemResponse = {
+  ...base, id: 6,
+  volunteerName: 'Bartholomew Christopher Windermere-Hutchinson',
+  groupName: 'Wednesday Evening Woodland Conservation Dig',
+}
+</script>
+
+<style scoped>
+.demo { outline: 1px solid var(--color-border); }
+</style>

--- a/frontend/src/pages/sandbox/SandboxEntryListResults.vue
+++ b/frontend/src/pages/sandbox/SandboxEntryListResults.vue
@@ -1,0 +1,125 @@
+<template>
+  <DefaultLayout>
+    <div class="sandbox">
+      <SandboxBackLink />
+      <h1>EntryListResults</h1>
+      <p class="sandbox-warning">Static mocked data — no API calls. Selection and edit events work locally.</p>
+
+      <h2>Default (no select, no edit — links to entry detail)</h2>
+      <div class="demo">
+        <EntryListResults
+          :entries="mockEntries"
+          :loading="false"
+          :error="null"
+          :selected="[]"
+        />
+      </div>
+
+      <h2>allowSelect — checkbox mode</h2>
+      <div class="demo">
+        <EntryListResults
+          :entries="mockEntries"
+          :loading="false"
+          :error="null"
+          :selected="selected"
+          allow-select
+          @update:selected="selected = $event"
+        />
+      </div>
+      <p class="note">Selected IDs: {{ selected.length ? selected.join(', ') : '(none)' }}</p>
+
+      <h2>allowEdit — click row to open modal (edit event logged)</h2>
+      <div class="demo">
+        <EntryListResults
+          :entries="mockEntries"
+          :loading="false"
+          :error="null"
+          :selected="editSelected"
+          allow-select
+          allow-edit
+          @update:selected="editSelected = $event"
+          @edit-entry="onEdit"
+        />
+      </div>
+      <p v-if="lastEdited" class="note">edit-entry: {{ lastEdited.volunteerName }} (id {{ lastEdited.id }})</p>
+
+      <h2>Loading state</h2>
+      <div class="demo">
+        <EntryListResults
+          :entries="[]"
+          :loading="true"
+          :error="null"
+          :selected="[]"
+        />
+      </div>
+
+      <h2>Error state</h2>
+      <div class="demo">
+        <EntryListResults
+          :entries="[]"
+          :loading="false"
+          error="Failed to load entries (500)"
+          :selected="[]"
+        />
+      </div>
+
+      <h2>Empty state</h2>
+      <div class="demo">
+        <EntryListResults
+          :entries="[]"
+          :loading="false"
+          :error="null"
+          :selected="[]"
+        />
+      </div>
+    </div>
+  </DefaultLayout>
+</template>
+
+<script setup lang="ts">
+import '../../styles/sandbox.css'
+import { ref } from 'vue'
+import DefaultLayout from '../../layouts/DefaultLayout.vue'
+import SandboxBackLink from './SandboxBackLink.vue'
+import EntryListResults from '../../components/entries/EntryListResults.vue'
+import { usePageTitle } from '../../composables/usePageTitle'
+import type { EntryListItemResponse } from '../../../../types/api-responses'
+
+usePageTitle('Sandbox')
+
+const selected = ref<number[]>([2])
+const editSelected = ref<number[]>([])
+const lastEdited = ref<EntryListItemResponse | null>(null)
+
+function onEdit(entry: EntryListItemResponse) {
+  lastEdited.value = entry
+}
+
+const mockEntries: EntryListItemResponse[] = [
+  {
+    id: 1, profileId: 10, volunteerName: 'Alice Smith', volunteerSlug: 'alice-smith-10',
+    date: '2026-04-08', groupKey: 'wed-dig', groupName: 'Wednesday Dig',
+    notes: undefined, checkedIn: true, hours: 4, count: 1, isGroup: false, hasAccompanyingAdult: false,
+  },
+  {
+    id: 2, profileId: 11, volunteerName: 'Bob Jones', volunteerSlug: 'bob-jones-11',
+    date: '2026-04-08', groupKey: 'wed-dig', groupName: 'Wednesday Dig',
+    notes: '#Child #New', checkedIn: false, hours: 0, count: 1, isGroup: false, hasAccompanyingAdult: true,
+  },
+  {
+    id: 3, profileId: 12, volunteerName: 'Carol White', volunteerSlug: 'carol-white-12',
+    date: '2026-03-20', groupKey: 'trail-crew', groupName: 'Trail Crew',
+    notes: undefined, checkedIn: true, hours: 5, count: 1, isGroup: false, hasAccompanyingAdult: false,
+  },
+  {
+    id: 4, profileId: 20, volunteerName: 'Saturday Crew', volunteerSlug: 'saturday-crew-20',
+    date: '2026-03-20', groupKey: 'trail-crew', groupName: 'Trail Crew',
+    notes: undefined, checkedIn: true, hours: 20, count: 6, isGroup: true, hasAccompanyingAdult: false,
+  },
+]
+</script>
+
+<style scoped>
+.demo { outline: 1px solid var(--color-border); }
+.note { font-size: 0.85rem; color: var(--color-text-muted); margin-top: 0.5rem; }
+</style>

--- a/frontend/src/pages/sandbox/SandboxFilterComponents.vue
+++ b/frontend/src/pages/sandbox/SandboxFilterComponents.vue
@@ -17,6 +17,12 @@
       <h2>GroupListFilter (Admin: New Group button visible)</h2>
       <GroupListFilter :groups="groups" :sessions="sessions" :can-add-group="true" @filtered="filteredGroups = $event" />
 
+      <h2>EntryListFilter — notes search + AccompanyingAdult dropdown</h2>
+      <EntryListFilter @filtered="filteredEntries = $event" />
+      <p v-if="filteredEntries" class="filter-note">
+        q: "{{ filteredEntries.q }}" · accompanyingAdult: "{{ filteredEntries.accompanyingAdult || '(all)' }}"
+      </p>
+
     </div>
   </DefaultLayout>
 </template>
@@ -29,15 +35,18 @@ import SandboxBackLink from './SandboxBackLink.vue'
 import SessionListFilter from '../../components/sessions/SessionListFilter.vue'
 import SessionListActions from '../../components/sessions/SessionListActions.vue'
 import GroupListFilter from '../../components/groups/GroupListFilter.vue'
+import EntryListFilter from '../../components/entries/EntryListFilter.vue'
 import { usePageTitle } from '../../composables/usePageTitle'
 import type { Session } from '../../types/session'
 import type { GroupResponse } from '../../../../types/api-responses'
 import type { GroupWithStats } from '../../components/groups/GroupListFilter.vue'
+import type { EntryFilterParams } from '../../components/entries/EntryListFilter.vue'
 
 usePageTitle('Sandbox')
 
 const filteredSessions = ref<Session[]>([])
 const filteredGroups = ref<GroupWithStats[]>([])
+const filteredEntries = ref<EntryFilterParams | null>(null)
 const emptySelected = ref<number[]>([])
 const activeSelected = ref<number[]>([1, 3, 4])
 

--- a/frontend/src/pages/sandbox/SandboxIndex.vue
+++ b/frontend/src/pages/sandbox/SandboxIndex.vue
@@ -57,6 +57,8 @@
           <RouterLink to="/sandbox/group-card">GroupCard</RouterLink>
           <RouterLink to="/sandbox/profile-list-item">ProfileListItem</RouterLink>
           <RouterLink to="/sandbox/profile-list-results">ProfileListResults</RouterLink>
+          <RouterLink to="/sandbox/entry-list-item">EntryListItem</RouterLink>
+          <RouterLink to="/sandbox/entry-list-results">EntryListResults</RouterLink>
         </nav>
       </section>
 

--- a/frontend/src/pages/sandbox/SandboxModals.vue
+++ b/frontend/src/pages/sandbox/SandboxModals.vue
@@ -96,6 +96,9 @@
       <EntryEditModal
         v-if="open === 'entry-edit'"
         :entry="mockEntry"
+        :profile-click="() => log('entry-edit: View Profile clicked')"
+        :session-click="() => log('entry-edit: View Session clicked')"
+        :session-adults="mockSessionAdults"
         :working="working"
         :error="error"
         @close="closeModal('close')"
@@ -293,8 +296,8 @@ function onSetHours(hours: number) {
   simulate(`set-hours: ${hours}h`)
 }
 
-function onEditSave(data: { checkedIn: boolean; count: number; hours: number; notes: string }) {
-  simulate(`entry-edit save → checkedIn=${data.checkedIn}, hours=${data.hours}, notes="${data.notes}"`)
+function onEditSave(data: { checkedIn: boolean; count: number; hours: number; notes: string; accompanyingAdultId: number | null }) {
+  simulate(`entry-edit save → checkedIn=${data.checkedIn}, hours=${data.hours}, notes="${data.notes}", accompanyingAdultId=${data.accompanyingAdultId}`)
 }
 
 function onEditDelete() {
@@ -384,13 +387,21 @@ const mockSession = {
 
 const mockEntry: EntryItem = {
   id: 1,
-  checkedIn: false,
-  hours: 0,
+  profileId: 42,
+  checkedIn: true,
+  hours: 3,
   count: 1,
-  notes: '#New',
+  notes: '#Child #New',
+  accompanyingAdultId: 2,
   profile: { name: 'Alice Bowen', slug: 'alice-bowen-42', isMember: true, cardStatus: 'Accepted', isGroup: false },
   session: { groupKey: 'dhsc', groupName: 'Sheepskull', date: '2026-04-19' },
 }
+
+const mockSessionAdults = [
+  { id: 2, name: 'Bob Carter' },
+  { id: 3, name: 'Carol Davies' },
+  { id: 4, name: 'David Evans' },
+]
 
 const mockProfiles: PickerProfile[] = [
   { id: 1, name: 'Alice Bowen', email: 'alice@example.com' },

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -16,6 +16,7 @@ import GroupDetailPage from '../pages/GroupDetailPage.vue'
 import SessionDetailPage from '../pages/SessionDetailPage.vue'
 import SessionListPage from '../pages/SessionListPage.vue'
 import AdminPage from '../pages/AdminPage.vue'
+import EntriesPage from '../pages/EntriesPage.vue'
 import ProfileListPage from '../pages/ProfileListPage.vue'
 import ProfileDetailPage from '../pages/ProfileDetailPage.vue'
 
@@ -29,6 +30,7 @@ export const profilesPath = () => '/profiles'
 export const profilePath = (slug: string) => `/profiles/${slug}`
 export const addEntryPath = (groupKey: string, date: string) => `/sessions/${groupKey}/${date}/add-entry`
 export const entryPath = (id: number) => `/entries/${id}`
+export const entriesPath = () => '/entries'
 export const adminPath = () => '/admin'
 export const consentPath = (slug: string) => `/profiles/${slug}/consent`
 export const uploadPath  = (entryId: number) => `/upload?entryId=${entryId}`
@@ -45,6 +47,7 @@ export const router = createRouter({
     { path: '/privacy', component: PrivacyPage },
     { path: '/terms', component: TermsPage },
     { path: '/login', component: LoginPage },
+    { path: '/entries', component: EntriesPage, meta: { requiresTrusted: true } },
     { path: '/admin', component: AdminPage },
     { path: '/not-found', component: () => import('../pages/NotFoundPage.vue') },
     { path: '/forbidden', component: () => import('../pages/ForbiddenPage.vue') },
@@ -79,6 +82,8 @@ export const router = createRouter({
     { path: '/sandbox/profile-linked-accounts', component: () => import('../pages/sandbox/SandboxProfileLinkedAccounts.vue') },
     { path: '/sandbox/profile-list-item', component: () => import('../pages/sandbox/SandboxProfileListItem.vue') },
     { path: '/sandbox/profile-list-results', component: () => import('../pages/sandbox/SandboxProfileListResults.vue') },
+    { path: '/sandbox/entry-list-item', component: () => import('../pages/sandbox/SandboxEntryListItem.vue') },
+    { path: '/sandbox/entry-list-results', component: () => import('../pages/sandbox/SandboxEntryListResults.vue') },
     { path: '/sandbox/regular-list', component: () => import('../pages/sandbox/SandboxRegularList.vue') },
     { path: '/sandbox/regular-item', component: () => import('../pages/sandbox/SandboxRegularItem.vue') },
     { path: '/sandbox/flash-message', component: () => import('../pages/sandbox/SandboxFlashMessage.vue') },

--- a/frontend/src/stores/entryList.ts
+++ b/frontend/src/stores/entryList.ts
@@ -1,0 +1,35 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import type { EntryListItemResponse } from '../../../types/api-responses'
+
+export const useEntryListStore = defineStore('entryList', () => {
+  const entries = ref<EntryListItemResponse[]>([])
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  async function fetch(params: { q?: string; accompanyingAdult?: string } = {}) {
+    loading.value = true
+    error.value = null
+    try {
+      const query = new URLSearchParams()
+      if (params.q) query.set('q', params.q)
+      if (params.accompanyingAdult) query.set('accompanyingAdult', params.accompanyingAdult)
+      const qs = query.toString()
+      const res = await window.fetch(`/api/entries${qs ? `?${qs}` : ''}`)
+      if (!res.ok) {
+        console.error(`[entryList] fetch failed: ${res.status} ${res.url}`)
+        error.value = `Failed to load entries (${res.status})`
+        return
+      }
+      const json = await res.json()
+      entries.value = json.data ?? []
+    } catch (err) {
+      console.error('[entryList] fetch error:', err)
+      error.value = err instanceof Error ? err.message : 'Unknown error'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return { entries, loading, error, fetch }
+})

--- a/frontend/src/types/entry.ts
+++ b/frontend/src/types/entry.ts
@@ -14,10 +14,12 @@ export interface EntrySessionSummary {
 
 export interface EntryItem {
   id: number
+  profileId?: number
   checkedIn: boolean
   hours: number
   count: number
   notes?: string
+  accompanyingAdultId?: number
   profile: EntryProfileSummary
   session: EntrySessionSummary
 }

--- a/frontend/src/utils/fetchSessionAdults.ts
+++ b/frontend/src/utils/fetchSessionAdults.ts
@@ -1,0 +1,15 @@
+import type { SessionDetailResponse } from '../../../types/api-responses'
+
+export async function fetchSessionAdults(groupKey: string, date: string): Promise<{ id: number; name: string }[]> {
+  try {
+    const res = await fetch(`/api/sessions/${encodeURIComponent(groupKey)}/${encodeURIComponent(date)}`)
+    if (!res.ok) return []
+    const json = await res.json()
+    const session: SessionDetailResponse = json.data
+    return (session.entries ?? [])
+      .filter(e => !e.isGroup && e.profileId !== undefined && !/\#child\b/i.test(e.notes ?? ''))
+      .map(e => ({ id: e.profileId!, name: e.volunteerName ?? 'Unknown' }))
+  } catch {
+    return []
+  }
+}

--- a/middleware/require-admin.ts
+++ b/middleware/require-admin.ts
@@ -39,9 +39,9 @@ const SELFSERVICE_ALLOWED_GET_PATTERNS = [
 ];
 
 const ADMIN_ONLY_GET_PATTERNS = [
-  /^\/sessions\/export$/,
-  /^\/records\/export$/,
-  /^\/entries$/,
+  /^\/sessions\/export\/?$/,
+  /^\/records\/export\/?$/,
+  /^\/entries\/?$/,
 ];
 
 export function requireAdmin(req: Request, res: Response, next: NextFunction): void {

--- a/middleware/require-admin.ts
+++ b/middleware/require-admin.ts
@@ -41,6 +41,7 @@ const SELFSERVICE_ALLOWED_GET_PATTERNS = [
 const ADMIN_ONLY_GET_PATTERNS = [
   /^\/sessions\/export$/,
   /^\/records\/export$/,
+  /^\/entries$/,
 ];
 
 export function requireAdmin(req: Request, res: Response, next: NextFunction): void {

--- a/routes/entries.ts
+++ b/routes/entries.ts
@@ -37,7 +37,7 @@ import multer from 'multer';
 import { sharePointClient } from '../services/sharepoint-client';
 import { mediaDriveId, exifDate, mediaFilename } from '../services/media-upload';
 
-import type { EntryDetailResponse, RecentSignupResponse, EntryUploadContextResponse } from '../types/api-responses';
+import type { EntryDetailResponse, EntryListItemResponse, RecentSignupResponse, EntryUploadContextResponse } from '../types/api-responses';
 import type { ApiResponse } from '../types/sharepoint';
 
 const router: Router = express.Router();
@@ -130,6 +130,72 @@ router.get('/entries/recent', async (req: Request, res: Response) => {
   } catch (error: any) {
     console.error('Error fetching recent entries:', error);
     res.status(500).json({ success: false, error: 'Failed to fetch recent entries', message: error.message });
+  }
+});
+
+router.get('/entries', async (req: Request, res: Response) => {
+  try {
+    const q = req.query.q ? String(req.query.q).toLowerCase() : '';
+    const accompanyingAdult = req.query.accompanyingAdult ? String(req.query.accompanyingAdult) : '';
+
+    const [rawEntries, rawSessions, rawGroups, rawProfiles] = await Promise.all([
+      entriesRepository.getAll(),
+      sessionsRepository.getAll(),
+      groupsRepository.getAll(),
+      profilesRepository.getAll()
+    ]);
+
+    const sessionMap = new Map(rawSessions.map(s => [s.ID, s]));
+    const groupMap = new Map(rawGroups.map(g => [g.ID, g]));
+    const profileMap = new Map(rawProfiles.map(p => [p.ID, p]));
+
+    const entries = validateArray(rawEntries, validateEntry, 'Entry');
+
+    const results: EntryListItemResponse[] = entries
+      .flatMap(e => {
+        const sessionId = safeParseLookupId(e[SESSION_LOOKUP]);
+        if (sessionId === undefined) return [];
+        const session = sessionMap.get(sessionId);
+        if (!session) return [];
+        const groupId = safeParseLookupId(session[GROUP_LOOKUP]);
+        if (groupId === undefined) return [];
+        const group = groupMap.get(groupId);
+        if (!group) return [];
+
+        if (q && !String(e.Notes || '').toLowerCase().includes(q)) return [];
+
+        const hasAdult = !!e.AccompanyingAdultLookupId;
+        if (accompanyingAdult === 'empty' && hasAdult) return [];
+        if (accompanyingAdult === 'notempty' && !hasAdult) return [];
+
+        const profileId = safeParseLookupId(e[PROFILE_LOOKUP]);
+        const profile = profileId !== undefined ? profileMap.get(profileId) : undefined;
+        const name = e[PROFILE_DISPLAY] || 'Unknown';
+        const slug = profileId !== undefined ? profileSlug(name, profileId) : nameToSlug(name);
+
+        return [{
+          id: e.ID,
+          profileId,
+          volunteerName: name,
+          volunteerSlug: slug,
+          date: session.Date,
+          groupKey: group.Title,
+          groupName: group.Name || group.Title,
+          notes: e.Notes,
+          checkedIn: e.Checked || false,
+          hours: parseHours(e.Hours),
+          count: e.Count || 1,
+          isGroup: profile?.IsGroup || false,
+          hasAccompanyingAdult: hasAdult,
+          accompanyingAdultId: e.AccompanyingAdultLookupId
+        }];
+      })
+      .sort((a, b) => b.date.localeCompare(a.date));
+
+    res.json({ success: true, data: results } as ApiResponse<EntryListItemResponse[]>);
+  } catch (error: any) {
+    console.error('Error fetching entries list:', error);
+    res.status(500).json({ success: false, error: 'Failed to fetch entries', message: error.message });
   }
 });
 
@@ -368,7 +434,7 @@ router.patch('/entries/:id', async (req: Request, res: Response) => {
       return;
     }
 
-    const { checkedIn, count, hours, notes } = req.body;
+    const { checkedIn, count, hours, notes, accompanyingAdultId } = req.body;
     const fields: Record<string, any> = {};
 
     if (typeof checkedIn === 'boolean') {
@@ -392,6 +458,9 @@ router.patch('/entries/:id', async (req: Request, res: Response) => {
     }
     if (typeof notes === 'string') {
       fields.Notes = notes;
+    }
+    if (accompanyingAdultId !== undefined) {
+      fields.AccompanyingAdultLookupId = accompanyingAdultId === null ? null : parseInt(String(accompanyingAdultId), 10);
     }
 
     if (Object.keys(fields).length === 0) {

--- a/routes/entries.ts
+++ b/routes/entries.ts
@@ -460,7 +460,16 @@ router.patch('/entries/:id', async (req: Request, res: Response) => {
       fields.Notes = notes;
     }
     if (accompanyingAdultId !== undefined) {
-      fields.AccompanyingAdultLookupId = accompanyingAdultId === null ? null : parseInt(String(accompanyingAdultId), 10);
+      if (accompanyingAdultId !== null) {
+        const adultIdNum = parseInt(String(accompanyingAdultId), 10);
+        if (isNaN(adultIdNum) || adultIdNum <= 0) {
+          res.status(400).json({ success: false, error: 'accompanyingAdultId must be a positive integer or null' });
+          return;
+        }
+        fields.AccompanyingAdultLookupId = adultIdNum;
+      } else {
+        fields.AccompanyingAdultLookupId = null;
+      }
     }
 
     if (Object.keys(fields).length === 0) {

--- a/routes/sessions.ts
+++ b/routes/sessions.ts
@@ -509,7 +509,8 @@ router.get('/sessions/:group/:date', async (req: Request, res: Response) => {
         count: e.Count || 1,
         hours: parseHours(e.Hours),
         checkedIn: e.Checked || false,
-        notes: e.Notes
+        notes: e.Notes,
+        accompanyingAdultId: e.AccompanyingAdultLookupId
       };
     });
 

--- a/services/repositories/entries-repository.ts
+++ b/services/repositories/entries-repository.ts
@@ -107,17 +107,10 @@ class EntriesRepository {
     ) as SharePointEntry[];
   }
 
-  async updateFields(entryId: number, fields: Partial<Pick<SharePointEntry, 'Checked' | 'Count' | 'Hours' | 'Notes'>>): Promise<void> {
+  async updateFields(entryId: number, fields: Partial<Pick<SharePointEntry, 'Checked' | 'Count' | 'Hours' | 'Notes' | 'AccompanyingAdultLookupId'>>): Promise<void> {
     await sharePointClient.updateListItem(this.listGuid, entryId, fields);
     sharePointClient.clearCacheKey('entries');
     sharePointClient.clearCacheByPrefix('sessions_FY');
-  }
-
-  // Narrow update for backfill only — only touches BookedBy and AccompanyingAdultLookupId.
-  // Never modifies Checked, Hours, Notes, Count, or other operational fields.
-  async updateBookingFields(entryId: number, fields: { BookedBy?: string; AccompanyingAdultLookupId?: number }): Promise<void> {
-    await sharePointClient.updateListItem(this.listGuid, entryId, fields);
-    sharePointClient.clearCacheKey('entries');
   }
 
   async create(fields: Record<string, any>): Promise<number> {

--- a/types/api-responses.ts
+++ b/types/api-responses.ts
@@ -168,6 +168,7 @@ export interface EntryResponse {
   hours: number;
   checkedIn: boolean;
   notes?: string;
+  accompanyingAdultId?: number;
 }
 
 export interface SessionDetailResponse {
@@ -223,6 +224,7 @@ export interface EntryDetailResponse {
   hours: number;
   checkedIn: boolean;
   notes?: string;
+  accompanyingAdultId?: number;
   date: string;
   groupKey?: string;
   groupName?: string;
@@ -264,6 +266,23 @@ export interface RecentSignupResponse {
   groupName: string;
   notes?: string;
   checkedIn: boolean;
+}
+
+export interface EntryListItemResponse {
+  id: number;
+  profileId?: number;
+  volunteerName?: string;
+  volunteerSlug?: string;
+  date: string;
+  groupKey: string;
+  groupName: string;
+  notes?: string;
+  checkedIn: boolean;
+  hours: number;
+  count: number;
+  isGroup: boolean;
+  hasAccompanyingAdult: boolean;
+  accompanyingAdultId?: number;
 }
 
 export interface TagHoursItem {


### PR DESCRIPTION
Admin-only Entries listing page (Vue) with notes search and AccompanyingAdult filter (empty/not-empty). Checkbox selection, in-place store update after edit (entry removed if no longer matches filter). EntryEditModal gains AccompanyingAdult dropdown (enabled when #Child in notes, disabled otherwise; clears on #Child removal) and optional profileClick/sessionClick callback props rendered as "View Profile" / "View Session" buttons. Entries page shows both; session detail shows profile only; profile detail shows session only. fetchSessionAdults utility fetches non-child adults from GET /api/sessions/:groupKey/:date for use across all three contexts. New GET /api/entries endpoint (admin-only) joins entries + sessions + groups + profiles, filters by q/accompanyingAdult, sorts by date DESC. accompanyingAdultId added to PATCH /api/entries/:id. EntryListItem refactored as a presentational component; EntryListResults owns all interaction (checkbox overlay, edit button) matching SessionListResults pattern. RecentEntryList updated to use EntryListItem.