### PR TITLE
#133 cancelled basics

### DIFF
--- a/frontend/src/components/EntryCard.vue
+++ b/frontend/src/components/EntryCard.vue
@@ -2,7 +2,7 @@
   <div class="ec-row">
 
     <!-- Card body -->
-    <div class="ec-card" :class="{ 'ec-card--checked': checkedIn }">
+    <div class="ec-card" :class="{ 'ec-card--checked': checkedIn, 'ec-card--cancelled': cancelled }">
       <div class="ec-card-left">
 
         <button v-if="allowEdit" class="ec-name ec-name--btn" @click="emit('editEntry')">
@@ -77,6 +77,7 @@ const props = defineProps<{
   allowEdit?: boolean
   allowCancel?: boolean
   working?: boolean
+  cancelled?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -208,6 +209,8 @@ function onHoursChange(input: HTMLInputElement) {
   gap: 0.5rem;
 }
 .ec-card--checked { border-left-color: var(--color-dtv-green); }
+.ec-card--cancelled { opacity: 0.5; }
+.ec-card--cancelled .ec-name { text-decoration: line-through; }
 
 .ec-card-left {
   flex: 1;

--- a/frontend/src/components/ModalLayout.vue
+++ b/frontend/src/components/ModalLayout.vue
@@ -19,7 +19,7 @@
       <div class="am-footer">
         <AppButton
           v-if="showDelete"
-          label="Delete"
+          :label="deleteText ?? 'Delete'"
           icon="delete"
           mode="icon-responsive"
           variant="danger"
@@ -60,6 +60,7 @@ const props = defineProps<{
   working?: boolean
   showDelete?: boolean
   deleteDisabled?: boolean
+  deleteText?: string
   error?: string
 }>()
 

--- a/frontend/src/components/RecentEntryList.vue
+++ b/frontend/src/components/RecentEntryList.vue
@@ -15,27 +15,146 @@
     <p v-else-if="!entries.length" class="rel-empty">No sign-ups in this period</p>
 
     <div v-else class="rel-list">
-      <EntryListItem
-        v-for="e in entries"
-        :key="e.id"
-        :entry="mapEntry(e)"
-        :to="sessionPath(e.groupKey, e.date)"
-      />
+      <template v-for="e in entries" :key="e.id">
+        <button v-if="isAdmin" class="rel-item-btn" @click="openModal(e)">
+          <EntryListItem :entry="mapEntry(e)" />
+        </button>
+        <EntryListItem v-else :entry="mapEntry(e)" :to="sessionPath(e.groupKey, e.date)" />
+      </template>
     </div>
+
+    <EntryEditModal
+      v-if="editingEntry"
+      :entry="editingEntry"
+      :is-cancelled="!!editingEntry.cancelled"
+      :is-admin="true"
+      :session-click="() => router.push(sessionPath(editingEntry!.session.groupKey, editingEntry!.session.date))"
+      :session-adults="sessionAdults"
+      :working="editWorking"
+      :error="editError"
+      @close="closeModal"
+      @save="onSave"
+      @delete="onDelete"
+    />
 
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
 import type { RecentSignupResponse, EntryListItemResponse } from '../../../types/api-responses'
+import type { EntryItem } from '../types/entry'
 import { sessionPath } from '../router/index'
 import EntryListItem from './entries/EntryListItem.vue'
+import EntryEditModal from '../pages/modals/EntryEditModal.vue'
+import { fetchSessionAdults } from '../utils/fetchSessionAdults'
 
+const props = defineProps<{ isAdmin?: boolean }>()
+
+const router = useRouter()
 const since = ref<string>('24h')
 const entries = ref<RecentSignupResponse[]>([])
 const loading = ref(false)
 const error = ref<string | null>(null)
+
+const editingEntry = ref<EntryItem | null>(null)
+const sessionAdults = ref<{ id: number; name: string }[]>([])
+const editWorking = ref(false)
+const editError = ref<string | undefined>()
+
+type EditData = { checkedIn: boolean; count: number; hours: number; notes: string; accompanyingAdultId: number | null }
+
+function mapToEntryItem(e: RecentSignupResponse): EntryItem {
+  return {
+    id: e.id,
+    checkedIn: e.checkedIn,
+    hours: e.hours,
+    count: e.count,
+    notes: e.notes,
+    accompanyingAdultId: e.accompanyingAdultId,
+    cancelled: e.cancelled,
+    profile: {
+      name: e.volunteerName,
+      slug: e.volunteerSlug,
+      isMember: false,
+      isGroup: false,
+    },
+    session: {
+      groupKey: e.groupKey,
+      groupName: e.groupName,
+      date: e.date,
+    },
+  }
+}
+
+async function openModal(e: RecentSignupResponse) {
+  editingEntry.value = mapToEntryItem(e)
+  sessionAdults.value = await fetchSessionAdults(e.groupKey, e.date)
+}
+
+function closeModal() {
+  editingEntry.value = null
+  sessionAdults.value = []
+  editWorking.value = false
+  editError.value = undefined
+}
+
+async function onSave(data: EditData) {
+  if (!editingEntry.value) return
+  editWorking.value = true
+  editError.value = undefined
+  try {
+    const res = await fetch(`/api/entries/${editingEntry.value.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+    if (!res.ok) throw new Error(`Save failed (${res.status})`)
+    const stored = entries.value.find(e => e.id === editingEntry.value!.id)
+    if (stored) {
+      stored.checkedIn = data.checkedIn
+      stored.hours = data.hours
+      stored.count = data.count
+      stored.notes = data.notes
+      stored.accompanyingAdultId = data.accompanyingAdultId ?? undefined
+    }
+    closeModal()
+  } catch (e) {
+    console.error('[RecentEntryList] save failed', e)
+    editError.value = 'Failed to save — please try again'
+    editWorking.value = false
+  }
+}
+
+async function onDelete() {
+  if (!editingEntry.value) return
+  editWorking.value = true
+  editError.value = undefined
+  const id = editingEntry.value.id
+  const isCancelled = !!editingEntry.value.cancelled
+  try {
+    if (isCancelled) {
+      const res = await fetch(`/api/entries/${id}`, { method: 'DELETE' })
+      if (!res.ok) throw new Error(`Delete failed (${res.status})`)
+      entries.value = entries.value.filter(e => e.id !== id)
+    } else {
+      const res = await fetch(`/api/entries/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ cancelled: true }),
+      })
+      if (!res.ok) throw new Error(`Cancel failed (${res.status})`)
+      const stored = entries.value.find(e => e.id === id)
+      if (stored) stored.cancelled = new Date().toISOString()
+    }
+    closeModal()
+  } catch (e) {
+    console.error('[RecentEntryList] delete/cancel failed', e)
+    editError.value = isCancelled ? 'Failed to delete — please try again' : 'Failed to cancel — please try again'
+    editWorking.value = false
+  }
+}
 
 function mapEntry(e: RecentSignupResponse): EntryListItemResponse {
   return {
@@ -51,6 +170,7 @@ function mapEntry(e: RecentSignupResponse): EntryListItemResponse {
     count: 1,
     isGroup: false,
     hasAccompanyingAdult: false,
+    cancelled: e.cancelled,
   }
 }
 
@@ -116,5 +236,15 @@ onMounted(load)
   display: flex;
   flex-direction: column;
   gap: 2px;
+}
+
+.rel-item-btn {
+  display: block;
+  width: 100%;
+  background: none;
+  border: none;
+  padding: 0;
+  text-align: left;
+  cursor: pointer;
 }
 </style>

--- a/frontend/src/components/entries/EntryListFilter.vue
+++ b/frontend/src/components/entries/EntryListFilter.vue
@@ -12,6 +12,11 @@
       <option value="notempty">Has Accompanying Adult</option>
       <option value="empty">No Accompanying Adult</option>
     </select>
+    <select v-model="cancelled" class="elf-select" @change="emitFiltered">
+      <option value="false">Not Cancelled</option>
+      <option value="all">Show All</option>
+      <option value="true">Cancelled</option>
+    </select>
   </div>
 </template>
 
@@ -22,6 +27,7 @@ import { useRoute, useRouter } from 'vue-router'
 export interface EntryFilterParams {
   q: string
   accompanyingAdult: string
+  cancelled: string
 }
 
 const emit = defineEmits<{ filtered: [params: EntryFilterParams] }>()
@@ -31,6 +37,7 @@ const router = useRouter()
 
 const q = ref((route.query.q as string) || '')
 const accompanyingAdult = ref((route.query.accompanyingAdult as string) || '')
+const cancelled = ref((route.query.cancelled as string) || 'false')
 
 let debounceTimer: ReturnType<typeof setTimeout> | null = null
 
@@ -40,15 +47,16 @@ function onTextInput() {
 }
 
 function emitFiltered() {
-  emit('filtered', { q: q.value, accompanyingAdult: accompanyingAdult.value })
+  emit('filtered', { q: q.value, accompanyingAdult: accompanyingAdult.value, cancelled: cancelled.value })
 }
 
 onMounted(() => emitFiltered())
 
-watch([q, accompanyingAdult], ([newQ, newAdult]) => {
+watch([q, accompanyingAdult, cancelled], ([newQ, newAdult, newCancelled]) => {
   const query: Record<string, string> = {}
-  if (newQ)    query.q                  = newQ
-  if (newAdult) query.accompanyingAdult = newAdult
+  if (newQ)       query.q                  = newQ
+  if (newAdult)   query.accompanyingAdult  = newAdult
+  if (newCancelled && newCancelled !== 'false') query.cancelled = newCancelled
   router.replace({ query })
 })
 </script>

--- a/frontend/src/components/entries/EntryListItem.vue
+++ b/frontend/src/components/entries/EntryListItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="eli-row" :class="{ 'eli-row--checked': entry.checkedIn, 'eli-row--selected': selected }">
+  <div class="eli-row" :class="{ 'eli-row--checked': entry.checkedIn, 'eli-row--selected': selected, 'eli-row--cancelled': !!entry.cancelled }">
     <component
       :is="to ? RouterLink : 'div'"
       v-bind="to ? { to } : {}"
@@ -57,6 +57,12 @@ function formatDate(date: string): string {
 }
 .eli-row--selected {
   background: var(--color-dtv-light);
+}
+.eli-row--cancelled {
+  opacity: 0.5;
+}
+.eli-row--cancelled .eli-name {
+  text-decoration: line-through;
 }
 
 .eli-content {

--- a/frontend/src/components/profiles/ProfileEntryList.vue
+++ b/frontend/src/components/profiles/ProfileEntryList.vue
@@ -39,6 +39,8 @@
       v-if="editingEntry"
       :entry="editingEntry"
       :title="cardTitle(editingEntry)"
+      :is-cancelled="!!editingEntry.cancelled"
+      :is-admin="isAdmin"
       :session-click="() => router.push(sessionPath(editingEntry!.session.groupKey, editingEntry!.session.date))"
       :session-adults="sessionAdults"
       :working="workingEdit"
@@ -67,12 +69,14 @@ type EditData = { checkedIn: boolean; count: number; hours: number; notes: strin
 const props = defineProps<{
   entries: EntryItem[]
   allowEdit?: boolean
+  isAdmin?: boolean
   workingId?: number | null
 }>()
 
 const emit = defineEmits<{
   update: [entry: EntryItem, checkedIn: boolean, hours: number]
   editEntry: [id: number, data: EditData | null]
+  cancelEntry: [id: number]
 }>()
 
 const router = useRouter()
@@ -170,12 +174,18 @@ function onDelete() {
   if (!editingEntry.value) return
   workingEdit.value = true
   editError.value = ''
-  emit('editEntry', editingEntry.value.id, null)
+  if (editingEntry.value.cancelled) {
+    emit('editEntry', editingEntry.value.id, null)
+  } else {
+    emit('cancelEntry', editingEntry.value.id)
+  }
 }
 
 defineExpose({
   onEditSuccess: closeEditModal,
   onEditError(msg: string) { workingEdit.value = false; editError.value = msg },
+  onCancelSuccess: closeEditModal,
+  onCancelError(msg: string) { workingEdit.value = false; editError.value = msg },
 })
 </script>
 

--- a/frontend/src/components/sessions/SessionDetailBook.vue
+++ b/frontend/src/components/sessions/SessionDetailBook.vue
@@ -5,9 +5,14 @@
       {{ daysToGo }} days to go
     </p>
 
-    <button class="bg-dtv-green text-white font-head text-lg uppercase tracking-wide py-4 px-8 self-center cursor-pointer hover:bg-dtv-green/80 transition-colors">
-      Book your spot
+    <button
+      class="bg-dtv-green text-white font-head text-lg uppercase tracking-wide py-4 px-8 self-center cursor-pointer hover:bg-dtv-green/80 transition-colors disabled:opacity-50 disabled:cursor-default"
+      :disabled="working"
+      @click="emit('book')"
+    >
+      {{ working ? 'Booking…' : 'Book your spot' }}
     </button>
+    <p v-if="error" class="text-red-600 text-sm text-center mt-2">{{ error }}</p>
 
     <div v-if="spacesLeft !== null" class="bg-dtv-dark text-white py-3 px-4 flex items-center justify-center self-end w-fit mr-12">
       <span class="font-head text-2xl leading-none">{{ spacesLeft }}</span>
@@ -25,7 +30,9 @@
 import { computed } from 'vue'
 import type { SessionDetailResponse } from '../../../../types/api-responses'
 
-const props = defineProps<{ session: SessionDetailResponse }>()
+const props = defineProps<{ session: SessionDetailResponse; working?: boolean; error?: string }>()
+
+const emit = defineEmits<{ book: [] }>()
 
 const spacesLeft = computed(() => props.session.limits.total !== undefined ? props.session.limits.total - props.session.registrations : null)
 

--- a/frontend/src/components/sessions/SessionDetailCancel.vue
+++ b/frontend/src/components/sessions/SessionDetailCancel.vue
@@ -1,0 +1,52 @@
+<template>
+  <div class="sdc-wrap">
+    <p class="sdc-status">You're booked on this session.</p>
+    <button
+      class="sdc-btn"
+      :disabled="working"
+      @click="emit('cancel')"
+    >
+      {{ working ? 'Cancelling…' : 'Remove booking' }}
+    </button>
+    <p v-if="error" class="sdc-error">{{ error }}</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+defineProps<{ working?: boolean; error?: string }>()
+const emit = defineEmits<{ cancel: [] }>()
+</script>
+
+<style scoped>
+.sdc-wrap {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.sdc-status {
+  font-size: 0.9rem;
+  color: var(--color-text-secondary);
+  margin: 0;
+}
+
+.sdc-btn {
+  background: var(--color-dtv-dirt);
+  color: var(--color-white);
+  border: none;
+  padding: 0.6rem 1.25rem;
+  font-family: inherit;
+  font-size: 0.95rem;
+  cursor: pointer;
+  align-self: flex-start;
+}
+.sdc-btn:hover:not(:disabled) { background: var(--color-dtv-dirt-dark, var(--color-dtv-dirt)); }
+.sdc-btn:disabled { opacity: 0.5; cursor: default; }
+
+.sdc-error {
+  font-size: 0.85rem;
+  color: var(--color-dtv-dirt);
+  margin: 0;
+}
+</style>

--- a/frontend/src/components/sessions/SessionEntryList.vue
+++ b/frontend/src/components/sessions/SessionEntryList.vue
@@ -5,7 +5,7 @@
     <div class="sel-header">
       <h2 class="sel-title">
         Check-ins
-        <span v-if="entries.length" class="sel-count">({{ checkedCount }} / {{ entries.length }})</span>
+        <span v-if="activeCount" class="sel-count">({{ checkedCount }} / {{ activeCount }})</span>
       </h2>
       <div v-if="allowEdit" class="sel-actions">
         <AppButton label="Refresh" icon="refresh" mode="icon-responsive" :working="refreshWorking" @click="emit('refreshRequest')" />
@@ -25,6 +25,7 @@
         :icons="iconsForEntry({ ...e.profile, notes: e.notes })"
         :allow-edit="allowEdit"
         :working="workingId === e.id"
+        :cancelled="!!e.cancelled"
         @update="(c, h) => emit('update', e, c, h)"
         @edit-entry="editingEntry = e"
       />
@@ -33,6 +34,8 @@
     <EntryEditModal
       v-if="editingEntry"
       :entry="editingEntry"
+      :is-cancelled="!!editingEntry.cancelled"
+      :is-admin="isAdmin"
       :profile-click="editingEntry.profile.slug ? () => router.push(profilePath(editingEntry!.profile.slug!)) : undefined"
       :session-adults="sessionAdults"
       :working="workingEdit"
@@ -84,6 +87,7 @@ type EditData = { checkedIn: boolean; count: number; hours: number; notes: strin
 const props = defineProps<{
   entries: EntryItem[]
   allowEdit: boolean
+  isAdmin?: boolean
   profiles: PickerProfile[]
   workingId?: number | null
   refreshWorking?: boolean
@@ -95,6 +99,7 @@ const emit = defineEmits<{
   setHours: [hours: number]
   addEntry: [payload: AddPayload]
   editEntry: [id: number, data: EditData | null]
+  cancelEntry: [id: number]
 }>()
 
 const editingEntry = ref<EntryItem | null>(null)
@@ -109,7 +114,8 @@ const setHoursError = ref('')
 
 const router = useRouter()
 
-const checkedCount = computed(() => props.entries.filter(e => e.checkedIn).length)
+const activeCount = computed(() => props.entries.filter(e => !e.cancelled).length)
+const checkedCount = computed(() => props.entries.filter(e => e.checkedIn && !e.cancelled).length)
 const eligibleCount = computed(() => props.entries.filter(e => e.checkedIn && !e.hours).length)
 const sessionAdults = computed(() =>
   props.entries
@@ -146,7 +152,13 @@ function onDelete() {
   if (!editingEntry.value) return
   workingEdit.value = true
   editError.value = ''
-  emit('editEntry', editingEntry.value.id, null)
+  if (editingEntry.value.cancelled) {
+    // Already cancelled — hard delete (admin only, enforced by backend)
+    emit('editEntry', editingEntry.value.id, null)
+  } else {
+    // Not yet cancelled — soft cancel
+    emit('cancelEntry', editingEntry.value.id)
+  }
 }
 
 function onAdd(payload: AddPayload) {
@@ -164,6 +176,8 @@ function onSetHours(hours: number) {
 defineExpose({
   onEditSuccess: closeEditModal,
   onEditError(msg: string) { workingEdit.value = false; editError.value = msg },
+  onCancelSuccess: closeEditModal,
+  onCancelError(msg: string) { workingEdit.value = false; editError.value = msg },
   onAddSuccess: closeAddModal,
   onAddError(msg: string) { workingAdd.value = false; addError.value = msg },
   onSetHoursSuccess: closeSetHoursModal,

--- a/frontend/src/pages/AdminPage.vue
+++ b/frontend/src/pages/AdminPage.vue
@@ -162,8 +162,8 @@ async function syncAttendees() {
     const res = await fetch('/api/eventbrite/sync-attendees', { method: 'POST' })
     const data = await res.json()
     if (!res.ok || !data.success) throw new Error(data.error || 'Sync failed')
-    const d = data.data
-    let msg = `${d.sessionsProcessed} sessions, ${d.newProfiles} new profiles, ${d.newEntries} new entries`
+    const d = data.data.attendees
+    let msg = `${d.sessionsProcessed} sessions, ${d.newProfiles} new profiles, ${d.newEntries} new entries, ${d.cancelledEntries ?? 0} cancelled`
     if (d.newRecords) msg += `, ${d.newRecords} consent records`
     attendeesResult.value = msg
   } catch (e: any) {

--- a/frontend/src/pages/EntriesPage.vue
+++ b/frontend/src/pages/EntriesPage.vue
@@ -153,7 +153,8 @@ async function onDelete() {
     if (isCancelled) {
       const res = await fetch(`/api/entries/${id}`, { method: 'DELETE' })
       if (!res.ok) throw new Error(`Delete failed (${res.status})`)
-      store.entries.splice(store.entries.findIndex(e => e.id === id), 1)
+      const delIdx = store.entries.findIndex(e => e.id === id)
+      if (delIdx >= 0) store.entries.splice(delIdx, 1)
       selected.value = selected.value.filter(sid => sid !== id)
     } else {
       const res = await fetch(`/api/entries/${id}`, {
@@ -166,7 +167,8 @@ async function onDelete() {
       if (stored) stored.cancelled = new Date().toISOString()
       // Remove from list if filter excludes cancelled entries
       if (currentFilter.value.cancelled === 'false' || !currentFilter.value.cancelled) {
-        store.entries.splice(store.entries.findIndex(e => e.id === id), 1)
+        const cancelIdx = store.entries.findIndex(e => e.id === id)
+        if (cancelIdx >= 0) store.entries.splice(cancelIdx, 1)
         selected.value = selected.value.filter(sid => sid !== id)
       }
     }

--- a/frontend/src/pages/EntriesPage.vue
+++ b/frontend/src/pages/EntriesPage.vue
@@ -18,6 +18,8 @@
     <EntryEditModal
       v-if="editingEntry"
       :entry="editingEntry"
+      :is-cancelled="!!editingEntry.cancelled"
+      :is-admin="viewer.isAdmin"
       :profile-click="editingEntry.profile.slug ? () => router.push(profilePath(editingEntry!.profile.slug!)) : undefined"
       :session-click="() => router.push(sessionPath(editingEntry!.session.groupKey, editingEntry!.session.date))"
       :session-adults="sessionAdults"
@@ -34,6 +36,7 @@
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { useEntryListStore } from '../stores/entryList'
+import { useViewer } from '../composables/useViewer'
 import type { EntryListItemResponse } from '../../../types/api-responses'
 import type { EntryItem } from '../types/entry'
 import type { EntryFilterParams } from '../components/entries/EntryListFilter.vue'
@@ -50,17 +53,18 @@ type EditData = { checkedIn: boolean; count: number; hours: number; notes: strin
 
 const store = useEntryListStore()
 const router = useRouter()
+const viewer = useViewer()
 
 const selected = ref<number[]>([])
 const editingEntry = ref<EntryItem | null>(null)
 const sessionAdults = ref<{ id: number; name: string }[]>([])
 const editWorking = ref(false)
 const editError = ref<string | undefined>()
-const currentFilter = ref<EntryFilterParams>({ q: '', accompanyingAdult: '' })
+const currentFilter = ref<EntryFilterParams>({ q: '', accompanyingAdult: '', cancelled: 'false' })
 
 function onFiltered(params: EntryFilterParams) {
   currentFilter.value = params
-  store.fetch(params)
+  store.fetch({ q: params.q, accompanyingAdult: params.accompanyingAdult, cancelled: params.cancelled })
 }
 
 function matchesFilter(entry: EntryListItemResponse, filter: EntryFilterParams): boolean {
@@ -79,6 +83,7 @@ function mapToEntryItem(e: EntryListItemResponse): EntryItem {
     count: e.count,
     notes: e.notes,
     accompanyingAdultId: e.accompanyingAdultId,
+    cancelled: e.cancelled,
     profile: {
       name: e.volunteerName ?? 'Unknown',
       slug: e.volunteerSlug,
@@ -142,15 +147,33 @@ async function onDelete() {
   if (!editingEntry.value) return
   editWorking.value = true
   editError.value = undefined
+  const id = editingEntry.value.id
+  const isCancelled = !!editingEntry.value.cancelled
   try {
-    const res = await fetch(`/api/entries/${editingEntry.value.id}`, { method: 'DELETE' })
-    if (!res.ok) throw new Error(`Delete failed (${res.status})`)
-    store.entries.splice(store.entries.findIndex(e => e.id === editingEntry.value!.id), 1)
-    selected.value = selected.value.filter(id => id !== editingEntry.value!.id)
+    if (isCancelled) {
+      const res = await fetch(`/api/entries/${id}`, { method: 'DELETE' })
+      if (!res.ok) throw new Error(`Delete failed (${res.status})`)
+      store.entries.splice(store.entries.findIndex(e => e.id === id), 1)
+      selected.value = selected.value.filter(sid => sid !== id)
+    } else {
+      const res = await fetch(`/api/entries/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ cancelled: true }),
+      })
+      if (!res.ok) throw new Error(`Cancel failed (${res.status})`)
+      const stored = store.entries.find(e => e.id === id)
+      if (stored) stored.cancelled = new Date().toISOString()
+      // Remove from list if filter excludes cancelled entries
+      if (currentFilter.value.cancelled === 'false' || !currentFilter.value.cancelled) {
+        store.entries.splice(store.entries.findIndex(e => e.id === id), 1)
+        selected.value = selected.value.filter(sid => sid !== id)
+      }
+    }
     closeEditModal()
   } catch (e) {
-    console.error('[EntriesPage] delete failed', e)
-    editError.value = 'Failed to delete — please try again'
+    console.error('[EntriesPage] delete/cancel failed', e)
+    editError.value = isCancelled ? 'Failed to delete — please try again' : 'Failed to cancel — please try again'
     editWorking.value = false
   }
 }

--- a/frontend/src/pages/HomePage.vue
+++ b/frontend/src/pages/HomePage.vue
@@ -113,7 +113,7 @@
     <!-- Recent sign-ups — admin/check-in only -->
     <section v-if="profile.isOperational" class="mb-8">
       <SectionHeader>Recent Sign-ups</SectionHeader>
-      <RecentEntryList />
+      <RecentEntryList :is-admin="profile.isAdmin" />
     </section>
 
     <DebugData label="homepage personal context" :item="{

--- a/frontend/src/pages/ProfileDetailPage.vue
+++ b/frontend/src/pages/ProfileDetailPage.vue
@@ -103,6 +103,36 @@
         </template>
       </LayoutColumns>
 
+      <LayoutColumns v-if="viewer.isAdmin && !store.profile.isGroup && childEntries.length" ratio="1">
+        <template #header><SectionHeader>Accompanying Adult</SectionHeader></template>
+        <template #left>
+          <div class="pd-child-list">
+            <button
+              v-for="e in childEntries"
+              :key="e.id"
+              class="pd-child-btn"
+              @click="openChildEditModal(e)"
+            >
+              <EntryListItem :entry="e" />
+            </button>
+          </div>
+        </template>
+      </LayoutColumns>
+
+      <EntryEditModal
+        v-if="childEditingEntry"
+        :entry="childEditingEntry"
+        :title="childEditingEntry.profile.name"
+        :profile-click="childEditingEntry.profile.slug ? () => router.push(profilePath(childEditingEntry!.profile.slug!)) : undefined"
+        :session-click="() => router.push(sessionPath(childEditingEntry!.session.groupKey, childEditingEntry!.session.date))"
+        :session-adults="childSessionAdults"
+        :working="childEditWorking"
+        :error="childEditError"
+        @close="closeChildEditModal"
+        @save="onChildSave"
+        @delete="onChildDelete"
+      />
+
       <DebugData :item="store.profile" label="pageProfile" />
       <DebugData :item="viewer.context" label="userProfile" />
     </template>
@@ -126,17 +156,20 @@ import ProfileDuplicateWarning from '../components/profiles/ProfileDuplicateWarn
 import ProfileLinkedAccounts from '../components/profiles/ProfileLinkedAccounts.vue'
 import ProfileRecordList from '../components/profiles/ProfileRecordList.vue'
 import RegularList from '../components/RegularList.vue'
+import EntryListItem from '../components/entries/EntryListItem.vue'
+import EntryEditModal from './modals/EntryEditModal.vue'
 import type { RegularListItem } from '../components/RegularList.vue'
 import { useViewer } from '../composables/useViewer'
 import { usePageTitle } from '../composables/usePageTitle'
 import { useProfileDetailStore } from '../stores/profileDetail'
-import { groupPath, profilePath, profilesPath } from '../router/index'
-import type { ProfileEntryResponse } from '../../../types/api-responses'
+import { groupPath, profilePath, profilesPath, sessionPath } from '../router/index'
+import type { ProfileEntryResponse, EntryListItemResponse } from '../../../types/api-responses'
 import type { EditProfilePayload } from './modals/ProfileEditModal.vue'
 import type { TransferProfilePayload } from './modals/ProfileTransferModal.vue'
 import type { AddRecordPayload } from './modals/RecordAddModal.vue'
 import type { SaveRecordPayload } from './modals/RecordEditModal.vue'
 import type { EntryItem } from '../types/entry'
+import { fetchSessionAdults } from '../utils/fetchSessionAdults'
 import type { PickerProfile } from '../components/ProfilePicker.vue'
 import LayoutColumns from '../components/LayoutColumns.vue'
 import SectionHeader from '../components/SectionHeader.vue'
@@ -167,6 +200,13 @@ const recordStatuses = ref<string[]>([])
 usePageTitle(computed(() => store.profile?.name ?? 'Profile'))
 const entryListRef = ref<InstanceType<typeof ProfileEntryList> | null>(null)
 
+// Child entries (this profile as accompanying adult) — admin only
+const childEntries = ref<EntryListItemResponse[]>([])
+const childEditingEntry = ref<EntryItem | null>(null)
+const childSessionAdults = ref<{ id: number; name: string }[]>([])
+const childEditWorking = ref(false)
+const childEditError = ref<string | undefined>()
+
 // Lazily loaded profiles for transfer picker
 const transferProfiles = ref<PickerProfile[]>([])
 
@@ -184,6 +224,21 @@ onMounted(async () => {
   }
 })
 watch(() => route.params.slug, slug => { if (slug) store.fetch(slug as string) })
+
+watch(
+  [() => store.profile, () => viewer.isAdmin],
+  async ([profile, isAdmin]) => {
+    if (!isAdmin || !profile || profile.isGroup) { childEntries.value = []; return }
+    try {
+      const res = await fetch(`/api/entries?accompanyingAdultId=${profile.id}`)
+      if (!res.ok) throw new Error(`Fetch failed (${res.status})`)
+      const json = await res.json()
+      childEntries.value = json.data ?? []
+    } catch (e) {
+      console.error('[ProfileDetailPage] Failed to load child entries', e)
+    }
+  }
+)
 
 const isMember = computed(() =>
   store.profile?.records?.some(r => r.type === 'Charity Membership' && r.status === 'Accepted') ?? false
@@ -368,6 +423,7 @@ function mapProfileEntry(e: ProfileEntryResponse): EntryItem {
     hours: e.hours,
     count: e.count,
     notes: e.notes,
+    accompanyingAdultId: e.accompanyingAdultId,
     profile: {
       name: store.profile?.name ?? 'Unknown',
       slug: store.profile?.slug,
@@ -434,6 +490,85 @@ async function onEditEntry(id: number, data: EditData | null) {
     entryListRef.value?.onEditError('Failed to save — please try again')
   }
 }
+
+function mapChildEntryToItem(e: EntryListItemResponse): EntryItem {
+  return {
+    id: e.id,
+    profileId: e.profileId,
+    checkedIn: e.checkedIn,
+    hours: e.hours,
+    count: e.count,
+    notes: e.notes,
+    accompanyingAdultId: e.accompanyingAdultId,
+    profile: {
+      name: e.volunteerName ?? 'Unknown',
+      slug: e.volunteerSlug,
+      isMember: false,
+      isGroup: e.isGroup,
+    },
+    session: {
+      groupKey: e.groupKey,
+      groupName: e.groupName,
+      date: e.date,
+    },
+  }
+}
+
+async function openChildEditModal(e: EntryListItemResponse) {
+  childEditingEntry.value = mapChildEntryToItem(e)
+  childSessionAdults.value = await fetchSessionAdults(e.groupKey, e.date)
+}
+
+function closeChildEditModal() {
+  childEditingEntry.value = null
+  childSessionAdults.value = []
+  childEditWorking.value = false
+  childEditError.value = undefined
+}
+
+async function onChildSave(data: { checkedIn: boolean; count: number; hours: number; notes: string; accompanyingAdultId: number | null }) {
+  if (!childEditingEntry.value) return
+  childEditWorking.value = true
+  childEditError.value = undefined
+  try {
+    const res = await fetch(`/api/entries/${childEditingEntry.value.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+    if (!res.ok) throw new Error(`Save failed (${res.status})`)
+    const stored = childEntries.value.find(e => e.id === childEditingEntry.value!.id)
+    if (stored) {
+      stored.checkedIn = data.checkedIn
+      stored.hours = data.hours
+      stored.count = data.count
+      stored.notes = data.notes
+      stored.accompanyingAdultId = data.accompanyingAdultId ?? undefined
+      stored.hasAccompanyingAdult = data.accompanyingAdultId !== null
+    }
+    closeChildEditModal()
+  } catch (e) {
+    console.error('[ProfileDetailPage] onChildSave failed', e)
+    childEditError.value = 'Failed to save — please try again'
+    childEditWorking.value = false
+  }
+}
+
+async function onChildDelete() {
+  if (!childEditingEntry.value) return
+  childEditWorking.value = true
+  childEditError.value = undefined
+  try {
+    const res = await fetch(`/api/entries/${childEditingEntry.value.id}`, { method: 'DELETE' })
+    if (!res.ok) throw new Error(`Delete failed (${res.status})`)
+    childEntries.value = childEntries.value.filter(e => e.id !== childEditingEntry.value!.id)
+    closeChildEditModal()
+  } catch (e) {
+    console.error('[ProfileDetailPage] onChildDelete failed', e)
+    childEditError.value = 'Failed to delete — please try again'
+    childEditWorking.value = false
+  }
+}
 </script>
 
 <style scoped>
@@ -473,5 +608,22 @@ async function onEditEntry(id: number, data: EditData | null) {
 .pd-task-link {
   color: var(--color-dtv-green-dark);
   opacity: 1;
+}
+
+.pd-child-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  background: var(--color-dtv-sand-light);
+}
+
+.pd-child-btn {
+  display: block;
+  width: 100%;
+  background: none;
+  border: none;
+  padding: 0;
+  text-align: left;
+  cursor: pointer;
 }
 </style>

--- a/frontend/src/pages/ProfileDetailPage.vue
+++ b/frontend/src/pages/ProfileDetailPage.vue
@@ -95,10 +95,12 @@
           <ProfileEntryList
             :entries="entries"
             :allow-edit="viewer.isOperational"
+            :is-admin="viewer.isAdmin"
             :working-id="workingId"
             ref="entryListRef"
             @update="onEntryUpdate"
             @edit-entry="onEditEntry"
+            @cancel-entry="onCancelEntry"
           />
         </template>
       </LayoutColumns>
@@ -123,6 +125,8 @@
         v-if="childEditingEntry"
         :entry="childEditingEntry"
         :title="childEditingEntry.profile.name"
+        :is-cancelled="!!childEditingEntry.cancelled"
+        :is-admin="viewer.isAdmin"
         :profile-click="childEditingEntry.profile.slug ? () => router.push(profilePath(childEditingEntry!.profile.slug!)) : undefined"
         :session-click="() => router.push(sessionPath(childEditingEntry!.session.groupKey, childEditingEntry!.session.date))"
         :session-adults="childSessionAdults"
@@ -424,6 +428,7 @@ function mapProfileEntry(e: ProfileEntryResponse): EntryItem {
     count: e.count,
     notes: e.notes,
     accompanyingAdultId: e.accompanyingAdultId,
+    cancelled: e.cancelled,
     profile: {
       name: store.profile?.name ?? 'Unknown',
       slug: store.profile?.slug,
@@ -491,6 +496,23 @@ async function onEditEntry(id: number, data: EditData | null) {
   }
 }
 
+async function onCancelEntry(id: number) {
+  try {
+    const res = await fetch(`/api/entries/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ cancelled: true }),
+    })
+    if (!res.ok) throw new Error(`Cancel failed (${res.status})`)
+    const stored = store.profile?.entries.find(e => e.id === id)
+    if (stored) stored.cancelled = new Date().toISOString()
+    entryListRef.value?.onCancelSuccess()
+  } catch (e) {
+    console.error('[ProfileDetailPage] onCancelEntry failed', e)
+    entryListRef.value?.onCancelError('Failed to cancel — please try again')
+  }
+}
+
 function mapChildEntryToItem(e: EntryListItemResponse): EntryItem {
   return {
     id: e.id,
@@ -500,6 +522,7 @@ function mapChildEntryToItem(e: EntryListItemResponse): EntryItem {
     count: e.count,
     notes: e.notes,
     accompanyingAdultId: e.accompanyingAdultId,
+    cancelled: e.cancelled,
     profile: {
       name: e.volunteerName ?? 'Unknown',
       slug: e.volunteerSlug,
@@ -558,14 +581,27 @@ async function onChildDelete() {
   if (!childEditingEntry.value) return
   childEditWorking.value = true
   childEditError.value = undefined
+  const id = childEditingEntry.value.id
+  const isCancelled = !!childEditingEntry.value.cancelled
   try {
-    const res = await fetch(`/api/entries/${childEditingEntry.value.id}`, { method: 'DELETE' })
-    if (!res.ok) throw new Error(`Delete failed (${res.status})`)
-    childEntries.value = childEntries.value.filter(e => e.id !== childEditingEntry.value!.id)
+    if (isCancelled) {
+      const res = await fetch(`/api/entries/${id}`, { method: 'DELETE' })
+      if (!res.ok) throw new Error(`Delete failed (${res.status})`)
+      childEntries.value = childEntries.value.filter(e => e.id !== id)
+    } else {
+      const res = await fetch(`/api/entries/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ cancelled: true }),
+      })
+      if (!res.ok) throw new Error(`Cancel failed (${res.status})`)
+      const stored = childEntries.value.find(e => e.id === id)
+      if (stored) stored.cancelled = new Date().toISOString()
+    }
     closeChildEditModal()
   } catch (e) {
     console.error('[ProfileDetailPage] onChildDelete failed', e)
-    childEditError.value = 'Failed to delete — please try again'
+    childEditError.value = isCancelled ? 'Failed to delete — please try again' : 'Failed to cancel — please try again'
     childEditWorking.value = false
   }
 }

--- a/frontend/src/pages/SessionDetailPage.vue
+++ b/frontend/src/pages/SessionDetailPage.vue
@@ -32,10 +32,11 @@
         <template #right>
           <MediaCard v-if="coverItem" :item="coverItem" constrain="width" />
           <ConcertinaLayout>
-            <ConcertinaItem label="Book" v-if="store.session.isBookable && !store.session.isRegistered" >
-              <SessionDetailBook :session="store.session" />
+            <ConcertinaItem label="Book" v-if="store.session.isBookable && !store.session.isRegistered">
+              <SessionDetailBook :session="store.session" :working="bookWorking" :error="bookError" @book="onBook" />
             </ConcertinaItem>
             <ConcertinaItem label="Cancel" v-if="store.session.isBookable && store.session.isRegistered">
+              <SessionDetailCancel :working="cancelWorking" :error="cancelError" @cancel="onCancel" />
             </ConcertinaItem>
 
           </ConcertinaLayout>
@@ -170,6 +171,7 @@
             ref="entryListRef"
             :entries="entries"
             :allow-edit="profile.isOperational"
+            :is-admin="profile.isAdmin"
             :profiles="profiles"
             :working-id="workingId"
             :refresh-working="refreshWorking"
@@ -178,6 +180,7 @@
             @set-hours="onSetHours"
             @add-entry="onAddEntry"
             @edit-entry="onEditEntry"
+            @cancel-entry="onCancelEntry"
           />
         </template>
       </LayoutColumns>
@@ -211,6 +214,7 @@ import { groupPath, sessionPath } from '../router/index'
 import PageHeader from '../components/PageHeader.vue'
 import LoadingSpinner from '../components/LoadingSpinner.vue'
 import SessionDetailBook from '../components/sessions/SessionDetailBook.vue'
+import SessionDetailCancel from '../components/sessions/SessionDetailCancel.vue'
 import MediaCard from '../components/MediaCard.vue'
 import SessionDetailHeader from '../components/sessions/SessionDetailHeader.vue'
 import SessionDetailStats from '../components/sessions/SessionDetailStats.vue'
@@ -246,6 +250,10 @@ const coverItem    = computed<MediaItem | null>(() =>
 const profiles = ref<PickerProfile[]>([])
 const workingId = ref<number | null>(null)
 const refreshWorking = ref(false)
+const bookWorking = ref(false)
+const bookError = ref<string | undefined>()
+const cancelWorking = ref(false)
+const cancelError = ref<string | undefined>()
 const entryListRef = ref<InstanceType<typeof SessionEntryList> | null>(null)
 const tagWorking = ref(false)
 const tagError = ref<string | undefined>()
@@ -260,6 +268,7 @@ function mapEntry(e: EntryResponse): EntryItem {
     count: e.count,
     notes: e.notes,
     accompanyingAdultId: e.accompanyingAdultId,
+    cancelled: e.cancelled,
     profile: {
       name: e.profileName ?? e.volunteerName ?? 'Unknown',
       slug: e.profileSlug ?? e.volunteerSlug,
@@ -275,7 +284,16 @@ function mapEntry(e: EntryResponse): EntryItem {
   }
 }
 
-const entries = computed<EntryItem[]>(() => (store.session?.entries ?? []).map(mapEntry))
+const entries = computed<EntryItem[]>(() => {
+  const mapped = (store.session?.entries ?? []).map(mapEntry)
+  return mapped.sort((a, b) => {
+    const aCancelled = !!a.cancelled
+    const bCancelled = !!b.cancelled
+    if (aCancelled !== bCancelled) return aCancelled ? 1 : -1
+    if (aCancelled && bCancelled) return (a.cancelled! < b.cancelled! ? -1 : 1)
+    return 0
+  })
+})
 
 function formatDate(dateStr: string): string {
   return new Date(dateStr).toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' })
@@ -429,6 +447,67 @@ async function onEditEntry(id: number, data: EditData | null) {
   } catch (e) {
     console.error('[SessionDetailPage] onEditEntry failed', e)
     entryListRef.value?.onEditError('Failed to save — please try again')
+  }
+}
+
+async function onCancelEntry(id: number) {
+  try {
+    const res = await fetch(`/api/entries/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ cancelled: true }),
+    })
+    if (!res.ok) throw new Error(`Cancel failed (${res.status})`)
+    const stored = store.session?.entries.find(e => e.id === id)
+    if (stored) stored.cancelled = new Date().toISOString()
+    entryListRef.value?.onCancelSuccess()
+  } catch (e) {
+    console.error('[SessionDetailPage] onCancelEntry failed', e)
+    entryListRef.value?.onCancelError('Failed to cancel — please try again')
+  }
+}
+
+async function onBook() {
+  if (!store.session?.userProfileId) return
+  const groupKey = route.params.groupKey as string
+  const date = store.session.date
+  bookWorking.value = true
+  bookError.value = undefined
+  try {
+    const res = await fetch(`/api/sessions/${groupKey}/${date}/entries`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ profileId: store.session.userProfileId }),
+    })
+    if (!res.ok) throw new Error(`Book failed (${res.status})`)
+    await store.fetch(groupKey, date)
+  } catch (e) {
+    console.error('[SessionDetailPage] onBook failed', e)
+    bookError.value = 'Failed to book — please try again'
+  } finally {
+    bookWorking.value = false
+  }
+}
+
+async function onCancel() {
+  if (!store.session?.userEntryId) return
+  const groupKey = route.params.groupKey as string
+  const date = store.session.date
+  cancelWorking.value = true
+  cancelError.value = undefined
+  try {
+    const res = await fetch(`/api/entries/${store.session.userEntryId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ cancelled: true }),
+    })
+    if (!res.ok) throw new Error(`Cancel failed (${res.status})`)
+    await store.fetch(groupKey, date)
+  } catch (e) {
+    console.error('[SessionDetailPage] onCancel failed', e)
+    cancelError.value = 'Failed to cancel — please try again'
+  } finally {
+    cancelWorking.value = false
   }
 }
 

--- a/frontend/src/pages/modals/EntryEditModal.vue
+++ b/frontend/src/pages/modals/EntryEditModal.vue
@@ -3,13 +3,18 @@
     :title="title ?? entry.profile.name"
     action="Save"
     action-icon="save"
-    show-delete
+    :show-delete="!isCancelled || isAdmin"
+    :delete-text="isCancelled ? 'Delete' : 'Cancel'"
     :working="working"
     :error="error"
     @close="emit('close')"
     @action="save"
-    @delete="confirmDelete = true"
+    @delete="isCancelled ? (confirmDelete = true) : emit('delete')"
   >
+    <div v-if="entry.cancelled" class="eem-cancelled">
+      Cancelled {{ formatCancelled(entry.cancelled) }}
+    </div>
+
     <div v-if="profileClick || sessionClick" class="eem-actions">
       <AppButton v-if="profileClick" label="View Profile" icon="profile" @click="profileClick!()" />
       <AppButton v-if="sessionClick" label="View Session" icon="register" @click="sessionClick!()" />
@@ -70,6 +75,8 @@ const props = defineProps<{
   working: boolean
   error?: string
   title?: string
+  isCancelled?: boolean
+  isAdmin?: boolean
   profileClick?: () => void
   sessionClick?: () => void
   sessionAdults?: { id: number; name: string }[]
@@ -105,6 +112,10 @@ watch(hasChild, (val) => {
   if (!val) form.accompanyingAdultId = null
 })
 
+function formatCancelled(iso: string): string {
+  return new Date(iso).toLocaleString('en-GB', { day: 'numeric', month: 'short', year: 'numeric', hour: '2-digit', minute: '2-digit' })
+}
+
 function save() {
   emit('save', {
     checkedIn: form.checkedIn,
@@ -122,6 +133,15 @@ function deleteEntry() {
 </script>
 
 <style scoped>
+.eem-cancelled {
+  background: var(--color-dtv-dirt-light);
+  color: var(--color-dtv-dirt-dark, var(--color-dtv-dirt));
+  padding: 0.5rem 0.75rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  margin-bottom: 1.25rem;
+}
+
 .eem-actions {
   display: flex;
   gap: 0.5rem;

--- a/frontend/src/pages/modals/EntryEditModal.vue
+++ b/frontend/src/pages/modals/EntryEditModal.vue
@@ -48,6 +48,7 @@
           <option :value="null">Select adult…</option>
           <option v-for="a in sessionAdults" :key="a.id" :value="a.id">{{ a.name }}</option>
         </select>
+        <p v-if="accompanyingAdultMissing" class="eem-adult-warning">Not registered at this session</p>
       </FormRow>
     </FormLayout>
   </ModalLayout>
@@ -99,6 +100,13 @@ const form = reactive({
 })
 
 const hasChild = computed(() => /\#child\b/i.test(form.notes))
+
+const accompanyingAdultMissing = computed(() =>
+  hasChild.value &&
+  form.accompanyingAdultId !== null &&
+  !!props.sessionAdults &&
+  !props.sessionAdults.some(a => a.id === form.accompanyingAdultId)
+)
 
 watch(() => props.entry, (e) => {
   form.checkedIn = e.checkedIn
@@ -188,4 +196,10 @@ function deleteEntry() {
 }
 .eem-select:disabled { color: var(--color-text-muted); }
 .eem-select--placeholder { color: var(--color-text-muted); }
+
+.eem-adult-warning {
+  margin-top: 0.25rem;
+  font-size: 0.8rem;
+  color: var(--color-dtv-dirt);
+}
 </style>

--- a/frontend/src/stores/entryList.ts
+++ b/frontend/src/stores/entryList.ts
@@ -7,13 +7,14 @@ export const useEntryListStore = defineStore('entryList', () => {
   const loading = ref(false)
   const error = ref<string | null>(null)
 
-  async function fetch(params: { q?: string; accompanyingAdult?: string } = {}) {
+  async function fetch(params: { q?: string; accompanyingAdult?: string; cancelled?: string } = {}) {
     loading.value = true
     error.value = null
     try {
       const query = new URLSearchParams()
       if (params.q) query.set('q', params.q)
       if (params.accompanyingAdult) query.set('accompanyingAdult', params.accompanyingAdult)
+      if (params.cancelled) query.set('cancelled', params.cancelled)
       const qs = query.toString()
       const res = await window.fetch(`/api/entries${qs ? `?${qs}` : ''}`)
       if (!res.ok) {

--- a/frontend/src/types/entry.ts
+++ b/frontend/src/types/entry.ts
@@ -20,6 +20,7 @@ export interface EntryItem {
   count: number
   notes?: string
   accompanyingAdultId?: number
+  cancelled?: string // ISO datetime if booking was cancelled
   profile: EntryProfileSummary
   session: EntrySessionSummary
 }

--- a/routes/entries.ts
+++ b/routes/entries.ts
@@ -137,6 +137,7 @@ router.get('/entries', async (req: Request, res: Response) => {
   try {
     const q = req.query.q ? String(req.query.q).toLowerCase() : '';
     const accompanyingAdult = req.query.accompanyingAdult ? String(req.query.accompanyingAdult) : '';
+    const filterAdultId = req.query.accompanyingAdultId ? parseInt(String(req.query.accompanyingAdultId), 10) : null;
 
     const [rawEntries, rawSessions, rawGroups, rawProfiles] = await Promise.all([
       entriesRepository.getAll(),
@@ -167,6 +168,7 @@ router.get('/entries', async (req: Request, res: Response) => {
         const hasAdult = !!e.AccompanyingAdultLookupId;
         if (accompanyingAdult === 'empty' && hasAdult) return [];
         if (accompanyingAdult === 'notempty' && !hasAdult) return [];
+        if (filterAdultId !== null && Number(e.AccompanyingAdultLookupId) !== filterAdultId) return [];
 
         const profileId = safeParseLookupId(e[PROFILE_LOOKUP]);
         const profile = profileId !== undefined ? profileMap.get(profileId) : undefined;

--- a/routes/entries.ts
+++ b/routes/entries.ts
@@ -28,7 +28,8 @@ import {
   GROUP_LOOKUP,
   SESSION_LOOKUP,
   SESSION_STATS,
-  PROFILE_LOOKUP, PROFILE_DISPLAY
+  PROFILE_LOOKUP, PROFILE_DISPLAY,
+  ENTRY_CANCELLED
 } from '../services/field-names';
 import { getAttendees } from '../services/eventbrite-client';
 
@@ -85,8 +86,10 @@ router.get('/entries/recent', async (req: Request, res: Response) => {
     const hours = hoursMap[since] ?? 24;
     const cutoff = new Date(Date.now() - hours * 60 * 60 * 1000);
 
-    const [rawEntries, rawSessions, rawGroups] = await Promise.all([
+    // Fetch both recently created entries and recently cancelled entries in parallel
+    const [rawRecent, rawCancelled, rawSessions, rawGroups] = await Promise.all([
       entriesRepository.getRecent(cutoff),
+      entriesRepository.getRecentlyCancelled(cutoff),
       sessionsRepository.getAll(),
       groupsRepository.getAll()
     ]);
@@ -94,11 +97,25 @@ router.get('/entries/recent', async (req: Request, res: Response) => {
     const sessionMap = new Map(rawSessions.map(s => [s.ID, s]));
     const groupMap = new Map(rawGroups.map(g => [g.ID, g]));
 
-    const entries = validateArray(rawEntries, validateEntry, 'Entry');
+    // Merge, deduplicate by ID (an entry could appear in both if cancelled after being recently created)
+    const seenIds = new Set<number>();
+    const allRaw = [...rawRecent, ...rawCancelled].filter(e => {
+      if (seenIds.has(e.ID)) return false;
+      seenIds.add(e.ID);
+      return true;
+    });
+
+    const entries = validateArray(allRaw, validateEntry, 'Entry');
+
+    function sortKey(e: typeof entries[0]): number {
+      // Cancelled entries sort by Cancelled date; new sign-ups sort by Created date
+      const ts = e.Cancelled ? new Date(e.Cancelled).getTime() : new Date(e.Created).getTime();
+      return ts;
+    }
 
     const recent: RecentSignupResponse[] = entries
-      .filter(e => !/#Regular\b/i.test(e.Notes || ''))
-      .sort((a, b) => new Date(b.Created).getTime() - new Date(a.Created).getTime())
+      .filter(e => e[ENTRY_CANCELLED] || !/#Regular\b/i.test(e.Notes || ''))
+      .sort((a, b) => sortKey(b) - sortKey(a))
       .slice(0, 50)
       .flatMap(e => {
         const sessionId = safeParseLookupId(e[SESSION_LOOKUP]);
@@ -122,7 +139,11 @@ router.get('/entries/recent', async (req: Request, res: Response) => {
           groupKey: group.Title,
           groupName: group.Name || group.Title,
           notes: e.Notes,
-          checkedIn: e.Checked || false
+          checkedIn: e.Checked || false,
+          hours: parseHours(e.Hours),
+          count: e.Count || 1,
+          accompanyingAdultId: e.AccompanyingAdultLookupId,
+          cancelled: e.Cancelled || undefined
         }];
       });
 
@@ -138,6 +159,8 @@ router.get('/entries', async (req: Request, res: Response) => {
     const q = req.query.q ? String(req.query.q).toLowerCase() : '';
     const accompanyingAdult = req.query.accompanyingAdult ? String(req.query.accompanyingAdult) : '';
     const filterAdultId = req.query.accompanyingAdultId ? parseInt(String(req.query.accompanyingAdultId), 10) : null;
+    // cancelled filter: 'true' = only cancelled, 'false'/'omitted' = only active, 'all' = both
+    const cancelledFilter = req.query.cancelled ? String(req.query.cancelled) : 'false';
 
     const [rawEntries, rawSessions, rawGroups, rawProfiles] = await Promise.all([
       entriesRepository.getAll(),
@@ -162,6 +185,11 @@ router.get('/entries', async (req: Request, res: Response) => {
         if (groupId === undefined) return [];
         const group = groupMap.get(groupId);
         if (!group) return [];
+
+        // Apply cancelled filter
+        const isCancelled = !!e.Cancelled;
+        if (cancelledFilter === 'false' && isCancelled) return [];
+        if (cancelledFilter === 'true' && !isCancelled) return [];
 
         if (q && !String(e.Notes || '').toLowerCase().includes(q)) return [];
 
@@ -189,7 +217,8 @@ router.get('/entries', async (req: Request, res: Response) => {
           count: e.Count || 1,
           isGroup: profile?.IsGroup || false,
           hasAccompanyingAdult: hasAdult,
-          accompanyingAdultId: e.AccompanyingAdultLookupId
+          accompanyingAdultId: e.AccompanyingAdultLookupId,
+          cancelled: e.Cancelled || undefined
         }];
       })
       .sort((a, b) => b.date.localeCompare(a.date));
@@ -436,8 +465,37 @@ router.patch('/entries/:id', async (req: Request, res: Response) => {
       return;
     }
 
-    const { checkedIn, count, hours, notes, accompanyingAdultId } = req.body;
+    const { checkedIn, count, hours, notes, accompanyingAdultId, cancelled } = req.body;
     const fields: Record<string, any> = {};
+
+    if (typeof cancelled === 'boolean') {
+      if (cancelled) {
+        // Set Cancelled only if not already set — preserve original cancellation date
+        const existing = await entriesRepository.getById(entryId);
+        if (!existing) {
+          res.status(404).json({ success: false, error: 'Entry not found' });
+          return;
+        }
+        // Self-service and check-in can only cancel (not un-cancel)
+        const role = req.session.user?.role;
+        if (!cancelled && role !== 'admin') {
+          res.status(403).json({ success: false, error: 'Only admins can un-cancel an entry' });
+          return;
+        }
+        if (!existing[ENTRY_CANCELLED]) {
+          fields[ENTRY_CANCELLED] = new Date().toISOString();
+        }
+        // If already cancelled, no-op (preserve original date) — still returns 200
+      } else {
+        // cancelled: false — clear the Cancelled field (admin only)
+        const role = req.session.user?.role;
+        if (role !== 'admin') {
+          res.status(403).json({ success: false, error: 'Only admins can un-cancel an entry' });
+          return;
+        }
+        fields[ENTRY_CANCELLED] = null;
+      }
+    }
 
     if (typeof checkedIn === 'boolean') {
       fields.Checked = checkedIn;
@@ -497,8 +555,8 @@ router.patch('/entries/:id', async (req: Request, res: Response) => {
         console.error(`[Stats] Failed targeted update for session ${sessionId}:`, err)
       );
     }
-    // Only hours changes affect profile stats (isMember/cardStatus are unaffected by entry updates)
-    if (profileId !== undefined && fields.Hours !== undefined) {
+    // Hours changes and cancellations affect profile stats
+    if (profileId !== undefined && (fields.Hours !== undefined || fields[ENTRY_CANCELLED] !== undefined)) {
       computeAndSaveProfileStats(profileId).catch(err =>
         console.error(`[Stats] Failed targeted profile update for profile ${profileId}:`, err)
       );
@@ -530,14 +588,15 @@ router.delete('/entries/:id', async (req: Request, res: Response) => {
       return;
     }
 
-    // Self-service users may only delete their own entry (supports multiple linked profiles)
-    if (req.session.user?.role === 'selfservice') {
-      const profileId = safeParseLookupId(entry[PROFILE_LOOKUP]);
-      const ownIds = req.session.user.profileIds?.length ? req.session.user.profileIds : (req.session.user.profileId ? [req.session.user.profileId] : []);
-      if (profileId === undefined || !ownIds.includes(profileId)) {
-        res.status(403).json({ success: false, error: 'Not your entry' });
-        return;
-      }
+    // Hard delete is admin-only and only permitted on already-cancelled entries
+    const role = req.session.user?.role;
+    if (role !== 'admin') {
+      res.status(403).json({ success: false, error: 'Only admins can delete entries — use cancel instead' });
+      return;
+    }
+    if (!entry[ENTRY_CANCELLED]) {
+      res.status(400).json({ success: false, error: 'Entry must be cancelled before it can be deleted' });
+      return;
     }
 
     // Read existing media count before delete clears the cache

--- a/routes/eventbrite.ts
+++ b/routes/eventbrite.ts
@@ -178,7 +178,8 @@ async function runSyncAttendees(): Promise<SyncAttendeesResult> {
       updatedRecords += updated;
     }
 
-    // Cancellation step — separate from entry creation; existing sync is untouched
+    // Cancellation step — skip if no entries exist for this session (nothing to cancel)
+    if (!sessionEntries.length) continue;
     const cancelledAttendees = await getCancelledAttendees(session.EventbriteEventID!);
     if (cancelledAttendees.length > 0) {
       console.log(`[Eventbrite Sync] Session ${session.ID}: ${cancelledAttendees.length} cancelled attendees to check`);

--- a/routes/eventbrite.ts
+++ b/routes/eventbrite.ts
@@ -6,9 +6,10 @@ import { profilesRepository } from '../services/repositories/profiles-repository
 import { recordsRepository } from '../services/repositories/records-repository';
 import { regularsRepository } from '../services/repositories/regulars-repository';
 import { validateArray, validateSession, validateEntry, validateProfile, validateGroup, safeParseLookupId } from '../services/data-layer';
-import { GROUP_LOOKUP, SESSION_LOOKUP, PROFILE_LOOKUP } from '../services/field-names';
-import { getAttendees, getOrgAttendees, getOrgEvents, getEventConfigCheck, EventbriteConfigCheck } from '../services/eventbrite-client';
-import { isNewVolunteer, findOrCreateProfile, upsertConsentRecords, bookingEmailFor, resolveAccompanyingAdult } from '../services/eventbrite-sync';
+import { GROUP_LOOKUP, SESSION_LOOKUP, PROFILE_LOOKUP, ENTRY_CANCELLED } from '../services/field-names';
+import { getAttendees, getOrgAttendees, getOrgEvents, getEventConfigCheck, getCancelledAttendees, EventbriteConfigCheck } from '../services/eventbrite-client';
+import { isNewVolunteer, findOrCreateProfile, findProfileByAttendee, upsertConsentRecords, bookingEmailFor, resolveAccompanyingAdult } from '../services/eventbrite-sync';
+import { computeAndSaveProfileStats } from '../services/profile-stats';
 import { runSessionStatsRefresh } from '../services/session-stats';
 import { runProfileStatsRefresh } from '../services/profile-stats';
 import { runBackupExport } from '../services/backup-export';
@@ -32,6 +33,7 @@ interface SyncAttendeesResult {
   newRecords: number;
   updatedRecords: number;
   duplicateWarnings: number;
+  cancelledEntries: number;
 }
 
 async function runSyncSessions(): Promise<SyncSessionsResult> {
@@ -120,6 +122,7 @@ async function runSyncAttendees(): Promise<SyncAttendeesResult> {
   let newRecords = 0;
   let updatedRecords = 0;
   let duplicateWarnings = 0;
+  let cancelledEntries = 0;
 
   // Load existing records for upsert
   const allRecords = await recordsRepository.getAll();
@@ -174,10 +177,39 @@ async function runSyncAttendees(): Promise<SyncAttendeesResult> {
       newRecords += created;
       updatedRecords += updated;
     }
+
+    // Cancellation step — separate from entry creation; existing sync is untouched
+    const cancelledAttendees = await getCancelledAttendees(session.EventbriteEventID!);
+    if (cancelledAttendees.length > 0) {
+      console.log(`[Eventbrite Sync] Session ${session.ID}: ${cancelledAttendees.length} cancelled attendees to check`);
+
+      // Build map of profileId → entry for quick lookup
+      const entryByProfile = new Map<number, { id: number; alreadyCancelled: boolean }>();
+      for (const entry of sessionEntries) {
+        const pid = safeParseLookupId(entry[PROFILE_LOOKUP]);
+        if (pid !== undefined) {
+          entryByProfile.set(pid, { id: entry.ID, alreadyCancelled: !!entry[ENTRY_CANCELLED] });
+        }
+      }
+
+      for (const attendee of cancelledAttendees) {
+        const profile = findProfileByAttendee(attendee, profiles);
+        if (!profile) continue;
+
+        const entryInfo = entryByProfile.get(profile.ID);
+        if (!entryInfo || entryInfo.alreadyCancelled) continue;
+
+        await entriesRepository.updateFields(entryInfo.id, { [ENTRY_CANCELLED]: new Date().toISOString() });
+        computeAndSaveProfileStats(profile.ID).catch(err =>
+          console.error('[Eventbrite Sync] computeAndSaveProfileStats failed for profile', profile.ID, err)
+        );
+        cancelledEntries++;
+      }
+    }
   }
 
-  console.log(`[Eventbrite Sync] Done: ${liveSessions.length} sessions, ${newProfiles} new profiles, ${newEntries} new entries, ${newRecords} new records, ${updatedRecords} updated records, ${duplicateWarnings} duplicate warnings`);
-  return { sessionsProcessed: liveSessions.length, newProfiles, newEntries, newRecords, updatedRecords, duplicateWarnings };
+  console.log(`[Eventbrite Sync] Done: ${liveSessions.length} sessions, ${newProfiles} new profiles, ${newEntries} new entries, ${cancelledEntries} cancelled, ${newRecords} new records, ${updatedRecords} updated records, ${duplicateWarnings} duplicate warnings`);
+  return { sessionsProcessed: liveSessions.length, newProfiles, newEntries, newRecords, updatedRecords, duplicateWarnings, cancelledEntries };
 }
 
 const WARMUP_KEYS = ['groups', 'sessions', 'profiles', 'regulars'] as const;
@@ -225,7 +257,7 @@ async function handleNightlyUpdate(req: Request, res: Response): Promise<void> {
     const profileIdsStr = profileStatsResult.updatedIds.length ? ` (${profileStatsResult.updatedIds.join(', ')})` : '';
     const parts = [
       `${sessionResult.totalEvents} events, ${sessionResult.matchedEvents} matched, ${sessionResult.newSessions} new sessions / ${attendeeResult.sessionsProcessed} sessions`,
-      `${attendeeResult.newProfiles} new profiles, ${attendeeResult.newEntries} new entries, ${attendeeResult.newRecords} new consent records, ${attendeeResult.updatedRecords} updated consent records${attendeeResult.duplicateWarnings ? `, ${attendeeResult.duplicateWarnings} duplicate warning(s) — check session entries` : ''}`,
+      `${attendeeResult.newProfiles} new profiles, ${attendeeResult.newEntries} new entries, ${attendeeResult.cancelledEntries} cancelled, ${attendeeResult.newRecords} new consent records, ${attendeeResult.updatedRecords} updated consent records${attendeeResult.duplicateWarnings ? `, ${attendeeResult.duplicateWarnings} duplicate warning(s) — check session entries` : ''}`,
       `Session stats: ${sessionStatsResult.updated}/${sessionStatsResult.total} updated${sessionStatsResult.errors.length ? `, ${sessionStatsResult.errors.length} error(s)` : ''}${sessionIdsStr}`,
       `Profile stats: ${profileStatsResult.updated}/${profileStatsResult.total} updated${profileStatsResult.errors.length ? `, ${profileStatsResult.errors.length} error(s)` : ''}${profileIdsStr}`,
       backupResult.updated.length ? `Backup: ${backupResult.updated.join(', ')} updated` : 'Backup: no changes',

--- a/routes/profiles.ts
+++ b/routes/profiles.ts
@@ -731,6 +731,7 @@ router.get('/profiles/:slug', async (req: Request, res: Response) => {
           hours: parseHours(e.Hours),
           checkedIn: e.Checked || false,
           notes: e.Notes,
+          accompanyingAdultId: e.AccompanyingAdultLookupId,
           financialYear: `FY${sessionFY}`
         };
       })

--- a/routes/profiles.ts
+++ b/routes/profiles.ts
@@ -28,7 +28,8 @@ import {
 import {
   GROUP_LOOKUP,
   SESSION_LOOKUP,
-  PROFILE_LOOKUP, PROFILE_DISPLAY
+  PROFILE_LOOKUP, PROFILE_DISPLAY,
+  ENTRY_CANCELLED
 } from '../services/field-names';
 import type { ProfileResponse, ProfileDetailResponse, ProfileDuplicateResponse, ProfileEntryResponse, ProfileGroupHours, ConsentRecordResponse } from '../types/api-responses';
 import type { ApiResponse } from '../types/sharepoint';
@@ -732,7 +733,8 @@ router.get('/profiles/:slug', async (req: Request, res: Response) => {
           checkedIn: e.Checked || false,
           notes: e.Notes,
           accompanyingAdultId: e.AccompanyingAdultLookupId,
-          financialYear: `FY${sessionFY}`
+          financialYear: `FY${sessionFY}`,
+          cancelled: e[ENTRY_CANCELLED] || undefined
         };
       })
       .sort((a, b) => b.date.localeCompare(a.date));

--- a/routes/sessions.ts
+++ b/routes/sessions.ts
@@ -30,7 +30,7 @@ import {
 import {
   GROUP_LOOKUP, GROUP_DISPLAY,
   SESSION_LOOKUP, SESSION_NOTES, SESSION_METADATA, SESSION_COVER_MEDIA, SESSION_STATS, SESSION_LIMITS,
-  PROFILE_LOOKUP, PROFILE_DISPLAY, PROFILE_STATS
+  PROFILE_LOOKUP, PROFILE_DISPLAY, PROFILE_STATS, ENTRY_CANCELLED
 } from '../services/field-names';
 import type { SessionResponse, SessionDetailResponse, EntryResponse } from '../types/api-responses';
 import type { ApiResponse } from '../types/sharepoint';
@@ -491,6 +491,9 @@ router.get('/sessions/:group/:date', async (req: Request, res: Response) => {
     const profiles = validateArray(rawProfiles, validateProfile, 'Profile');
     const profileMap = new Map(profiles.map(p => [p.ID, p]));
 
+    // Active entries: exclude cancelled for stats. All entries returned to operational users (with cancelled flag).
+    const activeEntries = sessionEntries.filter(e => !e[ENTRY_CANCELLED]);
+
     const entryResponses: EntryResponse[] = sessionEntries.map(e => {
       const volunteerId = safeParseLookupId(e[PROFILE_LOOKUP]);
       const profile = volunteerId !== undefined ? profileMap.get(volunteerId) : undefined;
@@ -510,33 +513,56 @@ router.get('/sessions/:group/:date', async (req: Request, res: Response) => {
         hours: parseHours(e.Hours),
         checkedIn: e.Checked || false,
         notes: e.Notes,
-        accompanyingAdultId: e.AccompanyingAdultLookupId
+        accompanyingAdultId: e.AccompanyingAdultLookupId,
+        cancelled: e[ENTRY_CANCELLED] || undefined
       };
     });
 
-    const totalHours = sessionEntries.reduce((sum, e) => sum + parseHours(e.Hours), 0);
-    const newCount = sessionEntries.filter(e => /#New\b/i.test(String(e.Notes || ''))).length;
-    const childCount = sessionEntries.filter(e => /#Child\b/i.test(String(e.Notes || ''))).length;
-    const regularCount = sessionEntries.filter(e => /#Regular\b/i.test(String(e.Notes || ''))).length;
-    const eventbriteCount = sessionEntries.filter(e => /#Eventbrite\b/i.test(String(e.Notes || ''))).length;
+    // Stats use only active (non-cancelled) entries
+    const totalHours = activeEntries.reduce((sum, e) => sum + parseHours(e.Hours), 0);
+    const newCount = activeEntries.filter(e => /#New\b/i.test(String(e.Notes || ''))).length;
+    const childCount = activeEntries.filter(e => /#Child\b/i.test(String(e.Notes || ''))).length;
+    const regularCount = activeEntries.filter(e => /#Regular\b/i.test(String(e.Notes || ''))).length;
+    const eventbriteCount = activeEntries.filter(e => /#Eventbrite\b/i.test(String(e.Notes || ''))).length;
 
     // Per-user personalised flags — from profile stats (all roles) with live entry fallback for admin/checkin
+    // For self-service: also look up their own entry to return userEntryId (needed for cancel flow)
     let isRegistered: boolean | undefined;
     let isAttended: boolean | undefined;
     let isRegular: boolean | undefined;
     let userEntryId: number | undefined;
+    let userProfileId: number | undefined;
 
     if (selfProfileId !== undefined) {
+      userProfileId = selfProfileId;
       if (selfProfileStats) {
-        isRegistered = selfProfileStats.sessionIds?.includes(spSession.ID) ?? false;
         isRegular = selfProfileStats.regularGroupIds?.includes(groupId) ?? false;
       }
-      if (!isSelfService) {
-        // Admin/checkin: derive live attended status from the fetched entries
+      if (isSelfService) {
+        // Self-service: fetch own entry to get userEntryId and live isRegistered status
+        const selfEntries = await entriesRepository.getByProfileId(selfProfileId);
+        const ownEntry = selfEntries.find(e => safeParseLookupId(e[SESSION_LOOKUP]) === spSession.ID);
+        if (ownEntry) {
+          userEntryId = ownEntry.ID;
+          // Cancelled entry: not registered (can re-book), but userEntryId still returned for cancel admin flows
+          isRegistered = !ownEntry[ENTRY_CANCELLED];
+        } else {
+          isRegistered = selfProfileStats?.sessionIds?.includes(spSession.ID) ?? false;
+        }
+        isRegular = isRegular ?? false;
+        isAttended = false; // self-service attended status not computed
+      } else {
+        if (selfProfileStats) {
+          isRegistered = selfProfileStats.sessionIds?.includes(spSession.ID) ?? false;
+        }
+        // Admin/checkin: derive live attended status and userEntryId from the fetched entries
         const ownEntry = entryResponses.find(e => e.profileId === selfProfileId);
         isRegistered = isRegistered ?? ownEntry !== undefined;
         isAttended = ownEntry?.checkedIn ?? false;
+        // userEntryId: use the entry even if cancelled so admin can act on it
         userEntryId = ownEntry?.id;
+        // If the own entry is cancelled, not registered
+        if (ownEntry?.cancelled) isRegistered = false;
         isRegular = isRegular ?? false;
       }
     }
@@ -551,7 +577,7 @@ router.get('/sessions/:group/:date', async (req: Request, res: Response) => {
       groupDescription: group.description,
       limits: sessionLimits,
       regularsCount,
-      registrations: isSelfService ? (JSON.parse(spSession[SESSION_STATS] || '{}').count ?? 0) : sessionEntries.length,
+      registrations: isSelfService ? (JSON.parse(spSession[SESSION_STATS] || '{}').count ?? 0) : activeEntries.length,
       hours: Math.round(totalHours * 10) / 10,
       newCount: newCount || undefined,
       childCount: childCount || undefined,
@@ -570,7 +596,8 @@ router.get('/sessions/:group/:date', async (req: Request, res: Response) => {
         isRegistered,
         isAttended,
         isRegular,
-        userEntryId
+        userEntryId,
+        userProfileId
       })
     };
 

--- a/routes/sessions.ts
+++ b/routes/sessions.ts
@@ -541,7 +541,14 @@ router.get('/sessions/:group/:date', async (req: Request, res: Response) => {
       if (isSelfService) {
         // Self-service: fetch own entry to get userEntryId and live isRegistered status
         const selfEntries = await entriesRepository.getByProfileId(selfProfileId);
-        const ownEntry = selfEntries.find(e => safeParseLookupId(e[SESSION_LOOKUP]) === spSession.ID);
+        // Prefer active entry over cancelled; among ties pick the most recently created
+        const sessionEntries = selfEntries
+          .filter(e => safeParseLookupId(e[SESSION_LOOKUP]) === spSession.ID)
+          .sort((a, b) => {
+            if (!!a[ENTRY_CANCELLED] !== !!b[ENTRY_CANCELLED]) return a[ENTRY_CANCELLED] ? 1 : -1;
+            return (b.ID ?? 0) - (a.ID ?? 0);
+          });
+        const ownEntry = sessionEntries[0];
         if (ownEntry) {
           userEntryId = ownEntry.ID;
           // Cancelled entry: not registered (can re-book), but userEntryId still returned for cancel admin flows

--- a/services/data-layer.ts
+++ b/services/data-layer.ts
@@ -225,6 +225,7 @@ export function calculateSessionStats(entries: SharePointEntry[]): Map<string, S
   const statsMap = new Map<string, SessionStats>();
 
   entries.forEach(entry => {
+    if (entry.Cancelled) return; // cancelled bookings excluded from all stats
     const sessionId = entry[SESSION_LOOKUP];
     if (!sessionId) return;
 
@@ -402,6 +403,7 @@ export function calculateFYStats(
   const sessionIdsFY = new Set(sessionsFY.map(s => s.ID));
 
   const entriesFY = allEntries.filter(entry => {
+    if (entry.Cancelled) return false; // cancelled bookings excluded from all stats
     const sessionId = safeParseLookupId(entry[SESSION_LOOKUP]);
     return sessionId !== undefined && sessionIdsFY.has(sessionId);
   });

--- a/services/eventbrite-client.ts
+++ b/services/eventbrite-client.ts
@@ -142,6 +142,25 @@ export async function getAttendees(eventId: string, changedSince?: Date): Promis
   return all;
 }
 
+export async function getCancelledAttendees(eventId: string): Promise<EventbriteAttendee[]> {
+  const all: EventbriteAttendee[] = [];
+  let page = 1;
+  let hasMore = true;
+
+  while (hasMore) {
+    const data = await fetchEventbrite<{
+      attendees: EventbriteAttendee[];
+      pagination: { has_more_items: boolean };
+    }>(`/events/${eventId}/attendees/?status=not_attending&expand=answers,order&page=${page}`);
+
+    all.push(...(data.attendees || []));
+    hasMore = data.pagination?.has_more_items || false;
+    page++;
+  }
+
+  return all;
+}
+
 export interface EventbriteConfigCheck {
   eventId: string;
   eventName: string;

--- a/services/eventbrite-sync.ts
+++ b/services/eventbrite-sync.ts
@@ -89,6 +89,34 @@ export function isNewVolunteer(
  * Mutates `profiles` by pushing any newly-created profile so subsequent
  * lookups within the same batch stay consistent.
  */
+/**
+ * Find a profile matching an Eventbrite attendee by name + email — find-only, no create.
+ * Uses the same matching priority as findOrCreateProfile (name+email first, name-only second).
+ */
+export function findProfileByAttendee(
+  attendee: EventbriteAttendee,
+  profiles: SharePointProfile[]
+): SharePointProfile | undefined {
+  const attendeeName = attendee.profile?.name;
+  if (!attendeeName) return undefined;
+  const nameKey = toMatchName(attendeeName);
+  const email = bookingEmailFor(attendee)?.toLowerCase();
+
+  if (email) {
+    const byNameAndEmail = profiles.find(p => {
+      const nameMatches = (p.MatchName && toMatchName(p.MatchName) === nameKey) ||
+                          (p.Title && toMatchName(p.Title) === nameKey);
+      return nameMatches && parseEmails(p.Email).some(e => e.toLowerCase() === email);
+    });
+    if (byNameAndEmail) return byNameAndEmail;
+  }
+
+  return profiles.find(p =>
+    (p.MatchName && toMatchName(p.MatchName) === nameKey) ||
+    (p.Title && toMatchName(p.Title) === nameKey)
+  );
+}
+
 export async function findOrCreateProfile(
   attendeeName: string,
   attendeeEmail: string | undefined,

--- a/services/field-names.ts
+++ b/services/field-names.ts
@@ -25,3 +25,4 @@ export const SESSION_COVER_MEDIA = 'CoverMediaLookupId'; // Lookup to Media libr
 export const SESSION_STATS       = 'Stats';  // Pre-computed JSON stats stored on Session items (avoid full entries scan on listing views)
 export const SESSION_LIMITS      = 'Limits'; // Per-session capacity limits JSON: {"new": 4, "total": 16}
 export const PROFILE_STATS       = 'Stats';  // Same field name on Profiles list
+export const ENTRY_CANCELLED     = 'Cancelled'; // Date/time when entry was cancelled; null = active booking

--- a/services/profile-stats.ts
+++ b/services/profile-stats.ts
@@ -17,7 +17,7 @@ import { recordsRepository } from './repositories/records-repository';
 import { regularsRepository } from './repositories/regulars-repository';
 import { sharePointClient } from './sharepoint-client';
 import { safeParseLookupId, calculateFinancialYear } from './data-layer';
-import { PROFILE_LOOKUP, GROUP_LOOKUP, SESSION_LOOKUP, PROFILE_STATS } from './field-names';
+import { PROFILE_LOOKUP, GROUP_LOOKUP, SESSION_LOOKUP, PROFILE_STATS, ENTRY_CANCELLED } from './field-names';
 
 export interface ProfileStatsRefreshResult {
   total: number;
@@ -55,6 +55,7 @@ export async function computeAndSaveProfileStats(profileId: number): Promise<voi
   const sessionIds: number[] = [];
 
   for (const e of profileEntries) {
+    if (e[ENTRY_CANCELLED]) continue; // cancelled bookings excluded from all stats
     const sessionId = safeParseLookupId(e[SESSION_LOOKUP]);
     if (sessionId === undefined) continue;
     sessionIds.push(sessionId);
@@ -123,6 +124,7 @@ export async function runProfileStatsRefresh(): Promise<ProfileStatsRefreshResul
   const profileSessionIds = new Map<number, number[]>();             // profileId → [sessionId, ...]
 
   for (const e of entriesRaw) {
+    if (e[ENTRY_CANCELLED]) continue; // cancelled bookings excluded from all stats
     const profileId = safeParseLookupId(e[PROFILE_LOOKUP]);
     const sessionId = safeParseLookupId(e[SESSION_LOOKUP]);
     if (profileId === undefined || sessionId === undefined) continue;

--- a/services/repositories/entries-repository.ts
+++ b/services/repositories/entries-repository.ts
@@ -6,7 +6,7 @@
 
 import { SharePointEntry } from '../../types/sharepoint';
 import { sharePointClient, CACHE_TTL } from '../sharepoint-client';
-import { SESSION_LOOKUP, SESSION_DISPLAY, PROFILE_LOOKUP, PROFILE_DISPLAY, ACCOMPANYING_ADULT_LOOKUP, ACCOMPANYING_ADULT_DISPLAY } from '../field-names';
+import { SESSION_LOOKUP, SESSION_DISPLAY, PROFILE_LOOKUP, PROFILE_DISPLAY, ACCOMPANYING_ADULT_LOOKUP, ACCOMPANYING_ADULT_DISPLAY, ENTRY_CANCELLED } from '../field-names';
 
 class EntriesRepository {
   private listGuid: string;
@@ -16,7 +16,7 @@ class EntriesRepository {
   }
 
   private get selectFields(): string {
-    return `ID,Title,${SESSION_DISPLAY},${SESSION_LOOKUP},${PROFILE_DISPLAY},${PROFILE_LOOKUP},Count,Checked,Hours,Notes,BookedBy,${ACCOMPANYING_ADULT_DISPLAY},${ACCOMPANYING_ADULT_LOOKUP},Created,Modified`;
+    return `ID,Title,${SESSION_DISPLAY},${SESSION_LOOKUP},${PROFILE_DISPLAY},${PROFILE_LOOKUP},Count,Checked,Hours,Notes,BookedBy,${ACCOMPANYING_ADULT_DISPLAY},${ACCOMPANYING_ADULT_LOOKUP},${ENTRY_CANCELLED},Created,Modified`;
   }
 
   async getAll(): Promise<SharePointEntry[]> {
@@ -52,6 +52,15 @@ class EntriesRepository {
   async getRecent(cutoff: Date): Promise<SharePointEntry[]> {
     // Requires a Created index on the Entries list (List Settings → Indexed Columns)
     const filter = `fields/Created ge '${cutoff.toISOString()}'`;
+    return await sharePointClient.getListItems(
+      this.listGuid,
+      this.selectFields,
+      filter
+    ) as SharePointEntry[];
+  }
+
+  async getRecentlyCancelled(cutoff: Date): Promise<SharePointEntry[]> {
+    const filter = `fields/${ENTRY_CANCELLED} ge '${cutoff.toISOString()}'`;
     return await sharePointClient.getListItems(
       this.listGuid,
       this.selectFields,
@@ -107,7 +116,7 @@ class EntriesRepository {
     ) as SharePointEntry[];
   }
 
-  async updateFields(entryId: number, fields: Partial<Pick<SharePointEntry, 'Checked' | 'Count' | 'Hours' | 'Notes' | 'AccompanyingAdultLookupId'>>): Promise<void> {
+  async updateFields(entryId: number, fields: Partial<Pick<SharePointEntry, 'Checked' | 'Count' | 'Hours' | 'Notes' | 'AccompanyingAdultLookupId' | 'Cancelled'>> & Record<string, any>): Promise<void> {
     await sharePointClient.updateListItem(this.listGuid, entryId, fields);
     sharePointClient.clearCacheKey('entries');
     sharePointClient.clearCacheByPrefix('sessions_FY');

--- a/types/api-responses.ts
+++ b/types/api-responses.ts
@@ -82,6 +82,7 @@ export interface ProfileEntryResponse {
   hours: number;
   checkedIn: boolean;
   notes?: string;
+  accompanyingAdultId?: number;
   financialYear: string;
 }
 

--- a/types/api-responses.ts
+++ b/types/api-responses.ts
@@ -84,6 +84,7 @@ export interface ProfileEntryResponse {
   notes?: string;
   accompanyingAdultId?: number;
   financialYear: string;
+  cancelled?: string;
 }
 
 export interface ProfileGroupHours {
@@ -170,6 +171,7 @@ export interface EntryResponse {
   checkedIn: boolean;
   notes?: string;
   accompanyingAdultId?: number;
+  cancelled?: string; // ISO datetime if booking was cancelled
 }
 
 export interface SessionDetailResponse {
@@ -202,7 +204,8 @@ export interface SessionDetailResponse {
   isAttended?: boolean;
   isRegular?: boolean;
   userIsNew?: boolean;        // #New tag present on the user's entry for this session
-  userEntryId?: number;       // entry ID for this user on this session (when isRegistered)
+  userEntryId?: number;       // entry ID for this user on this session (when isRegistered or cancelled)
+  userProfileId?: number;     // profile ID of the authenticated viewer (needed for self-service Book POST)
 }
 
 export interface EntryDetailResponse {
@@ -267,6 +270,10 @@ export interface RecentSignupResponse {
   groupName: string;
   notes?: string;
   checkedIn: boolean;
+  hours: number;
+  count: number;
+  accompanyingAdultId?: number;
+  cancelled?: string; // ISO datetime if booking was cancelled (appears in recent list ordered by Cancelled date)
 }
 
 export interface EntryListItemResponse {
@@ -284,6 +291,7 @@ export interface EntryListItemResponse {
   isGroup: boolean;
   hasAccompanyingAdult: boolean;
   accompanyingAdultId?: number;
+  cancelled?: string;
 }
 
 export interface TagHoursItem {

--- a/types/sharepoint.ts
+++ b/types/sharepoint.ts
@@ -73,6 +73,7 @@ export interface SharePointEntry extends SharePointBaseItem {
   BookedBy?: string;
   AccompanyingAdultLookupId?: number;
   AccompanyingAdult?: string;
+  Cancelled?: string; // ISO datetime when booking was cancelled; absent/null = active
   /** Allow bracket access for dynamic field names (SessionLookupId, ProfileLookupId, etc.) */
   [key: string]: any;
 }


### PR DESCRIPTION
Soft-cancel entries via a Cancelled datetime field on the SharePoint Entries list. Hard delete is now restricted to admin users on already-cancelled entries.

Backend:
- PATCH /api/entries/:id accepts { cancelled: true/false } — sets/clears Cancelled field; preserves original cancellation date
- DELETE /api/entries/:id restricted to admin + pre-cancelled entries (403/400 otherwise)
- GET /api/entries adds ?cancelled= filter (false/true/all, default false)
- GET /api/entries/recent merges recently created + recently cancelled entries, sorted by respective timestamp
- GET /api/sessions/:group/:date: userEntryId and userProfileId now set for self-service users; isRegistered=false when entry is cancelled; cancelled entries included (marked) for operational users only; all session stats (totalHours, counts, registrations) computed from active entries only
- Cancelled entries excluded from calculateSessionStats, calculateFYStats, computeAndSaveProfileStats, runProfileStatsRefresh

Frontend:
- EntryEditModal: Cancel replaces Delete for live entries; Delete shown only to admin on cancelled entries
- EntryCard + EntryListItem: strikethrough + muted styling when cancelled
- SessionEntryList, ProfileEntryList: cancel/delete dispatch, isAdmin prop, cancelEntry emit
- ProfileDetailPage, SessionDetailPage, EntriesPage: onCancelEntry/onDelete dispatch PATCH cancel vs DELETE; cancelled sorted to bottom of session entry list
- EntryListFilter: Not Cancelled / Show All / Cancelled dropdown (default Not Cancelled)
- SessionDetailBook: wired @book emit, working/error props
- New SessionDetailCancel: "Remove booking" card for self-service
- RecentEntryList: passes cancelled field through to EntryListItem

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
