### PR TITLE
Add pre-session email send (#172)

### DIFF
--- a/frontend/public/icons/email.svg
+++ b/frontend/public/icons/email.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 -2.5 20 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    
+    <title>email [#1573]</title>
+    <desc>Created with Sketch.</desc>
+    <defs>
+
+</defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Dribbble-Light-Preview" transform="translate(-300.000000, -922.000000)" fill="#000000">
+            <g id="icons" transform="translate(56.000000, 160.000000)">
+                <path d="M262,764.291 L254,771.318 L246,764.281 L246,764 L262,764 L262,764.291 Z M246,775 L246,766.945 L254,773.98 L262,766.953 L262,775 L246,775 Z M244,777 L264,777 L264,762 L244,762 L244,777 Z" id="email-[#1573]">
+
+</path>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -36,7 +36,7 @@
             <a v-if="profile.user" href="/auth/logout" class="text-dtv-green font-bold uppercase tracking-wide text-sm py-3 border-b border-white/10 hover:text-white transition-colors">
               Logout
             </a>
-            <RouterLink v-else to="/login" @click="open = false" class="text-dtv-green font-bold uppercase tracking-wide text-sm py-3 border-b border-white/10 hover:text-white transition-colors">
+            <RouterLink v-else :to="loginPath" @click="open = false" class="text-dtv-green font-bold uppercase tracking-wide text-sm py-3 border-b border-white/10 hover:text-white transition-colors">
               Login
             </RouterLink>
           </template>
@@ -48,13 +48,20 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { useRoute } from 'vue-router'
 import { useViewer } from '../composables/useViewer'
 import AboutModal from './AboutModal.vue'
 
 const isDev = import.meta.env.DEV
+const route = useRoute()
 
 const open = ref(false)
+
+const loginPath = computed(() => {
+  const current = route.fullPath
+  return current && current !== '/' ? `/login?returnTo=${encodeURIComponent(current)}` : '/login'
+})
 const showAbout = ref(false)
 const profile = useViewer()
 

--- a/frontend/src/components/sessions/SessionDetailActions.vue
+++ b/frontend/src/components/sessions/SessionDetailActions.vue
@@ -3,6 +3,7 @@
     <AppButton icon="share" label="Share" mode="icon-only" @click="onShare" />
     <AppButton icon="group" label="Group" mode="icon-only" @click="router.push(groupPath(groupKey))" />
     <AppButton v-if="canUpload" icon="uploadphoto" label="Upload" mode="icon-only" @click="onUpload" />
+    <AppButton v-if="allowEmail" icon="email" label="Email" mode="icon-only" @click="showEmail = true" />
     <AppButton v-if="allowEdit" icon="edit" label="Edit" mode="icon-only" @click="showEdit = true" />
 
     <EntryUploadPickerModal
@@ -10,6 +11,15 @@
       :entries="session.entries"
       @close="showPicker = false"
       @select="goUpload"
+    />
+
+    <SessionEmailSendModal
+      v-if="showEmail"
+      :adults="adults"
+      :working="emailWorking"
+      :error="emailError"
+      @close="showEmail = false"
+      @send="onEmailSend"
     />
 
     <SessionEditModal
@@ -30,8 +40,10 @@ import { ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import type { SessionDetailResponse } from '../../../../types/api-responses'
 import type { GroupItem, SessionSaveData } from '../../pages/modals/SessionEditModal.vue'
+import type { EmailAdult } from '../../pages/modals/SessionEmailSendModal.vue'
 import AppButton from '../AppButton.vue'
 import SessionEditModal from '../../pages/modals/SessionEditModal.vue'
+import SessionEmailSendModal from '../../pages/modals/SessionEmailSendModal.vue'
 import EntryUploadPickerModal from '../../pages/modals/EntryUploadPickerModal.vue'
 import { groupPath } from '../../router/index'
 
@@ -43,6 +55,7 @@ const props = defineProps<{
   editWorking: boolean
   editError?: string
   allowEdit: boolean
+  allowEmail: boolean
   isSelfService: boolean
 }>()
 
@@ -54,9 +67,19 @@ const emit = defineEmits<{
 const router = useRouter()
 const showPicker = ref(false)
 const showEdit = ref(false)
+const showEmail = ref(false)
+const emailWorking = ref(false)
+const emailError = ref<string | undefined>()
 
 const canUpload = computed(() =>
   (props.isSelfService && !!props.session.userEntryId) || props.allowEdit
+)
+
+// Adults = non-cancelled, non-group, non-child entries (email may be absent)
+const adults = computed<EmailAdult[]>(() =>
+  props.session.entries
+    .filter(e => !e.cancelled && !e.isGroup && !/#Child\b/i.test(e.notes ?? ''))
+    .map(e => ({ entryId: e.id, name: e.volunteerName ?? '', email: e.email }))
 )
 
 function onShare() {
@@ -78,6 +101,42 @@ function onUpload() {
 
 function goUpload(entryId: number) {
   window.location.href = `/upload?entryId=${entryId}`
+}
+
+async function sendOne(entryId: number, preview: boolean): Promise<boolean> {
+  const body = JSON.stringify({ preview })
+  const res = await fetch(`/api/entries/${entryId}/notify`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body,
+  })
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}))
+    emailError.value = data.error || 'Failed to send email'
+    return false
+  }
+  return true
+}
+
+async function onEmailSend({ recipient, preview }: { recipient: number | 'send-all', preview: boolean }) {
+  emailWorking.value = true
+  emailError.value = undefined
+  try {
+    if (recipient === 'send-all') {
+      for (const adult of adults.value.filter(a => a.email)) {
+        const ok = await sendOne(adult.entryId, false)
+        if (!ok) return
+      }
+    } else {
+      const ok = await sendOne(recipient, preview)
+      if (!ok) return
+    }
+    showEmail.value = false
+  } catch {
+    emailError.value = 'Failed to send email'
+  } finally {
+    emailWorking.value = false
+  }
 }
 
 function closeEdit() {

--- a/frontend/src/components/sessions/SessionDetailActions.vue
+++ b/frontend/src/components/sessions/SessionDetailActions.vue
@@ -123,7 +123,12 @@ async function onEmailSend({ recipient, preview }: { recipient: number | 'send-a
   emailError.value = undefined
   try {
     if (recipient === 'send-all') {
-      for (const adult of adults.value.filter(a => a.email)) {
+      const emailable = adults.value.filter(a => a.email)
+      if (!emailable.length) {
+        emailError.value = 'No recipients have an email address'
+        return
+      }
+      for (const adult of emailable) {
         const ok = await sendOne(adult.entryId, false)
         if (!ok) return
       }

--- a/frontend/src/layouts/DefaultLayout.vue
+++ b/frontend/src/layouts/DefaultLayout.vue
@@ -4,7 +4,8 @@
     <main class="flex-1 bg-white">
       <div class="max-w-5xl mx-auto">
         <FlashContainer :params="['flashName']" v-slot="{ flashKey, params, dismiss }">
-          <FlashMessage :show="flashKey === 'signed-in'"    type="info"    @dismiss="dismiss">{{ params.flashName || profile.user?.displayName }} logged in</FlashMessage>
+          <!-- TODO: decide whether to keep, restyle, or remove the signed-in flash -->
+          <!-- <FlashMessage :show="flashKey === 'signed-in'"    type="info"    @dismiss="dismiss">{{ params.flashName || profile.user?.displayName }} logged in</FlashMessage> -->
           <FlashMessage :show="flashKey === 'signed-out'"   type="neutral" @dismiss="dismiss">{{ params.flashName }} logged out</FlashMessage>
           <FlashMessage :show="flashKey === 'server-error'" type="error"   @dismiss="dismiss">Server could not be reached. Please try again.</FlashMessage>
         </FlashContainer>

--- a/frontend/src/layouts/TaskLayout.vue
+++ b/frontend/src/layouts/TaskLayout.vue
@@ -3,7 +3,8 @@
     <AppHeader />
     <main class="flex-1 bg-white">
       <FlashContainer v-slot="{ flashKey, dismiss }">
-        <FlashMessage :show="flashKey === 'signed-in'" type="info" @dismiss="dismiss">Welcome back.</FlashMessage>
+        <!-- TODO: decide whether to keep, restyle, or remove the signed-in flash -->
+        <!-- <FlashMessage :show="flashKey === 'signed-in'" type="info" @dismiss="dismiss">Welcome back.</FlashMessage> -->
       </FlashContainer>
       <div class="task-layout-body">
         <slot />

--- a/frontend/src/pages/SessionDetailPage.vue
+++ b/frontend/src/pages/SessionDetailPage.vue
@@ -47,7 +47,7 @@
 
       <!-- SECOND ROW -->
        <!-- TODO display a different set of text depending on the session category (dig, fund raising, behind the scenes etc.) -->
-      <LayoutColumns ratio="1-1-1" v-if="store.session.isBookable">
+      <LayoutColumns ratio="1-1-1" v-if="store.session.isBookable && !profile.isOperational">
         <template #header>
           <SectionHeader >What to expect?</SectionHeader>
         </template>
@@ -116,6 +116,7 @@
             :edit-working="editWorking"
             :edit-error="editError"
             :allow-edit="profile.isCheckIn || profile.isAdmin"
+            :allow-email="profile.isOperational"
             :is-self-service="profile.isSelfService"
             @session-save="onSessionSave"
             @session-delete="onSessionDelete"

--- a/frontend/src/pages/modals/SessionEmailSendModal.vue
+++ b/frontend/src/pages/modals/SessionEmailSendModal.vue
@@ -67,7 +67,11 @@ watch(recipient, val => {
   if (val === 'send-all') preview.value = false
 })
 
-const canSend = computed(() => props.adults.length > 0)
+const canSend = computed(() =>
+  recipient.value === 'send-all'
+    ? props.adults.some(a => a.email)
+    : props.adults.length > 0
+)
 
 function onSend() {
   emit('send', { recipient: recipient.value, preview: preview.value })

--- a/frontend/src/pages/modals/SessionEmailSendModal.vue
+++ b/frontend/src/pages/modals/SessionEmailSendModal.vue
@@ -1,0 +1,98 @@
+<template>
+  <ModalLayout
+    title="Send Email"
+    action="Send"
+    action-icon="email"
+    :action-disabled="!canSend"
+    :working="working"
+    :error="error"
+    @close="emit('close')"
+    @action="onSend"
+  >
+    <FormLayout>
+      <FormRow title="Template">
+        <select v-model="template" class="sem-select">
+          <option value="pre-session">Pre-Session</option>
+        </select>
+      </FormRow>
+
+      <FormRow title="Send To">
+        <select v-model="recipient" class="sem-select">
+          <option v-for="a in adults" :key="a.entryId" :value="a.entryId" :disabled="!a.email">
+            {{ a.name }}{{ a.email ? ` ${a.email}` : ' (no email)' }}
+          </option>
+          <option value="send-all">Send All</option>
+        </select>
+      </FormRow>
+
+      <FormRow title="Preview">
+        <label class="sem-check">
+          <input type="checkbox" v-model="preview" :disabled="recipient === 'send-all'" />
+          Send to my email address only
+        </label>
+      </FormRow>
+    </FormLayout>
+  </ModalLayout>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue'
+import ModalLayout from '../../components/ModalLayout.vue'
+import FormLayout from '../../components/FormLayout.vue'
+import FormRow from '../../components/FormRow.vue'
+
+export interface EmailAdult {
+  entryId: number
+  name: string
+  email?: string
+}
+
+const props = defineProps<{
+  adults: EmailAdult[]
+  working: boolean
+  error?: string
+}>()
+
+const emit = defineEmits<{
+  close: []
+  send: [{ recipient: number | 'send-all', preview: boolean }]
+}>()
+
+const template = ref<'pre-session'>('pre-session')
+const recipient = ref<number | 'send-all'>(props.adults.find(a => a.email)?.entryId ?? 'send-all')
+const preview = ref(true)
+
+// Disable preview when Send All is selected
+watch(recipient, val => {
+  if (val === 'send-all') preview.value = false
+})
+
+const canSend = computed(() => props.adults.length > 0)
+
+function onSend() {
+  emit('send', { recipient: recipient.value, preview: preview.value })
+}
+</script>
+
+<style scoped>
+.sem-select {
+  width: 100%;
+  padding: 0.4rem 0.5rem;
+  border: 1px solid var(--color-border);
+  background: var(--color-white);
+  font-size: 0.9rem;
+  color: var(--color-text);
+}
+
+.sem-check {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+.sem-check input {
+  cursor: pointer;
+}
+</style>

--- a/frontend/src/pages/sandbox/SandboxActionBars.vue
+++ b/frontend/src/pages/sandbox/SandboxActionBars.vue
@@ -16,6 +16,7 @@
         :groups="mockGroups"
         :edit-working="false"
         :allow-edit="true"
+        :allow-email="true"
         :is-self-service="false"
       />
 
@@ -27,6 +28,7 @@
         :groups="mockGroups"
         :edit-working="false"
         :allow-edit="false"
+        :allow-email="false"
         :is-self-service="true"
       />
 
@@ -38,6 +40,8 @@
         :groups="mockGroups"
         :edit-working="false"
         :allow-edit="false"
+        :allow-email="false"
+        volunteer-name=""
         :is-self-service="false"
       />
 

--- a/middleware/require-admin.ts
+++ b/middleware/require-admin.ts
@@ -15,6 +15,7 @@ const CHECKIN_ALLOWED_PATTERNS = [
   { method: 'PATCH', pattern: /^\/profiles\/[^/]+$/ },        // edit profile
   { method: 'POST',  pattern: /^\/profiles\/\d+\/consent$/ }, // collect consent
   { method: 'POST',  pattern: /^\/entries\/\d+\/photos$/ },   // upload photos to an entry
+  { method: 'POST',  pattern: /^\/entries\/\d+\/notify$/ },  // send pre-session email preview
   { method: 'PATCH', pattern: /^\/media\/[^/]+$/ },            // update media item metadata (title, isPublic)
 ];
 

--- a/routes/entries.ts
+++ b/routes/entries.ts
@@ -25,13 +25,14 @@ import {
 } from '../services/data-layer';
 import { isFirstSession, addSessionToProfileStats, findOrCreateProfile, upsertConsentRecords } from '../services/eventbrite-sync';
 import {
-  GROUP_LOOKUP,
-  SESSION_LOOKUP,
+  GROUP_LOOKUP, GROUP_DISPLAY,
+  SESSION_LOOKUP, SESSION_NOTES,
   SESSION_STATS,
   PROFILE_LOOKUP, PROFILE_DISPLAY,
   ENTRY_CANCELLED
 } from '../services/field-names';
 import { getAttendees } from '../services/eventbrite-client';
+import { sendEmail } from '../services/graph-mail';
 
 import { computeAndSaveProfileStats } from '../services/profile-stats';
 import multer from 'multer';
@@ -146,7 +147,7 @@ router.get('/entries/recent', async (req: Request, res: Response) => {
           checkedIn: e.Checked || false,
           hours: parseHours(e.Hours),
           count: e.Count || 1,
-          accompanyingAdultId: e.AccompanyingAdultLookupId,
+          accompanyingAdultId: safeParseLookupId(e.AccompanyingAdultLookupId),
           cancelled: e.Cancelled || undefined
         }];
       });
@@ -221,7 +222,7 @@ router.get('/entries', async (req: Request, res: Response) => {
           count: e.Count || 1,
           isGroup: profile?.IsGroup || false,
           hasAccompanyingAdult: hasAdult,
-          accompanyingAdultId: e.AccompanyingAdultLookupId,
+          accompanyingAdultId: safeParseLookupId(e.AccompanyingAdultLookupId),
           cancelled: e.Cancelled || undefined
         }];
       })
@@ -1180,6 +1181,141 @@ router.post('/entries/:id/photos', upload.array('photos', 10), async (req: Reque
   } catch (error: any) {
     console.error('Error uploading photos:', error);
     res.status(500).json({ success: false, error: 'Upload failed', message: error.message });
+  }
+});
+
+router.post('/entries/:entryId/notify', async (req: Request, res: Response) => {
+  try {
+    const entryId = parseInt(String(req.params.entryId), 10);
+    if (isNaN(entryId)) {
+      res.status(400).json({ success: false, error: 'Invalid entry ID' });
+      return;
+    }
+
+    const spEntry = await entriesRepository.getById(entryId);
+    if (!spEntry) {
+      res.status(404).json({ success: false, error: 'Entry not found' });
+      return;
+    }
+    if (spEntry[ENTRY_CANCELLED]) {
+      res.status(400).json({ success: false, error: 'Entry is cancelled' });
+      return;
+    }
+
+    const profileId = safeParseLookupId(spEntry[PROFILE_LOOKUP]);
+    const sessionId = safeParseLookupId(spEntry[SESSION_LOOKUP]);
+
+    const [allProfiles, allSessions, allGroups] = await Promise.all([
+      profilesRepository.getAll(),
+      sessionsRepository.getAll(),
+      groupsRepository.getAll(),
+    ]);
+
+    const profile = profileId !== undefined ? allProfiles.find(p => p.ID === profileId) : undefined;
+    const primaryEmail = profile ? parseEmails(profile.Email)[0] : undefined;
+    if (!primaryEmail) {
+      res.status(400).json({ success: false, error: 'No email address on this profile' });
+      return;
+    }
+
+    const spSession = sessionId !== undefined ? allSessions.find(s => s.ID === sessionId) : undefined;
+    if (!spSession) {
+      res.status(404).json({ success: false, error: 'Session not found for this entry' });
+      return;
+    }
+
+    const groupId = safeParseLookupId(spSession[GROUP_LOOKUP] as unknown as string);
+    const spGroup = groupId !== undefined ? allGroups.find(g => g.ID === groupId) : undefined;
+    const groupName = spGroup ? (spGroup.Name || spGroup.Title) : String(spSession[GROUP_DISPLAY] || '');
+    const groupKey = (spGroup?.Title || '').toLowerCase();
+    const dateParam = spSession.Date;
+    const description = spSession[SESSION_NOTES];
+
+    // Find children on this session whose accompanying adult is this volunteer
+    const sessionEntries = await entriesRepository.getBySessionIds([spSession.ID]);
+    const activeEntries = sessionEntries.filter(e => !e[ENTRY_CANCELLED]);
+    const myChildEntries = profileId !== undefined
+      ? activeEntries.filter(e => safeParseLookupId(e.AccompanyingAdultLookupId) === profileId)
+      : [];
+    const myChildNames = myChildEntries
+      .map(e => String(e[PROFILE_DISPLAY] || '').trim())
+      .filter(Boolean)
+      .join(' and ');
+
+    const isRegular = /#Regular\b/i.test(String(spEntry.Notes || ''));
+
+    // Date formatting
+    const d = new Date(dateParam + 'T12:00:00');
+    const dayName = d.toLocaleDateString('en-GB', { weekday: 'long' });
+    const dayNum = d.getDate();
+    const monthName = d.toLocaleDateString('en-GB', { month: 'long' });
+    const year = d.getFullYear();
+    const formattedDateShort = `${dayNum} ${monthName}`;
+    const formattedDateLong = `${dayName}, ${dayNum} ${monthName} ${year}`;
+
+    const base = process.env.FRONTEND_URL || `${req.protocol}://${req.get('host')}`;
+    const sessionUrl = `${base}/sessions/${groupKey}/${dateParam}`;
+    const loginUrl = `${base}/login?returnTo=${encodeURIComponent(`/sessions/${groupKey}/${dateParam}`)}`;
+
+    const subject = `${groupName} details for ${formattedDateShort}`;
+
+    const volunteerName = String(spEntry[PROFILE_DISPLAY] || '').trim();
+
+    const html = `
+<p>${volunteerName}, you're booked onto the next <strong>${groupName}</strong>.</p>
+
+<p>
+  <strong>Date:</strong> ${formattedDateLong}<br>
+  <strong>Time:</strong> 9:30 to 12:30 (about 3 hours)<br>
+  <strong>Location:</strong> Forest of Dean Cycle Centre
+</p>
+
+${description ? `<p>${description.replace(/\n/g, '<br>')}</p>` : ''}
+
+<p>Please bring sturdy boots, clothes you don't mind getting muddy, and water. Gloves are useful if you have them. We'll provide tools and hi-viz.</p>
+
+<p>Read more: <a href="${sessionUrl}">View session page</a></p>
+
+${isRegular ? `<p>You're a ${groupName} regular, so we sign you up automatically.</p>` : ''}
+
+<p>Can't make it? Please let us know and <a href="${loginUrl}">log in to cancel your place</a>.</p>
+
+${myChildNames ? `<p>You're signed up as the accompanying adult for ${myChildNames}.</p>` : ''}
+
+<p>Dean Trail Volunteers</p>
+    `.trim();
+
+    const text = [
+      `${volunteerName}, you're booked onto the next ${groupName}.`,
+      '',
+      `Date: ${formattedDateLong}`,
+      'Time: 9:30 to 12:30 (about 3 hours)',
+      'Location: Forest of Dean Cycle Centre',
+      '',
+      description || '',
+      '',
+      "Please bring sturdy boots, clothes you don't mind getting muddy, and water. Gloves are useful if you have them. We'll provide tools and hi-viz.",
+      '',
+      `Read more: ${sessionUrl}`,
+      '',
+      isRegular ? `You're a ${groupName} regular, so we sign you up automatically.` : '',
+      '',
+      `Can't make it? Log in to cancel your place: ${loginUrl}`,
+      '',
+      myChildNames ? `You're signed up as the accompanying adult for ${myChildNames}.` : '',
+      '',
+      'Dean Trail Volunteers',
+    ].filter(line => line !== undefined).join('\n');
+
+    const preview = req.body?.preview === true;
+    const toEmail = preview ? (req.session.user?.email || primaryEmail) : primaryEmail;
+
+    await sendEmail(toEmail, subject, html, text);
+
+    res.json({ success: true, data: { sent: 1 } } as ApiResponse<{ sent: number }>);
+  } catch (error: any) {
+    console.error('Error sending entry notify email:', error);
+    res.status(500).json({ success: false, error: 'Failed to send email', message: error.message });
   }
 });
 

--- a/routes/profiles.ts
+++ b/routes/profiles.ts
@@ -732,7 +732,7 @@ router.get('/profiles/:slug', async (req: Request, res: Response) => {
           hours: parseHours(e.Hours),
           checkedIn: e.Checked || false,
           notes: e.Notes,
-          accompanyingAdultId: e.AccompanyingAdultLookupId,
+          accompanyingAdultId: safeParseLookupId(e.AccompanyingAdultLookupId),
           financialYear: `FY${sessionFY}`,
           cancelled: e[ENTRY_CANCELLED] || undefined
         };

--- a/routes/sessions.ts
+++ b/routes/sessions.ts
@@ -487,6 +487,7 @@ router.get('/sessions/:group/:date', async (req: Request, res: Response) => {
     const selfProfileId = req.session.user?.profileId;
     const selfProfileStats = req.session.user?.profileStats;
     const isSelfService = role === 'selfservice';
+    const isOperational = role === 'admin' || role === 'checkin';
 
     const [rawEntries, rawProfiles] = await Promise.all([
       isSelfService ? Promise.resolve([]) : entriesRepository.getBySessionIds([spSession.ID]),
@@ -521,7 +522,7 @@ router.get('/sessions/:group/:date', async (req: Request, res: Response) => {
         notes: e.Notes,
         accompanyingAdultId: safeParseLookupId(e.AccompanyingAdultLookupId),
         cancelled: e[ENTRY_CANCELLED] || undefined,
-        email: !isSelfService ? (profile ? parseEmails(profile.Email)[0] : undefined) : undefined
+        email: isOperational ? (profile ? parseEmails(profile.Email)[0] : undefined) : undefined
       };
     });
 

--- a/routes/sessions.ts
+++ b/routes/sessions.ts
@@ -25,7 +25,8 @@ import {
   nameToSlug,
   profileSlug,
   extractMetadataTags,
-  calculateSessionStats
+  calculateSessionStats,
+  parseEmails
 } from '../services/data-layer';
 import {
   GROUP_LOOKUP, GROUP_DISPLAY,
@@ -518,8 +519,9 @@ router.get('/sessions/:group/:date', async (req: Request, res: Response) => {
         hours: parseHours(e.Hours),
         checkedIn: e.Checked || false,
         notes: e.Notes,
-        accompanyingAdultId: e.AccompanyingAdultLookupId,
-        cancelled: e[ENTRY_CANCELLED] || undefined
+        accompanyingAdultId: safeParseLookupId(e.AccompanyingAdultLookupId),
+        cancelled: e[ENTRY_CANCELLED] || undefined,
+        email: !isSelfService ? (profile ? parseEmails(profile.Email)[0] : undefined) : undefined
       };
     });
 

--- a/services/data-layer.ts
+++ b/services/data-layer.ts
@@ -555,9 +555,9 @@ export function toMatchName(name: string | undefined): string {
  * Safely converts a lookup ID to a number
  * Returns undefined if the ID is invalid
  */
-export function safeParseLookupId(lookupId: string | undefined): number | undefined {
-  if (!lookupId) return undefined;
-  const parsed = parseInt(lookupId, 10);
+export function safeParseLookupId(lookupId: string | number | undefined): number | undefined {
+  if (lookupId === undefined || lookupId === null) return undefined;
+  const parsed = parseInt(String(lookupId), 10);
   return isNaN(parsed) ? undefined : parsed;
 }
 

--- a/types/api-responses.ts
+++ b/types/api-responses.ts
@@ -173,6 +173,7 @@ export interface EntryResponse {
   notes?: string;
   accompanyingAdultId?: number;
   cancelled?: string; // ISO datetime if booking was cancelled
+  email?: string;     // only present for operational users (admin/check-in)
 }
 
 export interface SessionDetailResponse {


### PR DESCRIPTION
POST /entries/:entryId/notify sends a pre-session email for a specific entry. Modal lets operational users choose recipient (individual or all adults) and preview to their own address. Accompanying adult block shows only that recipient's own children. Fix safeParseLookupId to accept number | undefined, correcting AccompanyingAdultLookupId comparisons.