### PR TITLE
feat: child status via AccompanyingAdult + Regular Edit Modal (#185)

### DIFF
--- a/docs/sharepoint-schema.md
+++ b/docs/sharepoint-schema.md
@@ -199,12 +199,14 @@ Fall back to zeros/false if the field is empty (e.g. before first refresh run).
 | **Title** | Title | Single line of text | No | Regular membership title |
 | **Profile** | Profile | Lookup | No | Links to Profiles list (shows Title) |
 | **Group** | Group | Lookup | No | Links to Groups list (shows Title) |
+| **AccompanyingAdult** | AccompanyingAdult | Lookup | No | For child regulars: the adult responsible on the day; copied to entry when regulars are added to a session |
 | **Modified** | Modified | Date and Time | Auto | Last modified timestamp (read-only) |
 | **Created** | Created | Date and Time | Auto | Creation timestamp (read-only) |
 
 ### Lookup Fields
 - **Profile** / **ProfileLookupId**: Lookup to Profiles list
 - **Group** / **GroupLookupId**: Lookup to Groups list
+- **AccompanyingAdult** / **AccompanyingAdultLookupId**: Lookup to Profiles list
 
 ### Data Model Notes
 This is a **many-to-many junction table** that creates the relationship between:

--- a/frontend/src/components/EntryIconPicker.vue
+++ b/frontend/src/components/EntryIconPicker.vue
@@ -3,7 +3,7 @@
     <AppButton
       v-for="t in tagButtons"
       :key="t.manualKey"
-      :label="t.activeLabel ? `${t.alt} (${t.activeLabel})` : t.alt"
+      :label="(isActive(t.manualKey!) ? 'Unset ' : 'Set ') + (t.activeLabel ? `${t.alt} (${t.activeLabel})` : t.alt)"
       :icon="t.icon.replace('.svg', '')"
       mode="icon-only"
       :variant="isActive(t.manualKey!) ? 'primary' : 'subtle'"

--- a/frontend/src/components/EntryIconPicker.vue
+++ b/frontend/src/components/EntryIconPicker.vue
@@ -1,29 +1,33 @@
 <template>
   <div class="etp-tags">
-    <div v-for="t in tagButtons" :key="t.manualKey" class="etp-tag">
-      <AppButton
-        :label="t.alt"
-        :icon="t.icon.replace('.svg', '')"
-        mode="icon-only"
-        :variant="isActive(t.manualKey!) ? 'primary' : 'subtle'"
-        :selected="isActive(t.manualKey!)"
-        :disabled="disabled"
-        @click="!disabled && toggleTag(t.manualKey!)"
-      />
-      <span v-if="t.activeLabel && isActive(t.manualKey!)" class="etp-active-label">{{ t.activeLabel }}</span>
-    </div>
+    <AppButton
+      v-for="t in tagButtons"
+      :key="t.manualKey"
+      :label="t.activeLabel ? `${t.alt} (${t.activeLabel})` : t.alt"
+      :icon="t.icon.replace('.svg', '')"
+      mode="icon-only"
+      :variant="isActive(t.manualKey!) ? 'primary' : 'subtle'"
+      :selected="isActive(t.manualKey!)"
+      :disabled="disabled"
+      @click="!disabled && toggleTag(t.manualKey!)"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
 import { EDITABLE_TAG_ICONS } from '../utils/tagIcons'
 import AppButton from './AppButton.vue'
-import type { EntryStatsManual } from '../../../types/entry-stats'
+import type { EntryStatsManual, EntryStatsSnapshot } from '../../../types/entry-stats'
 
-const props = defineProps<{ modelValue: EntryStatsManual; disabled?: boolean }>()
+const props = defineProps<{ modelValue: EntryStatsManual; snapshot?: EntryStatsSnapshot; disabled?: boolean }>()
 const emit = defineEmits<{ 'update:modelValue': [value: EntryStatsManual] }>()
 
-const tagButtons = EDITABLE_TAG_ICONS
+const tagButtons = computed(() =>
+  EDITABLE_TAG_ICONS.filter(t =>
+    !t.snapshotKey || props.snapshot?.[t.snapshotKey]
+  )
+)
 
 function isActive(key: keyof EntryStatsManual): boolean {
   return props.modelValue[key] === true
@@ -36,18 +40,4 @@ function toggleTag(key: keyof EntryStatsManual) {
 
 <style scoped>
 .etp-tags { display: flex; flex-wrap: wrap; gap: 0.4rem; }
-
-.etp-tag {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.15rem;
-}
-
-.etp-active-label {
-  font-size: 0.65rem;
-  color: var(--color-dtv-green-dark);
-  font-weight: 600;
-  line-height: 1;
-}
 </style>

--- a/frontend/src/components/EntryIconPicker.vue
+++ b/frontend/src/components/EntryIconPicker.vue
@@ -1,44 +1,53 @@
 <template>
   <div class="etp-tags">
-    <AppButton
-      v-for="t in tagButtons"
-      :key="t.tag"
-      :label="t.alt"
-      :icon="t.icon.replace('.svg', '')"
-      mode="icon-only"
-      :variant="hasTag(t.tag!) ? 'primary' : 'subtle'"
-      :selected="hasTag(t.tag!)"
-      :disabled="disabled"
-      @click="!disabled && toggleTag(t.tag!)"
-    />
+    <div v-for="t in tagButtons" :key="t.manualKey" class="etp-tag">
+      <AppButton
+        :label="t.alt"
+        :icon="t.icon.replace('.svg', '')"
+        mode="icon-only"
+        :variant="isActive(t.manualKey!) ? 'primary' : 'subtle'"
+        :selected="isActive(t.manualKey!)"
+        :disabled="disabled"
+        @click="!disabled && toggleTag(t.manualKey!)"
+      />
+      <span v-if="t.activeLabel && isActive(t.manualKey!)" class="etp-active-label">{{ t.activeLabel }}</span>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
 import { EDITABLE_TAG_ICONS } from '../utils/tagIcons'
 import AppButton from './AppButton.vue'
+import type { EntryStatsManual } from '../../../types/entry-stats'
 
-const props = defineProps<{ modelValue: string; disabled?: boolean }>()
-const emit = defineEmits<{ 'update:modelValue': [value: string] }>()
+const props = defineProps<{ modelValue: EntryStatsManual; disabled?: boolean }>()
+const emit = defineEmits<{ 'update:modelValue': [value: EntryStatsManual] }>()
 
 const tagButtons = EDITABLE_TAG_ICONS
 
-function hasTag(tag: string): boolean {
-  return new RegExp(tag, 'i').test(props.modelValue)
+function isActive(key: keyof EntryStatsManual): boolean {
+  return props.modelValue[key] === true
 }
 
-function toggleTag(tag: string) {
-  let notes = props.modelValue
-  if (hasTag(tag)) {
-    notes = notes.replace(new RegExp('\\s*' + tag, 'gi'), '').trim()
-  } else {
-    notes = notes ? notes.trimEnd() + ' ' + tag : tag
-  }
-  emit('update:modelValue', notes)
+function toggleTag(key: keyof EntryStatsManual) {
+  emit('update:modelValue', { ...props.modelValue, [key]: !props.modelValue[key] || undefined })
 }
 </script>
 
 <style scoped>
 .etp-tags { display: flex; flex-wrap: wrap; gap: 0.4rem; }
+
+.etp-tag {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.15rem;
+}
+
+.etp-active-label {
+  font-size: 0.65rem;
+  color: var(--color-dtv-green-dark);
+  font-weight: 600;
+  line-height: 1;
+}
 </style>

--- a/frontend/src/components/RegularItem.vue
+++ b/frontend/src/components/RegularItem.vue
@@ -1,56 +1,32 @@
 <template>
-  <div class="ri-card">
-    <template v-if="allowToggleRegular">
-      <span v-if="working" class="ri-spinner" />
-      <input
-        v-else
-        type="checkbox"
-        class="ri-checkbox"
-        :checked="isRegular"
-        @change="onToggle"
-      />
-    </template>
-    <input
-      v-else-if="isRegular"
-      type="checkbox"
-      class="ri-checkbox ri-checkbox--static"
-      checked
-      tabindex="-1"
-      readonly
-    />
-
-    <RouterLink :to="linkTo" class="ri-name">{{ name }}</RouterLink>
+  <button
+    class="ri-card"
+    :class="{ 'ri-card--regular': isRegular, 'ri-card--child': accompanyingAdultId !== undefined }"
+    :disabled="working"
+    @click="emit('edit')"
+  >
+    <span v-if="working" class="ri-spinner" />
+    <span class="ri-name">{{ name }}</span>
     <strong class="ri-hours">{{ formatHours(hours) }}h</strong>
-  </div>
+  </button>
 </template>
 
 <script setup lang="ts">
-import { RouterLink } from 'vue-router'
-import type { RouteLocationRaw } from 'vue-router'
-
 const props = defineProps<{
   name: string
-  linkTo: RouteLocationRaw
   hours: number
   isRegular: boolean
   regularId?: number
-  allowToggleRegular?: boolean
+  accompanyingAdultId?: number
   working?: boolean
 }>()
 
 const emit = defineEmits<{
-  addRegular: []
-  removeRegular: []
+  edit: []
 }>()
 
 function formatHours(h: number): string {
   return h % 1 === 0 ? String(h) : h.toFixed(1)
-}
-
-function onToggle(event: Event) {
-  const isAdding = (event.target as HTMLInputElement).checked
-  if (isAdding) emit('addRegular')
-  else emit('removeRegular')
 }
 </script>
 
@@ -61,19 +37,22 @@ function onToggle(event: Event) {
   gap: 0.5rem;
   background: var(--color-dtv-sand);
   padding: 0.5rem 0.75rem;
-}
-
-.ri-checkbox {
-  accent-color: var(--color-dtv-green);
-  width: 1.1rem;
-  height: 1.1rem;
-  flex-shrink: 0;
+  border: 2px solid transparent;
   cursor: pointer;
+  font-family: inherit;
+  text-align: left;
 }
-.ri-checkbox--static {
-  pointer-events: none;
-  cursor: default;
+.ri-card:hover { background: var(--color-dtv-sand-dark); }
+.ri-card:disabled { opacity: 0.6; cursor: default; }
+
+.ri-card--regular {
+  background: var(--color-dtv-green);
+  border-color: var(--color-dtv-green);
 }
+.ri-card--regular:hover { background: var(--color-dtv-green-dark); border-color: var(--color-dtv-green-dark); }
+.ri-card--regular .ri-name { color: var(--color-dtv-light); }
+.ri-card--regular .ri-hours { color: var(--color-dtv-light); }
+.ri-card--child { border-style: dashed; }
 
 .ri-spinner {
   display: block;
@@ -91,9 +70,7 @@ function onToggle(event: Event) {
   flex: 1;
   font-size: 0.9rem;
   color: var(--color-text);
-  text-decoration: none;
 }
-.ri-name:hover { text-decoration: underline; }
 
 .ri-hours {
   font-size: 0.9rem;

--- a/frontend/src/components/RegularList.vue
+++ b/frontend/src/components/RegularList.vue
@@ -14,14 +14,12 @@
         v-for="item in items"
         :key="item.slug"
         :name="item.name"
-        :link-to="item.linkTo"
         :hours="item.hours"
         :is-regular="item.isRegular"
         :regular-id="item.regularId"
-        :allow-toggle-regular="allowToggleRegular"
+        :accompanying-adult-id="item.accompanyingAdultId"
         :working="workingSlug === item.slug"
-        @add-regular="emit('addRegular', item.slug, item.isRegular, item.regularId)"
-        @remove-regular="emit('removeRegular', item.slug, item.regularId)"
+        @edit="emit('editRegular', item.slug)"
       />
     </div>
 
@@ -31,28 +29,26 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import type { RouteLocationRaw } from 'vue-router'
 import RegularItem from './RegularItem.vue'
 
 export interface RegularListItem {
+  profileId?: number
   slug: string
   name: string
-  linkTo: RouteLocationRaw
   hours: number
   isRegular: boolean
   regularId?: number
+  accompanyingAdultId?: number
 }
 
 const props = defineProps<{
   items: RegularListItem[]
-  allowToggleRegular?: boolean
   workingSlug?: string
   error?: string
 }>()
 
 const emit = defineEmits<{
-  addRegular: [slug: string, isRegular: boolean, regularId: number | undefined]
-  removeRegular: [slug: string, regularId: number | undefined]
+  editRegular: [slug: string]
 }>()
 
 const regularCount = computed(() => props.items.filter(i => i.isRegular).length)

--- a/frontend/src/components/entries/EntryListItem.vue
+++ b/frontend/src/components/entries/EntryListItem.vue
@@ -29,7 +29,7 @@ import { computed } from 'vue'
 import { RouterLink } from 'vue-router'
 import type { RouteLocationRaw } from 'vue-router'
 import type { EntryListItemResponse } from '../../../../types/api-responses'
-import { iconsFromNotes } from '../../utils/tagIcons'
+import { iconsForEntry } from '../../utils/tagIcons'
 
 const props = defineProps<{
   entry: EntryListItemResponse
@@ -37,7 +37,7 @@ const props = defineProps<{
   selected?: boolean
 }>()
 
-const icons = computed(() => iconsFromNotes(props.entry.notes))
+const icons = computed(() => iconsForEntry({ isGroup: props.entry.isGroup, stats: props.entry.stats }))
 
 function formatDate(date: string): string {
   return new Date(date).toLocaleDateString('en-GB', { day: 'numeric', month: 'short' })

--- a/frontend/src/components/profiles/ProfileEntryList.vue
+++ b/frontend/src/components/profiles/ProfileEntryList.vue
@@ -39,7 +39,6 @@
       v-if="editingEntry"
       :entry="editingEntry"
       :title="cardTitle(editingEntry)"
-      :is-cancelled="!!editingEntry.cancelled"
       :is-admin="isAdmin"
       :session-click="() => router.push(sessionPath(editingEntry!.session.groupKey, editingEntry!.session.date))"
       :session-adults="sessionAdults"
@@ -64,7 +63,7 @@ import { sessionPath } from '../../router/index'
 import { iconsForEntry } from '../../utils/tagIcons'
 import { fetchSessionAdults } from '../../utils/fetchSessionAdults'
 
-type EditData = { checkedIn: boolean; count: number; hours: number; notes: string; accompanyingAdultId: number | null; statsManual: import('../../../../types/entry-stats').EntryStatsManual }
+type EditData = { checkedIn: boolean; count: number; hours: number; notes: string; accompanyingAdultId: number | null; statsManual: import('../../../../types/entry-stats').EntryStatsManual; cancelled: boolean }
 
 const props = defineProps<{
   entries: EntryItem[]
@@ -76,7 +75,6 @@ const props = defineProps<{
 const emit = defineEmits<{
   update: [entry: EntryItem, checkedIn: boolean, hours: number]
   editEntry: [id: number, data: EditData | null]
-  cancelEntry: [id: number]
 }>()
 
 const router = useRouter()
@@ -174,18 +172,12 @@ function onDelete() {
   if (!editingEntry.value) return
   workingEdit.value = true
   editError.value = ''
-  if (editingEntry.value.cancelled) {
-    emit('editEntry', editingEntry.value.id, null)
-  } else {
-    emit('cancelEntry', editingEntry.value.id)
-  }
+  emit('editEntry', editingEntry.value.id, null)
 }
 
 defineExpose({
   onEditSuccess: closeEditModal,
   onEditError(msg: string) { workingEdit.value = false; editError.value = msg },
-  onCancelSuccess: closeEditModal,
-  onCancelError(msg: string) { workingEdit.value = false; editError.value = msg },
 })
 </script>
 

--- a/frontend/src/components/profiles/ProfileEntryList.vue
+++ b/frontend/src/components/profiles/ProfileEntryList.vue
@@ -27,7 +27,7 @@
         :title-to="allowEdit ? undefined : sessionPath(e.session.groupKey, e.session.date)"
         :checked-in="e.checkedIn"
         :hours="e.hours"
-        :icons="iconsForEntry({ ...e.profile, notes: e.notes, stats: e.stats }).filter(i => i.type !== 'badge')"
+        :icons="iconsForEntry({ ...e.profile, stats: e.stats }).filter(i => i.type !== 'badge')"
         :allow-edit="allowEdit ?? false"
         :working="workingId === e.id"
         @update="(c, h) => emit('update', e, c, h)"
@@ -64,7 +64,7 @@ import { sessionPath } from '../../router/index'
 import { iconsForEntry } from '../../utils/tagIcons'
 import { fetchSessionAdults } from '../../utils/fetchSessionAdults'
 
-type EditData = { checkedIn: boolean; count: number; hours: number; notes: string; accompanyingAdultId: number | null }
+type EditData = { checkedIn: boolean; count: number; hours: number; notes: string; accompanyingAdultId: number | null; statsManual: import('../../../../types/entry-stats').EntryStatsManual }
 
 const props = defineProps<{
   entries: EntryItem[]

--- a/frontend/src/components/sessions/SessionEntryList.vue
+++ b/frontend/src/components/sessions/SessionEntryList.vue
@@ -119,7 +119,7 @@ const checkedCount = computed(() => props.entries.filter(e => e.checkedIn && !e.
 const eligibleCount = computed(() => props.entries.filter(e => e.checkedIn && !e.hours).length)
 const sessionAdults = computed(() =>
   props.entries
-    .filter(e => e.profileId && !e.profile.isGroup && !/\#child\b/i.test(e.notes ?? ''))
+    .filter(e => e.profileId && !e.profile.isGroup && !e.accompanyingAdultId)
     .map(e => ({ id: e.profileId!, name: e.profile.name }))
 )
 

--- a/frontend/src/components/sessions/SessionEntryList.vue
+++ b/frontend/src/components/sessions/SessionEntryList.vue
@@ -34,7 +34,6 @@
     <EntryEditModal
       v-if="editingEntry"
       :entry="editingEntry"
-      :is-cancelled="!!editingEntry.cancelled"
       :is-admin="isAdmin"
       :profile-click="editingEntry.profile.slug ? () => router.push(profilePath(editingEntry!.profile.slug!)) : undefined"
       :session-adults="sessionAdults"
@@ -82,7 +81,7 @@ import { profilePath } from '../../router/index'
 import { iconsForEntry } from '../../utils/tagIcons'
 
 type AddPayload = { profileId: number } | { newName: string; newEmail: string }
-type EditData = { checkedIn: boolean; count: number; hours: number; notes: string; accompanyingAdultId: number | null; statsManual: import('../../../../types/entry-stats').EntryStatsManual }
+type EditData = { checkedIn: boolean; count: number; hours: number; notes: string; accompanyingAdultId: number | null; statsManual: import('../../../../types/entry-stats').EntryStatsManual; cancelled: boolean }
 
 const props = defineProps<{
   entries: EntryItem[]
@@ -99,7 +98,6 @@ const emit = defineEmits<{
   setHours: [hours: number]
   addEntry: [payload: AddPayload]
   editEntry: [id: number, data: EditData | null]
-  cancelEntry: [id: number]
 }>()
 
 const editingEntry = ref<EntryItem | null>(null)
@@ -152,13 +150,7 @@ function onDelete() {
   if (!editingEntry.value) return
   workingEdit.value = true
   editError.value = ''
-  if (editingEntry.value.cancelled) {
-    // Already cancelled — hard delete (admin only, enforced by backend)
-    emit('editEntry', editingEntry.value.id, null)
-  } else {
-    // Not yet cancelled — soft cancel
-    emit('cancelEntry', editingEntry.value.id)
-  }
+  emit('editEntry', editingEntry.value.id, null)
 }
 
 function onAdd(payload: AddPayload) {
@@ -176,8 +168,6 @@ function onSetHours(hours: number) {
 defineExpose({
   onEditSuccess: closeEditModal,
   onEditError(msg: string) { workingEdit.value = false; editError.value = msg },
-  onCancelSuccess: closeEditModal,
-  onCancelError(msg: string) { workingEdit.value = false; editError.value = msg },
   onAddSuccess: closeAddModal,
   onAddError(msg: string) { workingAdd.value = false; addError.value = msg },
   onSetHoursSuccess: closeSetHoursModal,

--- a/frontend/src/components/sessions/SessionEntryList.vue
+++ b/frontend/src/components/sessions/SessionEntryList.vue
@@ -22,7 +22,7 @@
         :title-to="allowEdit ? undefined : (e.profile.slug ? profilePath(e.profile.slug) : undefined)"
         :checked-in="e.checkedIn"
         :hours="e.hours"
-        :icons="iconsForEntry({ ...e.profile, notes: e.notes, stats: e.stats })"
+        :icons="iconsForEntry({ ...e.profile, stats: e.stats })"
         :allow-edit="allowEdit"
         :working="workingId === e.id"
         :cancelled="!!e.cancelled"
@@ -82,7 +82,7 @@ import { profilePath } from '../../router/index'
 import { iconsForEntry } from '../../utils/tagIcons'
 
 type AddPayload = { profileId: number } | { newName: string; newEmail: string }
-type EditData = { checkedIn: boolean; count: number; hours: number; notes: string; accompanyingAdultId: number | null }
+type EditData = { checkedIn: boolean; count: number; hours: number; notes: string; accompanyingAdultId: number | null; statsManual: import('../../../../types/entry-stats').EntryStatsManual }
 
 const props = defineProps<{
   entries: EntryItem[]

--- a/frontend/src/pages/EntriesPage.vue
+++ b/frontend/src/pages/EntriesPage.vue
@@ -18,7 +18,6 @@
     <EntryEditModal
       v-if="editingEntry"
       :entry="editingEntry"
-      :is-cancelled="!!editingEntry.cancelled"
       :is-admin="viewer.isAdmin"
       :profile-click="editingEntry.profile.slug ? () => router.push(profilePath(editingEntry!.profile.slug!)) : undefined"
       :session-click="() => router.push(sessionPath(editingEntry!.session.groupKey, editingEntry!.session.date))"
@@ -49,7 +48,7 @@ import EntryEditModal from './modals/EntryEditModal.vue'
 import { profilePath, sessionPath } from '../router/index'
 import { fetchSessionAdults } from '../utils/fetchSessionAdults'
 
-type EditData = { checkedIn: boolean; count: number; hours: number; notes: string; accompanyingAdultId: number | null; statsManual: import('../../../types/entry-stats').EntryStatsManual }
+type EditData = { checkedIn: boolean; count: number; hours: number; notes: string; accompanyingAdultId: number | null; statsManual: import('../../../types/entry-stats').EntryStatsManual; cancelled: boolean }
 
 const store = useEntryListStore()
 const router = useRouter()
@@ -131,6 +130,7 @@ async function onSave(data: EditData) {
       stored.accompanyingAdultId = data.accompanyingAdultId ?? undefined
       stored.hasAccompanyingAdult = data.accompanyingAdultId !== null
       stored.stats = { ...stored.stats, manual: data.statsManual }
+      stored.cancelled = data.cancelled ? (stored.cancelled || new Date().toISOString()) : undefined
       if (!matchesFilter(stored, currentFilter.value)) {
         store.entries.splice(idx, 1)
         selected.value = selected.value.filter(id => id !== editingEntry.value!.id)
@@ -149,34 +149,16 @@ async function onDelete() {
   editWorking.value = true
   editError.value = undefined
   const id = editingEntry.value.id
-  const isCancelled = !!editingEntry.value.cancelled
   try {
-    if (isCancelled) {
-      const res = await fetch(`/api/entries/${id}`, { method: 'DELETE' })
-      if (!res.ok) throw new Error(`Delete failed (${res.status})`)
-      const delIdx = store.entries.findIndex(e => e.id === id)
-      if (delIdx >= 0) store.entries.splice(delIdx, 1)
-      selected.value = selected.value.filter(sid => sid !== id)
-    } else {
-      const res = await fetch(`/api/entries/${id}`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ cancelled: true }),
-      })
-      if (!res.ok) throw new Error(`Cancel failed (${res.status})`)
-      const stored = store.entries.find(e => e.id === id)
-      if (stored) stored.cancelled = new Date().toISOString()
-      // Remove from list if filter excludes cancelled entries
-      if (currentFilter.value.cancelled === 'false' || !currentFilter.value.cancelled) {
-        const cancelIdx = store.entries.findIndex(e => e.id === id)
-        if (cancelIdx >= 0) store.entries.splice(cancelIdx, 1)
-        selected.value = selected.value.filter(sid => sid !== id)
-      }
-    }
+    const res = await fetch(`/api/entries/${id}`, { method: 'DELETE' })
+    if (!res.ok) throw new Error(`Delete failed (${res.status})`)
+    const idx = store.entries.findIndex(e => e.id === id)
+    if (idx >= 0) store.entries.splice(idx, 1)
+    selected.value = selected.value.filter(sid => sid !== id)
     closeEditModal()
   } catch (e) {
-    console.error('[EntriesPage] delete/cancel failed', e)
-    editError.value = isCancelled ? 'Failed to delete — please try again' : 'Failed to cancel — please try again'
+    console.error('[EntriesPage] delete failed', e)
+    editError.value = 'Failed to delete — please try again'
     editWorking.value = false
   }
 }

--- a/frontend/src/pages/EntriesPage.vue
+++ b/frontend/src/pages/EntriesPage.vue
@@ -49,7 +49,7 @@ import EntryEditModal from './modals/EntryEditModal.vue'
 import { profilePath, sessionPath } from '../router/index'
 import { fetchSessionAdults } from '../utils/fetchSessionAdults'
 
-type EditData = { checkedIn: boolean; count: number; hours: number; notes: string; accompanyingAdultId: number | null }
+type EditData = { checkedIn: boolean; count: number; hours: number; notes: string; accompanyingAdultId: number | null; statsManual: import('../../../types/entry-stats').EntryStatsManual }
 
 const store = useEntryListStore()
 const router = useRouter()
@@ -130,6 +130,7 @@ async function onSave(data: EditData) {
       stored.notes = data.notes
       stored.accompanyingAdultId = data.accompanyingAdultId ?? undefined
       stored.hasAccompanyingAdult = data.accompanyingAdultId !== null
+      stored.stats = { ...stored.stats, manual: data.statsManual }
       if (!matchesFilter(stored, currentFilter.value)) {
         store.entries.splice(idx, 1)
         selected.value = selected.value.filter(id => id !== editingEntry.value!.id)

--- a/frontend/src/pages/GroupDetailPage.vue
+++ b/frontend/src/pages/GroupDetailPage.vue
@@ -47,11 +47,22 @@
       <RegularList
         v-if="profile.isAdmin || profile.isCheckIn"
         :items="regularItems"
-        :allow-toggle-regular="profile.isAdmin || profile.isCheckIn"
         :working-slug="workingRegularSlug ?? undefined"
         :error="regularError"
-        @add-regular="onGroupAddRegular"
-        @remove-regular="onGroupRemoveRegular"
+        @edit-regular="onRegularEdit"
+      />
+
+      <RegularEditModal
+        v-if="editingRegular"
+        :regular="editingRegular"
+        :adults="regularAdults"
+        :accompanying-for="regularAccompanyingFor"
+        :working="regularWorking"
+        :error="regularModalError"
+        @close="editingRegular = null"
+        @view-link="router.push(profilePath(editingRegular.slug))"
+        @save="onRegularSave"
+        @delete="onRegularDelete"
       />
 
       <!-- Group Contribution: bar chart left, word cloud right -->
@@ -99,6 +110,8 @@ import GroupDetailHeader from '../components/groups/GroupDetailHeader.vue'
 import GroupDetailActions from '../components/groups/GroupDetailActions.vue'
 import RegularList from '../components/RegularList.vue'
 import type { RegularListItem } from '../components/RegularList.vue'
+import RegularEditModal from './modals/RegularEditModal.vue'
+import type { RegularEditItem } from './modals/RegularEditModal.vue'
 import SessionListResults from '../components/sessions/SessionListResults.vue'
 import FyBarChart from '../components/FyBarChart.vue'
 import TermCloud from '../components/TermCloud.vue'
@@ -119,16 +132,27 @@ const profile = useViewer()
 const actionsRef = ref<InstanceType<typeof GroupDetailActions> | null>(null)
 const workingRegularSlug = ref<string | null>(null)
 const regularError = ref('')
+const editingRegular = ref<RegularEditItem | null>(null)
+const regularAccompanyingFor = ref<string[]>([])
+const regularWorking = ref(false)
+const regularModalError = ref('')
 
 const regularItems = computed<RegularListItem[]>(() =>
   (store.group?.regulars ?? []).map(r => ({
+    profileId: r.profileId,
     slug: r.slug,
     name: r.name,
-    linkTo: profilePath(r.slug),
     hours: r.hours,
     isRegular: r.isRegular,
     regularId: r.regularId,
+    accompanyingAdultId: r.accompanyingAdultId,
   }))
+)
+
+const regularAdults = computed(() =>
+  regularItems.value
+    .filter(r => r.isRegular && r.accompanyingAdultId === undefined && r.profileId !== undefined)
+    .map(r => ({ id: r.profileId as number, name: r.name }))
 )
 
 const titleText = computed(() => store.group?.displayName || store.group?.key || '')
@@ -276,41 +300,82 @@ async function onDeleteGroup() {
   }
 }
 
-async function onGroupAddRegular(profileSlug: string) {
-  if (!store.group) return
-  workingRegularSlug.value = profileSlug
-  regularError.value = ''
+function onRegularEdit(slug: string) {
+  const item = regularItems.value.find(r => r.slug === slug)
+  if (!item) return
+  regularModalError.value = ''
+  regularAccompanyingFor.value = item.profileId !== undefined
+    ? regularItems.value.filter(r => r.accompanyingAdultId === item.profileId).map(r => r.name)
+    : []
+  editingRegular.value = {
+    name: item.name,
+    slug: item.slug,
+    regularId: item.regularId,
+    accompanyingAdultId: item.accompanyingAdultId,
+  }
+}
+
+async function onRegularSave(data: { accompanyingAdultId: number | null }) {
+  if (!editingRegular.value || !store.group) return
+  const { slug, regularId } = editingRegular.value
+  workingRegularSlug.value = slug
+  regularWorking.value = true
+  regularModalError.value = ''
   try {
-    const res = await fetch(`/api/profiles/${profileSlug}/regulars`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ groupId: store.group.id }),
-    })
-    if (!res.ok) throw new Error(`Add failed (${res.status})`)
-    const json = await res.json()
-    const item = store.group.regulars.find(r => r.slug === profileSlug)
-    if (item) { item.isRegular = true; item.regularId = json.data.id }
+    if (regularId !== undefined) {
+      const res = await fetch(`/api/regulars/${regularId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ accompanyingAdultId: data.accompanyingAdultId }),
+      })
+      if (!res.ok) throw new Error(`Update failed (${res.status})`)
+      const item = store.group.regulars.find(r => r.slug === slug)
+      if (item) item.accompanyingAdultId = data.accompanyingAdultId ?? undefined
+    } else {
+      const res = await fetch(`/api/profiles/${slug}/regulars`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          groupId: store.group.id,
+          ...(data.accompanyingAdultId !== null && { accompanyingAdultId: data.accompanyingAdultId }),
+        }),
+      })
+      if (!res.ok) throw new Error(`Add failed (${res.status})`)
+      const json = await res.json()
+      const item = store.group.regulars.find(r => r.slug === slug)
+      if (item) {
+        item.isRegular = true
+        item.regularId = json.data.id
+        item.accompanyingAdultId = data.accompanyingAdultId ?? undefined
+      }
+    }
+    editingRegular.value = null
   } catch (e) {
-    console.error('[GroupDetailPage] onGroupAddRegular failed', e)
-    regularError.value = 'Failed to update — please try again'
+    console.error('[GroupDetailPage] onRegularSave failed', e)
+    regularModalError.value = 'Failed to save — please try again'
   } finally {
+    regularWorking.value = false
     workingRegularSlug.value = null
   }
 }
 
-async function onGroupRemoveRegular(profileSlug: string, regularId: number | undefined) {
-  if (!store.group || regularId === undefined) return
-  workingRegularSlug.value = profileSlug
-  regularError.value = ''
+async function onRegularDelete() {
+  if (!editingRegular.value?.regularId || !store.group) return
+  const { slug, regularId } = editingRegular.value
+  workingRegularSlug.value = slug
+  regularWorking.value = true
+  regularModalError.value = ''
   try {
     const res = await fetch(`/api/regulars/${regularId}`, { method: 'DELETE' })
     if (!res.ok) throw new Error(`Delete failed (${res.status})`)
-    const item = store.group.regulars.find(r => r.slug === profileSlug)
-    if (item) { item.isRegular = false; item.regularId = undefined }
+    const item = store.group.regulars.find(r => r.slug === slug)
+    if (item) { item.isRegular = false; item.regularId = undefined; item.accompanyingAdultId = undefined }
+    editingRegular.value = null
   } catch (e) {
-    console.error('[GroupDetailPage] onGroupRemoveRegular failed', e)
-    regularError.value = 'Failed to update — please try again'
+    console.error('[GroupDetailPage] onRegularDelete failed', e)
+    regularModalError.value = 'Failed to delete — please try again'
   } finally {
+    regularWorking.value = false
     workingRegularSlug.value = null
   }
 }

--- a/frontend/src/pages/ProfileDetailPage.vue
+++ b/frontend/src/pages/ProfileDetailPage.vue
@@ -491,7 +491,7 @@ function mapProfileEntry(e: ProfileEntryResponse): EntryItem {
 
 const entries = computed<EntryItem[]>(() => (store.profile?.entries ?? []).map(mapProfileEntry))
 
-type EditData = { checkedIn: boolean; count: number; hours: number; notes: string; accompanyingAdultId: number | null }
+type EditData = { checkedIn: boolean; count: number; hours: number; notes: string; accompanyingAdultId: number | null; statsManual: import('../../../types/entry-stats').EntryStatsManual }
 
 async function onEntryUpdate(entry: EntryItem, checkedIn: boolean, hours: number) {
   workingId.value = entry.id
@@ -536,6 +536,7 @@ async function onEditEntry(id: number, data: EditData | null) {
             count: data.count,
             notes: data.notes,
             accompanyingAdultId: data.accompanyingAdultId ?? undefined,
+            stats: { ...store.profile.entries[idx].stats, manual: data.statsManual },
           })
         }
       }

--- a/frontend/src/pages/ProfileDetailPage.vue
+++ b/frontend/src/pages/ProfileDetailPage.vue
@@ -111,7 +111,6 @@
             ref="entryListRef"
             @update="onEntryUpdate"
             @edit-entry="onEditEntry"
-            @cancel-entry="onCancelEntry"
           />
         </template>
       </LayoutColumns>
@@ -136,7 +135,6 @@
         v-if="childEditingEntry"
         :entry="childEditingEntry"
         :title="childEditingEntry.profile.name"
-        :is-cancelled="!!childEditingEntry.cancelled"
         :is-admin="viewer.isAdmin"
         :profile-click="childEditingEntry.profile.slug ? () => router.push(profilePath(childEditingEntry!.profile.slug!)) : undefined"
         :session-click="() => router.push(sessionPath(childEditingEntry!.session.groupKey, childEditingEntry!.session.date))"
@@ -491,7 +489,7 @@ function mapProfileEntry(e: ProfileEntryResponse): EntryItem {
 
 const entries = computed<EntryItem[]>(() => (store.profile?.entries ?? []).map(mapProfileEntry))
 
-type EditData = { checkedIn: boolean; count: number; hours: number; notes: string; accompanyingAdultId: number | null; statsManual: import('../../../types/entry-stats').EntryStatsManual }
+type EditData = { checkedIn: boolean; count: number; hours: number; notes: string; accompanyingAdultId: number | null; statsManual: import('../../../types/entry-stats').EntryStatsManual; cancelled: boolean }
 
 async function onEntryUpdate(entry: EntryItem, checkedIn: boolean, hours: number) {
   workingId.value = entry.id
@@ -537,6 +535,7 @@ async function onEditEntry(id: number, data: EditData | null) {
             notes: data.notes,
             accompanyingAdultId: data.accompanyingAdultId ?? undefined,
             stats: { ...store.profile.entries[idx].stats, manual: data.statsManual },
+            cancelled: data.cancelled ? (store.profile.entries[idx].cancelled || new Date().toISOString()) : undefined,
           })
         }
       }
@@ -548,22 +547,6 @@ async function onEditEntry(id: number, data: EditData | null) {
   }
 }
 
-async function onCancelEntry(id: number) {
-  try {
-    const res = await fetch(`/api/entries/${id}`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ cancelled: true }),
-    })
-    if (!res.ok) throw new Error(`Cancel failed (${res.status})`)
-    const stored = store.profile?.entries.find(e => e.id === id)
-    if (stored) stored.cancelled = new Date().toISOString()
-    entryListRef.value?.onCancelSuccess()
-  } catch (e) {
-    console.error('[ProfileDetailPage] onCancelEntry failed', e)
-    entryListRef.value?.onCancelError('Failed to cancel — please try again')
-  }
-}
 
 function mapChildEntryToItem(e: EntryListItemResponse): EntryItem {
   return {

--- a/frontend/src/pages/ProfileDetailPage.vue
+++ b/frontend/src/pages/ProfileDetailPage.vue
@@ -68,11 +68,22 @@
 
       <RegularList
         :items="regularItems"
-        :allow-toggle-regular="viewer.isOperational"
         :working-slug="workingRegularSlug ?? undefined"
         :error="regularError"
-        @add-regular="onAddRegular"
-        @remove-regular="onRemoveRegular"
+        @edit-regular="onRegularEdit"
+      />
+
+      <RegularEditModal
+        v-if="editingRegular && viewer.isOperational"
+        :regular="editingRegular"
+        :adults="[]"
+        view-link-label="View Group"
+        :working="regularWorking"
+        :error="regularModalError"
+        @close="editingRegular = null"
+        @view-link="router.push(groupPath(editingRegular.groupKey))"
+        @save="onRegularSave"
+        @delete="onRegularDelete"
       />
 
       <ProfileRecordList
@@ -162,7 +173,9 @@ import ProfileRecordList from '../components/profiles/ProfileRecordList.vue'
 import RegularList from '../components/RegularList.vue'
 import EntryListItem from '../components/entries/EntryListItem.vue'
 import EntryEditModal from './modals/EntryEditModal.vue'
+import RegularEditModal from './modals/RegularEditModal.vue'
 import type { RegularListItem } from '../components/RegularList.vue'
+import type { RegularEditItem } from './modals/RegularEditModal.vue'
 import { useViewer } from '../composables/useViewer'
 import { usePageTitle } from '../composables/usePageTitle'
 import { useProfileDetailStore } from '../stores/profileDetail'
@@ -187,12 +200,14 @@ const actionsRef = ref<InstanceType<typeof ProfileDetailActions> | null>(null)
 const recordListRef = ref<InstanceType<typeof ProfileRecordList> | null>(null)
 const workingRegularSlug = ref<string | null>(null)
 const regularError = ref('')
+const editingRegular = ref<(RegularEditItem & { groupKey: string }) | null>(null)
+const regularWorking = ref(false)
+const regularModalError = ref('')
 
 const regularItems = computed<RegularListItem[]>(() =>
   (store.profile?.groupHours ?? []).map(g => ({
     slug: g.groupKey,
     name: g.groupName,
-    linkTo: groupPath(g.groupKey),
     hours: g.hoursRolling,
     isRegular: g.isRegular,
     regularId: g.regularId,
@@ -379,43 +394,72 @@ async function onDeleteRecord(id: number) {
   }
 }
 
-async function onAddRegular(groupKey: string) {
-  if (!store.profile) return
+function onRegularEdit(groupKey: string) {
+  const group = store.profile?.groupHours.find(g => g.groupKey === groupKey)
+  if (!group) return
+  regularModalError.value = ''
+  editingRegular.value = {
+    name: group.groupName,
+    slug: groupKey,
+    groupKey,
+    regularId: group.regularId,
+  }
+}
+
+async function onRegularSave(data: { accompanyingAdultId: number | null }) {
+  if (!editingRegular.value || !store.profile) return
+  const { slug: groupKey, regularId } = editingRegular.value
   workingRegularSlug.value = groupKey
-  regularError.value = ''
+  regularWorking.value = true
+  regularModalError.value = ''
   try {
-    const group = store.profile.groupHours.find(g => g.groupKey === groupKey)
-    if (!group) throw new Error('Group not found')
-    const res = await fetch(`/api/profiles/${route.params.slug}/regulars`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ groupId: group.groupId }),
-    })
-    if (!res.ok) throw new Error(`Add failed (${res.status})`)
-    const json = await res.json()
-    group.isRegular = true
-    group.regularId = json.data.id
+    if (regularId !== undefined) {
+      const res = await fetch(`/api/regulars/${regularId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ accompanyingAdultId: data.accompanyingAdultId }),
+      })
+      if (!res.ok) throw new Error(`Update failed (${res.status})`)
+    } else {
+      const group = store.profile.groupHours.find(g => g.groupKey === groupKey)
+      if (!group) throw new Error('Group not found')
+      const res = await fetch(`/api/profiles/${route.params.slug}/regulars`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ groupId: group.groupId }),
+      })
+      if (!res.ok) throw new Error(`Add failed (${res.status})`)
+      const json = await res.json()
+      group.isRegular = true
+      group.regularId = json.data.id
+    }
+    editingRegular.value = null
   } catch (e) {
-    console.error('[ProfileDetailPage] onAddRegular failed', e)
-    regularError.value = 'Failed to update — please try again'
+    console.error('[ProfileDetailPage] onRegularSave failed', e)
+    regularModalError.value = 'Failed to update — please try again'
   } finally {
+    regularWorking.value = false
     workingRegularSlug.value = null
   }
 }
 
-async function onRemoveRegular(groupKey: string, regularId: number | undefined) {
-  if (!store.profile || regularId === undefined) return
+async function onRegularDelete() {
+  if (!editingRegular.value?.regularId || !store.profile) return
+  const { slug: groupKey, regularId } = editingRegular.value
   workingRegularSlug.value = groupKey
-  regularError.value = ''
+  regularWorking.value = true
+  regularModalError.value = ''
   try {
     const res = await fetch(`/api/regulars/${regularId}`, { method: 'DELETE' })
     if (!res.ok) throw new Error(`Delete failed (${res.status})`)
     const group = store.profile.groupHours.find(g => g.groupKey === groupKey)
     if (group) { group.isRegular = false; group.regularId = undefined }
+    editingRegular.value = null
   } catch (e) {
-    console.error('[ProfileDetailPage] onRemoveRegular failed', e)
-    regularError.value = 'Failed to update — please try again'
+    console.error('[ProfileDetailPage] onRegularDelete failed', e)
+    regularModalError.value = 'Failed to delete — please try again'
   } finally {
+    regularWorking.value = false
     workingRegularSlug.value = null
   }
 }
@@ -447,7 +491,7 @@ function mapProfileEntry(e: ProfileEntryResponse): EntryItem {
 
 const entries = computed<EntryItem[]>(() => (store.profile?.entries ?? []).map(mapProfileEntry))
 
-type EditData = { checkedIn: boolean; count: number; hours: number; notes: string }
+type EditData = { checkedIn: boolean; count: number; hours: number; notes: string; accompanyingAdultId: number | null }
 
 async function onEntryUpdate(entry: EntryItem, checkedIn: boolean, hours: number) {
   workingId.value = entry.id
@@ -482,12 +526,18 @@ async function onEditEntry(id: number, data: EditData | null) {
         body: JSON.stringify(data),
       })
       if (!res.ok) throw new Error(`Save failed (${res.status})`)
-      const stored = store.profile?.entries.find(e => e.id === id)
-      if (stored) {
-        stored.checkedIn = data.checkedIn
-        stored.hours = data.hours
-        stored.count = data.count
-        stored.notes = data.notes
+      if (store.profile) {
+        const idx = store.profile.entries.findIndex(e => e.id === id)
+        if (idx !== -1) {
+          store.profile.entries.splice(idx, 1, {
+            ...store.profile.entries[idx],
+            checkedIn: data.checkedIn,
+            hours: data.hours,
+            count: data.count,
+            notes: data.notes,
+            accompanyingAdultId: data.accompanyingAdultId ?? undefined,
+          })
+        }
       }
     }
     entryListRef.value?.onEditSuccess()

--- a/frontend/src/pages/ProfileDetailPage.vue
+++ b/frontend/src/pages/ProfileDetailPage.vue
@@ -417,7 +417,7 @@ async function onRegularSave(data: { accompanyingAdultId: number | null }) {
       const res = await fetch(`/api/regulars/${regularId}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ accompanyingAdultId: data.accompanyingAdultId }),
+        body: JSON.stringify({}),
       })
       if (!res.ok) throw new Error(`Update failed (${res.status})`)
     } else {

--- a/frontend/src/pages/SessionDetailPage.vue
+++ b/frontend/src/pages/SessionDetailPage.vue
@@ -172,7 +172,6 @@
             @set-hours="onSetHours"
             @add-entry="onAddEntry"
             @edit-entry="onEditEntry"
-            @cancel-entry="onCancelEntry"
           />
         </template>
       </LayoutColumns>
@@ -487,7 +486,7 @@ async function onAddEntry(payload: { profileId: number } | { newName: string; ne
   }
 }
 
-type EditData = { checkedIn: boolean; count: number; hours: number; notes: string; accompanyingAdultId: number | null; statsManual: import('../../../types/entry-stats').EntryStatsManual }
+type EditData = { checkedIn: boolean; count: number; hours: number; notes: string; accompanyingAdultId: number | null; statsManual: import('../../../types/entry-stats').EntryStatsManual; cancelled: boolean }
 
 async function onEditEntry(id: number, data: EditData | null) {
   try {
@@ -512,6 +511,7 @@ async function onEditEntry(id: number, data: EditData | null) {
         stored.notes = data.notes
         stored.accompanyingAdultId = data.accompanyingAdultId ?? undefined
         stored.stats = { ...stored.stats, manual: data.statsManual }
+        stored.cancelled = data.cancelled ? (stored.cancelled || new Date().toISOString()) : undefined
       }
     }
     entryListRef.value?.onEditSuccess()
@@ -521,22 +521,6 @@ async function onEditEntry(id: number, data: EditData | null) {
   }
 }
 
-async function onCancelEntry(id: number) {
-  try {
-    const res = await fetch(`/api/entries/${id}`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ cancelled: true }),
-    })
-    if (!res.ok) throw new Error(`Cancel failed (${res.status})`)
-    const stored = store.session?.entries.find(e => e.id === id)
-    if (stored) stored.cancelled = new Date().toISOString()
-    entryListRef.value?.onCancelSuccess()
-  } catch (e) {
-    console.error('[SessionDetailPage] onCancelEntry failed', e)
-    entryListRef.value?.onCancelError('Failed to cancel — please try again')
-  }
-}
 
 async function onBook() {
   if (!store.session?.userProfileId) return

--- a/frontend/src/pages/SessionDetailPage.vue
+++ b/frontend/src/pages/SessionDetailPage.vue
@@ -487,7 +487,7 @@ async function onAddEntry(payload: { profileId: number } | { newName: string; ne
   }
 }
 
-type EditData = { checkedIn: boolean; count: number; hours: number; notes: string; accompanyingAdultId: number | null }
+type EditData = { checkedIn: boolean; count: number; hours: number; notes: string; accompanyingAdultId: number | null; statsManual: import('../../../types/entry-stats').EntryStatsManual }
 
 async function onEditEntry(id: number, data: EditData | null) {
   try {
@@ -511,6 +511,7 @@ async function onEditEntry(id: number, data: EditData | null) {
         stored.count = data.count
         stored.notes = data.notes
         stored.accompanyingAdultId = data.accompanyingAdultId ?? undefined
+        stored.stats = { ...stored.stats, manual: data.statsManual }
       }
     }
     entryListRef.value?.onEditSuccess()

--- a/frontend/src/pages/modals/EntryEditModal.vue
+++ b/frontend/src/pages/modals/EntryEditModal.vue
@@ -33,7 +33,7 @@
       <FormRow title="Tags" :full-width="true">
         <div class="eem-tags">
           <AppButton
-            label="Child"
+            :label="(childMode ? 'Unset' : 'Set') + ' Child'"
             icon="badges/child"
             mode="icon-only"
             :variant="childMode ? 'primary' : 'subtle'"

--- a/frontend/src/pages/modals/EntryEditModal.vue
+++ b/frontend/src/pages/modals/EntryEditModal.vue
@@ -38,14 +38,13 @@
         <EntryIconPicker v-model="form.notes" />
       </FormRow>
 
-      <FormRow v-if="sessionAdults" title="Accompanying Adult" :disabled="!hasChild">
+      <FormRow v-if="sessionAdults" title="Accompanying Adult">
         <select
           class="eem-select"
           :class="{ 'eem-select--placeholder': form.accompanyingAdultId === null }"
           v-model="form.accompanyingAdultId"
-          :disabled="!hasChild"
         >
-          <option :value="null">Select adult…</option>
+          <option :value="null">Select if child…</option>
           <option v-for="a in sessionAdults" :key="a.id" :value="a.id">{{ a.name }}</option>
         </select>
         <p v-if="accompanyingAdultMissing" class="eem-adult-warning">Not registered at this session</p>
@@ -99,10 +98,7 @@ const form = reactive({
   accompanyingAdultId: props.entry.accompanyingAdultId ?? null as number | null,
 })
 
-const hasChild = computed(() => /\#child\b/i.test(form.notes))
-
 const accompanyingAdultMissing = computed(() =>
-  hasChild.value &&
   form.accompanyingAdultId !== null &&
   !props.sessionAdults?.some(a => a.id == form.accompanyingAdultId)
 )
@@ -113,10 +109,6 @@ watch(() => props.entry, (e) => {
   form.hours = e.hours
   form.notes = e.notes ?? ''
   form.accompanyingAdultId = e.accompanyingAdultId ?? null
-})
-
-watch(hasChild, (val) => {
-  if (!val) form.accompanyingAdultId = null
 })
 
 function formatCancelled(iso: string): string {

--- a/frontend/src/pages/modals/EntryEditModal.vue
+++ b/frontend/src/pages/modals/EntryEditModal.vue
@@ -4,7 +4,7 @@
     action="Save"
     action-icon="save"
     :show-delete="!isCancelled || isAdmin"
-    :delete-text="isCancelled ? 'Delete' : 'Cancel'"
+    :delete-text="'Delete'"
     :working="working"
     :error="error"
     @close="emit('close')"
@@ -20,35 +20,61 @@
       <AppButton v-if="sessionClick" label="View Session" icon="register" @click="sessionClick!()" />
     </div>
 
+    <div v-if="entryIcons.length" class="eem-icon-summary">
+      <div v-for="icon in entryIcons" :key="icon.alt" class="eem-icon-summary-item" :class="{ 'eem-icon-summary-item--subdued': icon.subdued }">
+        <span class="eem-icon-summary-icon" :class="icon.color ? 'icon-' + icon.color : ''">
+          <img :src="'/icons/' + icon.icon" :alt="icon.alt" />
+        </span>
+        <span>{{ icon.alt }}</span>
+      </div>
+    </div>
+
     <FormLayout :disabled="working">
-      <FormRow title="Checked In">
-        <input type="checkbox" class="eem-checkbox" v-model="form.checkedIn" />
-      </FormRow>
-
-      <FormRow v-if="entry.profile.isGroup" title="Count">
-        <input type="number" class="eem-input" v-model.number="form.count" min="1" />
-      </FormRow>
-
-      <FormRow title="Hours" :disabled="!form.checkedIn">
-        <input type="number" class="eem-input" v-model.number="form.hours" min="0" step="0.5" :disabled="!form.checkedIn" />
-      </FormRow>
-
-      <FormRow title="Notes" :full-width="true">
-        <textarea class="eem-textarea" v-model="form.notes" rows="2" />
-        <EntryIconPicker v-model="form.notes" />
+      <FormRow title="Tags" :full-width="true">
+        <div class="eem-tags">
+          <AppButton
+            label="Child"
+            icon="badges/child"
+            mode="icon-only"
+            :variant="childMode ? 'primary' : 'subtle'"
+            :selected="childMode"
+            :disabled="working"
+            @click="toggleChild"
+          />
+          <EntryIconPicker v-model="form.statsManual" :disabled="working" />
+        </div>
+        <p v-if="childValidationError" class="eem-validation">Select an accompanying adult or deselect Child.</p>
       </FormRow>
 
       <FormRow v-if="sessionAdults" title="Accompanying Adult">
         <select
           class="eem-select"
           :class="{ 'eem-select--placeholder': form.accompanyingAdultId === null }"
+          :disabled="!childMode || working"
           v-model="form.accompanyingAdultId"
         >
-          <option :value="null">Select if child…</option>
+          <option :value="null">Select adult…</option>
           <option v-for="a in sessionAdults" :key="a.id" :value="a.id">{{ a.name }}</option>
         </select>
         <p v-if="accompanyingAdultMissing" class="eem-adult-warning">Not registered at this session</p>
       </FormRow>
+
+      <FormRow v-if="entry.profile.isGroup" title="Count">
+        <input type="number" class="eem-input" v-model.number="form.count" min="1" />
+      </FormRow>
+
+      <FormRow title="Checked In">
+        <input type="checkbox" class="eem-checkbox" v-model="form.checkedIn" />
+      </FormRow>
+
+      <FormRow title="Hours" :disabled="!form.checkedIn">
+        <input type="number" class="eem-input" v-model.number="form.hours" min="0" step="0.5" :disabled="!form.checkedIn" />
+      </FormRow>
+
+      <!-- Notes hidden during #189 testing — restore once tags migration complete and notes UX tidied -->
+      <!-- <FormRow title="Notes" :full-width="true">
+        <textarea class="eem-textarea" v-model="form.notes" rows="2" />
+      </FormRow> -->
     </FormLayout>
   </ModalLayout>
 
@@ -63,12 +89,14 @@
 <script setup lang="ts">
 import { ref, reactive, watch, computed } from 'vue'
 import type { EntryItem } from '../../types/entry'
+import type { EntryStatsManual } from '../../../../types/entry-stats'
 import ModalLayout from '../../components/ModalLayout.vue'
 import FormLayout from '../../components/FormLayout.vue'
 import FormRow from '../../components/FormRow.vue'
 import AppButton from '../../components/AppButton.vue'
 import EntryIconPicker from '../../components/EntryIconPicker.vue'
 import DeleteModal from './DeleteModal.vue'
+import { iconsForEntry } from '../../utils/tagIcons'
 
 const props = defineProps<{
   entry: EntryItem
@@ -84,17 +112,21 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   close: []
-  save: [data: { checkedIn: boolean; count: number; hours: number; notes: string; accompanyingAdultId: number | null }]
+  save: [data: { checkedIn: boolean; count: number; hours: number; notes: string; accompanyingAdultId: number | null; statsManual: EntryStatsManual }]
   delete: []
 }>()
 
 const confirmDelete = ref(false)
+const childValidationError = ref(false)
+
+const childMode = ref(props.entry.accompanyingAdultId !== null && props.entry.accompanyingAdultId !== undefined)
 
 const form = reactive({
   checkedIn: props.entry.checkedIn,
   count: props.entry.count,
   hours: props.entry.hours,
   notes: props.entry.notes ?? '',
+  statsManual: { ...props.entry.stats?.manual } as EntryStatsManual,
   accompanyingAdultId: props.entry.accompanyingAdultId ?? null as number | null,
 })
 
@@ -103,25 +135,55 @@ const accompanyingAdultMissing = computed(() =>
   !props.sessionAdults?.some(a => a.id == form.accompanyingAdultId)
 )
 
+const entryIcons = computed(() => iconsForEntry({
+  isMember: props.entry.profile.isMember,
+  isGroup: props.entry.profile.isGroup,
+  cardStatus: props.entry.profile.cardStatus,
+  stats: {
+    ...props.entry.stats,
+    snapshot: { ...props.entry.stats?.snapshot, isChild: form.accompanyingAdultId !== null },
+    manual: form.statsManual,
+  },
+}))
+
 watch(() => props.entry, (e) => {
   form.checkedIn = e.checkedIn
   form.count = e.count
   form.hours = e.hours
   form.notes = e.notes ?? ''
+  form.statsManual = { ...e.stats?.manual }
   form.accompanyingAdultId = e.accompanyingAdultId ?? null
+  childMode.value = e.accompanyingAdultId !== null && e.accompanyingAdultId !== undefined
+  childValidationError.value = false
 })
+
+function toggleChild() {
+  if (childMode.value) {
+    childMode.value = false
+    form.accompanyingAdultId = null
+    childValidationError.value = false
+  } else {
+    childMode.value = true
+  }
+}
 
 function formatCancelled(iso: string): string {
   return new Date(iso).toLocaleString('en-GB', { day: 'numeric', month: 'short', year: 'numeric', hour: '2-digit', minute: '2-digit' })
 }
 
 function save() {
+  if (childMode.value && form.accompanyingAdultId === null) {
+    childValidationError.value = true
+    return
+  }
+  childValidationError.value = false
   emit('save', {
     checkedIn: form.checkedIn,
     count: form.count,
     hours: form.hours,
     notes: form.notes,
     accompanyingAdultId: form.accompanyingAdultId,
+    statsManual: form.statsManual,
   })
 }
 
@@ -175,6 +237,13 @@ function deleteEntry() {
   box-sizing: border-box;
 }
 
+.eem-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-top: 0.4rem;
+}
+
 .eem-select {
   width: 100%;
   background: var(--color-dtv-light);
@@ -193,4 +262,42 @@ function deleteEntry() {
   font-size: 0.8rem;
   color: var(--color-dtv-dirt);
 }
+
+.eem-validation {
+  margin-top: 0.25rem;
+  font-size: 0.8rem;
+  color: var(--color-dtv-dirt);
+}
+
+.eem-icon-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin-bottom: 1.25rem;
+}
+
+.eem-icon-summary-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.eem-icon-summary-icon {
+  width: 1.25rem;
+  height: 1.25rem;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.eem-icon-summary-icon img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.eem-icon-summary-item--subdued { color: var(--color-dtv-sand-dark); }
+.eem-icon-summary-item--subdued .eem-icon-summary-icon img { opacity: 0.4; }
 </style>

--- a/frontend/src/pages/modals/EntryEditModal.vue
+++ b/frontend/src/pages/modals/EntryEditModal.vue
@@ -3,13 +3,13 @@
     :title="title ?? entry.profile.name"
     action="Save"
     action-icon="save"
-    :show-delete="!isCancelled || isAdmin"
-    :delete-text="'Delete'"
+    :show-delete="isAdmin"
+    delete-text="Delete"
     :working="working"
     :error="error"
     @close="emit('close')"
     @action="save"
-    @delete="isCancelled ? (confirmDelete = true) : emit('delete')"
+    @delete="confirmDelete = true"
   >
     <div v-if="entry.cancelled" class="eem-cancelled">
       Cancelled {{ formatCancelled(entry.cancelled) }}
@@ -41,7 +41,7 @@
             :disabled="working"
             @click="toggleChild"
           />
-          <EntryIconPicker v-model="form.statsManual" :disabled="working" />
+          <EntryIconPicker v-model="form.statsManual" :snapshot="entry.stats?.snapshot" :disabled="working" />
         </div>
         <p v-if="childValidationError" class="eem-validation">Select an accompanying adult or deselect Child.</p>
       </FormRow>
@@ -69,6 +69,10 @@
 
       <FormRow title="Hours" :disabled="!form.checkedIn">
         <input type="number" class="eem-input" v-model.number="form.hours" min="0" step="0.5" :disabled="!form.checkedIn" />
+      </FormRow>
+
+      <FormRow title="Cancel Booking">
+        <input type="checkbox" class="eem-checkbox" v-model="form.cancelled" />
       </FormRow>
 
       <!-- Notes hidden during #189 testing — restore once tags migration complete and notes UX tidied -->
@@ -103,7 +107,6 @@ const props = defineProps<{
   working: boolean
   error?: string
   title?: string
-  isCancelled?: boolean
   isAdmin?: boolean
   profileClick?: () => void
   sessionClick?: () => void
@@ -112,7 +115,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   close: []
-  save: [data: { checkedIn: boolean; count: number; hours: number; notes: string; accompanyingAdultId: number | null; statsManual: EntryStatsManual }]
+  save: [data: { checkedIn: boolean; count: number; hours: number; notes: string; accompanyingAdultId: number | null; statsManual: EntryStatsManual; cancelled: boolean }]
   delete: []
 }>()
 
@@ -128,6 +131,7 @@ const form = reactive({
   notes: props.entry.notes ?? '',
   statsManual: { ...props.entry.stats?.manual } as EntryStatsManual,
   accompanyingAdultId: props.entry.accompanyingAdultId ?? null as number | null,
+  cancelled: !!props.entry.cancelled,
 })
 
 const accompanyingAdultMissing = computed(() =>
@@ -153,6 +157,7 @@ watch(() => props.entry, (e) => {
   form.notes = e.notes ?? ''
   form.statsManual = { ...e.stats?.manual }
   form.accompanyingAdultId = e.accompanyingAdultId ?? null
+  form.cancelled = !!e.cancelled
   childMode.value = e.accompanyingAdultId !== null && e.accompanyingAdultId !== undefined
   childValidationError.value = false
 })
@@ -184,6 +189,7 @@ function save() {
     notes: form.notes,
     accompanyingAdultId: form.accompanyingAdultId,
     statsManual: form.statsManual,
+    cancelled: form.cancelled,
   })
 }
 

--- a/frontend/src/pages/modals/RegularEditModal.vue
+++ b/frontend/src/pages/modals/RegularEditModal.vue
@@ -1,0 +1,103 @@
+<template>
+  <ModalLayout
+    :title="regular.name"
+    :action="regular.regularId ? 'Update' : 'Add'"
+    action-icon="save"
+    :show-delete="!!regular.regularId"
+    :delete-disabled="!regular.regularId"
+    :working="working"
+    :error="error"
+    @close="emit('close')"
+    @action="save"
+    @delete="emit('delete')"
+  >
+    <div class="rem-actions">
+      <AppButton :label="viewLinkLabel ?? 'View Profile'" icon="profile" @click="emit('viewLink')" />
+    </div>
+
+    <FormLayout :disabled="working">
+      <FormRow v-if="accompanyingFor?.length || adults.length" title="Accompanying Adult">
+        <p v-if="accompanyingFor?.length" class="rem-info">
+          Accompanying adult for {{ accompanyingFor.join(', ') }}
+        </p>
+        <select
+          v-else
+          class="rem-select"
+          :class="{ 'rem-select--placeholder': form.accompanyingAdultId === null }"
+          v-model="form.accompanyingAdultId"
+        >
+          <option :value="null">Select if child…</option>
+          <option v-for="a in adults" :key="a.id" :value="a.id">{{ a.name }}</option>
+        </select>
+      </FormRow>
+    </FormLayout>
+  </ModalLayout>
+</template>
+
+<script setup lang="ts">
+import { reactive, watch } from 'vue'
+import ModalLayout from '../../components/ModalLayout.vue'
+import FormLayout from '../../components/FormLayout.vue'
+import FormRow from '../../components/FormRow.vue'
+import AppButton from '../../components/AppButton.vue'
+
+export interface RegularEditItem {
+  name: string
+  slug: string
+  groupKey?: string
+  regularId?: number
+  accompanyingAdultId?: number
+}
+
+const props = defineProps<{
+  regular: RegularEditItem
+  adults: { id: number; name: string }[]
+  accompanyingFor?: string[]
+  working: boolean
+  error?: string
+  viewLinkLabel?: string
+}>()
+
+const emit = defineEmits<{
+  close: []
+  viewLink: []
+  save: [data: { accompanyingAdultId: number | null }]
+  delete: []
+}>()
+
+const form = reactive({
+  accompanyingAdultId: props.regular.accompanyingAdultId ?? null as number | null,
+})
+
+watch(() => props.regular, (r) => {
+  form.accompanyingAdultId = r.accompanyingAdultId ?? null
+})
+
+function save() {
+  emit('save', { accompanyingAdultId: form.accompanyingAdultId })
+}
+</script>
+
+<style scoped>
+.rem-actions {
+  margin-bottom: 1.25rem;
+}
+
+.rem-select {
+  width: 100%;
+  background: var(--color-dtv-light);
+  border: none;
+  color: var(--color-text);
+  padding: 0.3rem 0.5rem;
+  font-family: inherit;
+  font-size: 0.95rem;
+  box-sizing: border-box;
+}
+.rem-select--placeholder { color: var(--color-text-muted); }
+
+.rem-info {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--color-text);
+}
+</style>

--- a/frontend/src/pages/sandbox/SandboxEntryCard.vue
+++ b/frontend/src/pages/sandbox/SandboxEntryCard.vue
@@ -28,7 +28,7 @@
           :title-to="profilePath('bob-carter-7')"
           :checked-in="true"
           :hours="0"
-          :icons="iconsForEntry({ isMember: true, cardStatus: 'Accepted', notes: '#New' })"
+          :icons="iconsForEntry({ isMember: true, cardStatus: 'Accepted', stats: { snapshot: { booking: 'New' } } })"
           :allow-edit="true"
           :working="working2"
           @update="(c, h) => onUpdate(2, c, h)"
@@ -43,7 +43,7 @@
           :title-to="profilePath('carol-davies-18')"
           :checked-in="true"
           :hours="3.5"
-          :icons="iconsForEntry({ isMember: true, cardStatus: 'Invited', notes: '#Regular #DigLead' })"
+          :icons="iconsForEntry({ isMember: true, cardStatus: 'Invited', stats: { snapshot: { booking: 'Regular' }, manual: { digLead: true } } })"
           :allow-edit="true"
           :working="working3"
           @update="(c, h) => onUpdate(3, c, h)"
@@ -58,7 +58,7 @@
           :title-to="profilePath('alice-bowen-42')"
           :checked-in="true"
           :hours="2"
-          :icons="iconsForEntry({ isMember: false, notes: '#New' })"
+          :icons="iconsForEntry({ isMember: false, stats: { snapshot: { booking: 'New' } } })"
         />
       </div>
 
@@ -92,7 +92,7 @@
           :title-to="sessionPath('dhsc', '2026-04-19')"
           :checked-in="true"
           :hours="4"
-          :icons="iconsForEntry({ notes: '#Regular' })"
+          :icons="iconsForEntry({ stats: { snapshot: { booking: 'Regular' } } })"
         />
       </div>
 

--- a/frontend/src/pages/sandbox/SandboxEntryList.vue
+++ b/frontend/src/pages/sandbox/SandboxEntryList.vue
@@ -23,7 +23,7 @@
             :title-to="e.profile.slug ? profilePath(e.profile.slug) : undefined"
             :checked-in="e.checkedIn"
             :hours="e.hours"
-            :icons="iconsForEntry({ ...e.profile, notes: e.notes })"
+            :icons="iconsForEntry({ ...e.profile, stats: e.stats })"
             :allow-edit="true"
             :working="workingId === e.id"
             @update="(c, h) => onUpdate(e, c, h)"
@@ -41,7 +41,7 @@
             :title-to="e.profile.slug ? profilePath(e.profile.slug) : undefined"
             :checked-in="e.checkedIn"
             :hours="e.hours"
-            :icons="iconsForEntry({ ...e.profile, notes: e.notes })"
+            :icons="iconsForEntry({ ...e.profile, stats: e.stats })"
           />
         </EntryList>
       </div>
@@ -55,7 +55,7 @@
             :title-to="e.profile.slug ? profilePath(e.profile.slug) : undefined"
             :checked-in="e.checkedIn"
             :hours="e.hours"
-            :icons="iconsForEntry({ ...e.profile, notes: e.notes })"
+            :icons="iconsForEntry({ ...e.profile, stats: e.stats })"
             :allow-cancel="true"
             @cancel="log(`cancel: id=${e.id} &quot;${e.profile.name}&quot;`)"
           />
@@ -71,7 +71,7 @@
             :title-to="sessionPath(e.session.groupKey, e.session.date)"
             :checked-in="e.checkedIn"
             :hours="e.hours"
-            :icons="iconsForEntry({ notes: e.notes })"
+            :icons="iconsForEntry({ stats: e.stats })"
           />
         </EntryList>
       </div>
@@ -113,30 +113,30 @@ const adhoc = { groupKey: 'adhoc', groupName: 'Ad Hoc',                         
 const long  = { groupKey: 'x',     groupName: 'Very Long Group Name That Might Overflow The Card', date: '2026-02-08' }
 
 const sessionEntries = ref<EntryItem[]>([
-  { id: 1, checkedIn: false, hours: 0, count: 1, notes: undefined,
+  { id: 1, checkedIn: false, hours: 0, count: 1,
     profile: { name: 'Jo', slug: 'jo-1', isMember: false, cardStatus: undefined, isGroup: false }, session: dhsc },
-  { id: 2, checkedIn: true,  hours: 0, count: 1, notes: undefined,
+  { id: 2, checkedIn: true,  hours: 0, count: 1,
     profile: { name: 'Bartholomew Featherstonehaugh-Wright', slug: 'bartholomew-2', isMember: true, cardStatus: 'Accepted', isGroup: false }, session: dhsc },
-  { id: 3, checkedIn: true,  hours: 3.5, count: 1, notes: '#New',
+  { id: 3, checkedIn: true,  hours: 3.5, count: 1, stats: { snapshot: { booking: 'New' } },
     profile: { name: 'Carol Davies', slug: 'carol-davies-18', isMember: false, cardStatus: 'Invited', isGroup: false }, session: dhsc },
-  { id: 4, checkedIn: true,  hours: 6, count: 1, notes: '#Regular #DigLead #FirstAider #DofE #Child',
+  { id: 4, checkedIn: true,  hours: 6, count: 1, stats: { snapshot: { booking: 'Regular', isChild: true }, manual: { digLead: true, firstAider: true } },
     profile: { name: 'Emma Fox', slug: 'emma-fox-99', isMember: true, cardStatus: 'Accepted', isGroup: false }, session: dhsc },
-  { id: 5, checkedIn: false, hours: 0, count: 1, notes: '#Duplicate',
+  { id: 5, checkedIn: false, hours: 0, count: 1, stats: { manual: { duplicate: true } },
     profile: { name: 'Dean Heritage Volunteers Ltd', slug: undefined, isMember: false, cardStatus: undefined, isGroup: true }, session: dhsc },
-  { id: 6, checkedIn: true,  hours: 1.5, count: 1, notes: undefined,
+  { id: 6, checkedIn: true,  hours: 1.5, count: 1,
     profile: { name: 'Sam Green', slug: undefined, isMember: false, cardStatus: undefined, isGroup: false }, session: dhsc },
-  { id: 7, checkedIn: false, hours: 0, count: 1, notes: '#New #Child',
+  { id: 7, checkedIn: false, hours: 0, count: 1, stats: { snapshot: { booking: 'New', isChild: true } },
     profile: { name: 'Priya Nair', slug: 'priya-nair-55', isMember: true, cardStatus: undefined, isGroup: false }, session: dhsc },
 ])
 
 const profileEntries = ref<EntryItem[]>([
-  { id: 10, checkedIn: true,  hours: 4,   count: 1, notes: '#Regular',
+  { id: 10, checkedIn: true,  hours: 4,   count: 1, stats: { snapshot: { booking: 'Regular' } },
     profile: { name: 'Alice Bowen', slug: 'alice-bowen-42', isMember: false, cardStatus: undefined, isGroup: false }, session: dhsc },
-  { id: 11, checkedIn: true,  hours: 3,   count: 1, notes: '#New',
+  { id: 11, checkedIn: true,  hours: 3,   count: 1, stats: { snapshot: { booking: 'New' } },
     profile: { name: 'Alice Bowen', slug: 'alice-bowen-42', isMember: false, cardStatus: undefined, isGroup: false }, session: fod },
-  { id: 12, checkedIn: false, hours: 0,   count: 1, notes: undefined,
+  { id: 12, checkedIn: false, hours: 0,   count: 1,
     profile: { name: 'Alice Bowen', slug: 'alice-bowen-42', isMember: false, cardStatus: undefined, isGroup: false }, session: adhoc },
-  { id: 13, checkedIn: true,  hours: 2.5, count: 1, notes: '#DigLead #FirstAider',
+  { id: 13, checkedIn: true,  hours: 2.5, count: 1, stats: { manual: { digLead: true, firstAider: true } },
     profile: { name: 'Alice Bowen', slug: 'alice-bowen-42', isMember: false, cardStatus: undefined, isGroup: false }, session: long },
 ])
 

--- a/frontend/src/pages/sandbox/SandboxFormComponents.vue
+++ b/frontend/src/pages/sandbox/SandboxFormComponents.vue
@@ -276,8 +276,8 @@ const dateValue = ref('2026-03-15')
 const tagValue = ref('')
 const tagValueSelected = ref('Sheepskull')
 
-const tagNotes = ref('')
-const tagNotesSelected = ref('#New #Regular')
+const tagNotes = ref<import('../../../../types/entry-stats').EntryStatsManual>({})
+const tagNotesSelected = ref<import('../../../../types/entry-stats').EntryStatsManual>({ digLead: true, csr: true })
 
 const groups = ref([
   { key: 'sheepskull', name: 'Sheepskull' },

--- a/frontend/src/pages/sandbox/SandboxModals.vue
+++ b/frontend/src/pages/sandbox/SandboxModals.vue
@@ -329,8 +329,8 @@ function onSetHours(hours: number) {
   simulate(`set-hours: ${hours}h`)
 }
 
-function onEditSave(data: { checkedIn: boolean; count: number; hours: number; notes: string; accompanyingAdultId: number | null }) {
-  simulate(`entry-edit save → checkedIn=${data.checkedIn}, hours=${data.hours}, notes="${data.notes}", accompanyingAdultId=${data.accompanyingAdultId}`)
+function onEditSave(data: { checkedIn: boolean; count: number; hours: number; notes: string; accompanyingAdultId: number | null; statsManual: import('../../../../types/entry-stats').EntryStatsManual }) {
+  simulate(`entry-edit save → checkedIn=${data.checkedIn}, hours=${data.hours}, notes="${data.notes}", accompanyingAdultId=${data.accompanyingAdultId}, statsManual=${JSON.stringify(data.statsManual)}`)
 }
 
 function onEditDelete() {
@@ -430,8 +430,9 @@ const mockEntry: EntryItem = {
   checkedIn: true,
   hours: 3,
   count: 1,
-  notes: '#Child #New',
+  notes: 'First time volunteer',
   accompanyingAdultId: 2,
+  stats: { snapshot: { booking: 'New', isChild: true }, manual: { digLead: true } },
   profile: { name: 'Alice Bowen', slug: 'alice-bowen-42', isMember: true, cardStatus: 'Accepted', isGroup: false },
   session: { groupKey: 'dhsc', groupName: 'Sheepskull', date: '2026-04-19' },
 }

--- a/frontend/src/pages/sandbox/SandboxModals.vue
+++ b/frontend/src/pages/sandbox/SandboxModals.vue
@@ -66,6 +66,14 @@
           <h2>About</h2>
           <AppButton label="Open" @click="open = 'about'" />
         </div>
+        <div>
+          <h2>Regular Edit (existing)</h2>
+          <AppButton label="Open" @click="open = 'regular-edit-existing'" />
+        </div>
+        <div>
+          <h2>Regular Edit (new)</h2>
+          <AppButton label="Open" @click="open = 'regular-edit-new'" />
+        </div>
       </div>
 
       <label class="fail-toggle">
@@ -219,6 +227,30 @@
         @close="closeModal('close')"
       />
 
+      <RegularEditModal
+        v-if="open === 'regular-edit-existing'"
+        :regular="mockRegularExisting"
+        :adults="mockRegularAdults"
+        :working="working"
+        :error="error"
+        @close="closeModal('close')"
+        @view-link="log('regular-edit: View Profile clicked')"
+        @save="onRegularEditSave"
+        @delete="simulate('regular-edit: delete')"
+      />
+
+      <RegularEditModal
+        v-if="open === 'regular-edit-new'"
+        :regular="mockRegularNew"
+        :adults="mockRegularAdults"
+        :working="working"
+        :error="error"
+        @close="closeModal('close')"
+        @view-link="log('regular-edit: View Profile clicked')"
+        @save="onRegularEditSave"
+        @delete="simulate('regular-edit: delete')"
+      />
+
       <h2>Event log</h2>
       <div class="event-log">
         <div v-if="!events.length" class="event-log-empty">No events yet.</div>
@@ -251,6 +283,7 @@ import RecordEditModal from '../modals/RecordEditModal.vue'
 import GroupAddSessionModal from '../modals/GroupAddSessionModal.vue'
 import SessionAddTagsModal from '../modals/SessionAddTagsModal.vue'
 import AboutModal from '../../components/AboutModal.vue'
+import RegularEditModal from '../modals/RegularEditModal.vue'
 import type { MediaItem } from '../../types/media'
 import type { EntryItem } from '../../types/entry'
 import type { PickerProfile } from '../../components/ProfilePicker.vue'
@@ -360,6 +393,10 @@ function onSessionEditDelete() {
   simulate('session-edit: delete')
 }
 
+function onRegularEditSave(data: { accompanyingAdultId: number | null }) {
+  simulate(`regular-edit: save → accompanyingAdultId=${data.accompanyingAdultId}`)
+}
+
 // --- mock data ---
 
 const mockGroups = [
@@ -449,6 +486,13 @@ const mockGroup = {
   stats: { sessions: 12, hours: 240, newVolunteers: 5, children: 2, totalVolunteers: 30 },
   sessions: [],
 }
+
+const mockRegularExisting = { name: 'Mini Digger', slug: 'mini-digger-88', regularId: 203, accompanyingAdultId: 42 }
+const mockRegularNew = { name: 'New Volunteer', slug: 'new-volunteer-99' }
+const mockRegularAdults = [
+  { id: 42, name: 'Jane Smith' },
+  { id: 7, name: 'Alice Brown' },
+]
 
 const mockTransferProfiles: PickerProfile[] = [
   { id: 2, name: 'Bob Carter', email: 'bob@example.com' },

--- a/frontend/src/pages/sandbox/SandboxRegularItem.vue
+++ b/frontend/src/pages/sandbox/SandboxRegularItem.vue
@@ -5,89 +5,58 @@
       <SandboxBackLink />
       <h1>RegularItem</h1>
 
-      <h2>Toggle allowed — idle, not regular</h2>
+      <h2>Is regular — no accompanying adult</h2>
       <div class="demo">
         <RegularItem
           name="Sheepskull"
-          link-to="/groups/sheepskull"
-          :hours="40"
-          :is-regular="false"
-          :allow-toggle-regular="true"
-          @add-regular="log('addRegular')"
-          @remove-regular="log('removeRegular')"
-        />
-      </div>
-
-      <h2>Toggle allowed — idle, is regular</h2>
-      <div class="demo">
-        <RegularItem
-          name="Sheepskull"
-          link-to="/groups/sheepskull"
           :hours="40"
           :is-regular="true"
           :regular-id="101"
-          :allow-toggle-regular="true"
-          @add-regular="log('addRegular')"
-          @remove-regular="log('removeRegular')"
+          @edit="log('edit: Sheepskull')"
         />
       </div>
 
-      <h2>Toggle allowed — working (in-flight)</h2>
+      <h2>Is regular — has accompanying adult (child, dashed border)</h2>
       <div class="demo">
         <RegularItem
-          name="Sheepskull"
-          link-to="/groups/sheepskull"
-          :hours="40"
+          name="Mini Digger"
+          :hours="12"
           :is-regular="true"
-          :regular-id="101"
-          :allow-toggle-regular="true"
-          :working="true"
+          :regular-id="202"
+          :accompanying-adult-id="101"
+          @edit="log('edit: Mini Digger')"
         />
       </div>
 
-      <h2>Read-only — is regular</h2>
-      <div class="demo">
-        <RegularItem
-          name="Sheepskull"
-          link-to="/groups/sheepskull"
-          :hours="40"
-          :is-regular="true"
-          :regular-id="101"
-        />
-      </div>
-
-      <h2>Read-only — not regular</h2>
+      <h2>Not yet regular (no green border)</h2>
       <div class="demo">
         <RegularItem
           name="Dig Deep"
-          link-to="/groups/dig-deep"
           :hours="6"
           :is-regular="false"
+          @edit="log('edit: Dig Deep')"
+        />
+      </div>
+
+      <h2>Working (in-flight)</h2>
+      <div class="demo">
+        <RegularItem
+          name="Riverside Crew"
+          :hours="7.5"
+          :is-regular="true"
+          :regular-id="303"
+          :working="true"
         />
       </div>
 
       <h2>Fractional hours</h2>
       <div class="demo">
         <RegularItem
-          name="Riverside Crew"
-          link-to="/groups/riverside"
-          :hours="7.5"
-          :is-regular="false"
-          :allow-toggle-regular="true"
-        />
-      </div>
-
-      <h2>Profile context (name is a volunteer)</h2>
-      <div class="demo">
-        <RegularItem
           name="Jane Smith"
-          link-to="/profiles/jane-smith-42"
-          :hours="18"
+          :hours="18.5"
           :is-regular="true"
-          :regular-id="202"
-          :allow-toggle-regular="true"
-          @add-regular="log('addRegular')"
-          @remove-regular="log('removeRegular')"
+          :regular-id="404"
+          @edit="log('edit: Jane Smith')"
         />
       </div>
 

--- a/frontend/src/pages/sandbox/SandboxRegularList.vue
+++ b/frontend/src/pages/sandbox/SandboxRegularList.vue
@@ -5,34 +5,22 @@
       <SandboxBackLink />
       <h1>RegularList</h1>
 
-      <h2>Profile context — Admin toggle (groups the volunteer attends)</h2>
-      <div class="demo">
-        <RegularList
-          :items="profileItems"
-          :allow-toggle-regular="true"
-          :working-slug="workingSlug"
-          :error="error"
-          ref="listRef"
-          @add-regular="onAdd"
-          @remove-regular="onRemove"
-        />
-      </div>
-
-      <h2>Group context — Admin toggle (volunteers who attend the group)</h2>
+      <h2>Group context — volunteers (click to edit)</h2>
       <div class="demo">
         <RegularList
           :items="groupItems"
-          :allow-toggle-regular="true"
-          :working-slug="workingSlugGroup"
-          :error="errorGroup"
-          @add-regular="onAddGroup"
-          @remove-regular="onRemoveGroup"
+          :working-slug="workingSlug"
+          :error="error"
+          @edit-regular="onEdit"
         />
       </div>
 
-      <h2>Read-only — regular badges, no toggle</h2>
+      <h2>With a child regular (dashed border)</h2>
       <div class="demo">
-        <RegularList :items="profileItems" />
+        <RegularList
+          :items="groupWithChildItems"
+          @edit-regular="onEdit"
+        />
       </div>
 
       <h2>Empty state</h2>
@@ -64,84 +52,28 @@ usePageTitle('Sandbox')
 const events = ref<string[]>([])
 const workingSlug = ref<string | undefined>(undefined)
 const error = ref('')
-const workingSlugGroup = ref<string | undefined>(undefined)
-const errorGroup = ref('')
 
 function log(msg: string) {
   events.value.unshift(msg)
 }
 
-const FAIL_SLUG = 'dig-deep'
-
-// Profile context: items are groups
-const profileItems = reactive<RegularListItem[]>([
-  { slug: 'sheepskull', name: 'Sheepskull', linkTo: '/groups/sheepskull', hours: 40, isRegular: true, regularId: 101 },
-  { slug: 'dig-deep', name: 'Dig Deep', linkTo: '/groups/dig-deep', hours: 6, isRegular: false },
-  { slug: 'riverside', name: 'Riverside Crew', linkTo: '/groups/riverside', hours: 14, isRegular: false },
-])
-
-function onAdd(slug: string) {
-  log(`addRegular slug=${slug}`)
-  workingSlug.value = slug
-  error.value = ''
-  setTimeout(() => {
-    if (slug === FAIL_SLUG) {
-      error.value = 'Failed to add regular — please try again'
-      log(`addRegular slug=${slug} — FAILED`)
-    } else {
-      const item = profileItems.find(i => i.slug === slug)
-      if (item) { item.isRegular = true; item.regularId = 999 }
-      log(`addRegular slug=${slug} — OK`)
-    }
-    workingSlug.value = undefined
-  }, 1000)
-}
-
-function onRemove(slug: string) {
-  log(`removeRegular slug=${slug}`)
-  workingSlug.value = slug
-  error.value = ''
-  setTimeout(() => {
-    if (slug === FAIL_SLUG) {
-      error.value = 'Failed to remove regular — please try again'
-      log(`removeRegular slug=${slug} — FAILED`)
-    } else {
-      const item = profileItems.find(i => i.slug === slug)
-      if (item) { item.isRegular = false; item.regularId = undefined }
-      log(`removeRegular slug=${slug} — OK`)
-    }
-    workingSlug.value = undefined
-  }, 1000)
-}
-
-// Group context: items are profiles
 const groupItems = reactive<RegularListItem[]>([
-  { slug: 'jane-smith-42', name: 'Jane Smith', linkTo: '/profiles/jane-smith-42', hours: 24, isRegular: true, regularId: 201 },
-  { slug: 'bob-jones-15', name: 'Bob Jones', linkTo: '/profiles/bob-jones-15', hours: 12, isRegular: false },
-  { slug: 'alice-brown-7', name: 'Alice Brown', linkTo: '/profiles/alice-brown-7', hours: 8, isRegular: true, regularId: 202 },
+  { profileId: 42, slug: 'jane-smith-42', name: 'Jane Smith', hours: 24, isRegular: true, regularId: 201 },
+  { profileId: 15, slug: 'bob-jones-15', name: 'Bob Jones', hours: 12, isRegular: false },
+  { profileId: 7, slug: 'alice-brown-7', name: 'Alice Brown', hours: 8, isRegular: true, regularId: 202 },
 ])
 
-function onAddGroup(slug: string) {
-  log(`[group] addRegular slug=${slug}`)
-  workingSlugGroup.value = slug
-  errorGroup.value = ''
-  setTimeout(() => {
-    const item = groupItems.find(i => i.slug === slug)
-    if (item) { item.isRegular = true; item.regularId = 999 }
-    log(`[group] addRegular slug=${slug} — OK`)
-    workingSlugGroup.value = undefined
-  }, 1000)
-}
+const groupWithChildItems = reactive<RegularListItem[]>([
+  { profileId: 42, slug: 'jane-smith-42', name: 'Jane Smith', hours: 24, isRegular: true, regularId: 201 },
+  { profileId: 88, slug: 'mini-digger-88', name: 'Mini Digger', hours: 10, isRegular: true, regularId: 203, accompanyingAdultId: 42 },
+])
 
-function onRemoveGroup(slug: string) {
-  log(`[group] removeRegular slug=${slug}`)
-  workingSlugGroup.value = slug
-  errorGroup.value = ''
+function onEdit(slug: string) {
+  log(`editRegular slug=${slug}`)
+  workingSlug.value = slug
   setTimeout(() => {
-    const item = groupItems.find(i => i.slug === slug)
-    if (item) { item.isRegular = false; item.regularId = undefined }
-    log(`[group] removeRegular slug=${slug} — OK`)
-    workingSlugGroup.value = undefined
-  }, 1000)
+    log(`editRegular slug=${slug} — modal would open`)
+    workingSlug.value = undefined
+  }, 600)
 }
 </script>

--- a/frontend/src/utils/tagIcons.ts
+++ b/frontend/src/utils/tagIcons.ts
@@ -6,8 +6,8 @@ export interface TagIcon {
   type: 'badge' | 'tag'
   color?: string
   subdued?: boolean
-  activeLabel?: string              // suffix when manually active, e.g. "On Duty"
-  availableLabel?: string           // suffix when snapshot-qualified but not manual, e.g. "Available"
+  activeLabel?: string              // alt text suffix when manually active, e.g. "On Duty"
+  availableLabel?: string           // alt text suffix when snapshot-qualified but not manual, e.g. "Available"
   snapshotKey?: keyof EntryStatsSnapshot  // snapshot field for the available/qualified state
   manualKey?: keyof EntryStatsManual      // manual field this picker button toggles
 }

--- a/frontend/src/utils/tagIcons.ts
+++ b/frontend/src/utils/tagIcons.ts
@@ -34,7 +34,7 @@ export const TAG_ICONS: TagIcon[] = [
 
 /** Tags shown via notes in picker (operational/manual only — not auto-computed) */
 export const EDITABLE_TAG_ICONS = TAG_ICONS.filter(t =>
-  t.type === 'tag' && ['#Child', '#DigLead', '#FirstAider', '#CSR', '#Late', '#Eventbrite'].includes(t.tag ?? '')
+  t.type === 'tag' && ['#DigLead', '#FirstAider', '#CSR', '#Late', '#Eventbrite'].includes(t.tag ?? '')
 )
 
 /** Returns tag icons matched from an entry's notes string */

--- a/frontend/src/utils/tagIcons.ts
+++ b/frontend/src/utils/tagIcons.ts
@@ -1,13 +1,15 @@
-// Ported from public/js/tag-icons.js
-
-import type { EntryStats } from '../../../types/entry-stats'
+import type { EntryStats, EntryStatsManual, EntryStatsSnapshot } from '../../../types/entry-stats'
 
 export interface TagIcon {
   icon: string
   alt: string
   type: 'badge' | 'tag'
-  tag?: string        // hashtag to match in entry.notes, e.g. '#New'
-  color?: string      // css modifier: 'orange' | 'red' | 'dark-green' | 'green'
+  color?: string
+  subdued?: boolean
+  activeLabel?: string              // suffix when manually active, e.g. "On Duty"
+  availableLabel?: string           // suffix when snapshot-qualified but not manual, e.g. "Available"
+  snapshotKey?: keyof EntryStatsSnapshot  // snapshot field for the available/qualified state
+  manualKey?: keyof EntryStatsManual      // manual field this picker button toggles
 }
 
 export const TAG_ICONS: TagIcon[] = [
@@ -17,43 +19,33 @@ export const TAG_ICONS: TagIcon[] = [
   { icon: 'badges/card.svg',    alt: 'Card In Container',  type: 'badge', color: 'orange' },
   { icon: 'badges/group.svg',   alt: 'Group / Company',    type: 'badge' },
 
-  // Entry tags (matched from notes — these remain manual/operational)
-  { icon: 'badges/child.svg',      alt: 'Child',            tag: '#Child',      type: 'tag' },
-  { icon: 'badges/diglead.svg',    alt: 'Dig Lead',         tag: '#DigLead',    type: 'tag' },
-  { icon: 'badges/firstaider.svg', alt: 'First Aider',      tag: '#FirstAider', type: 'tag', color: 'green' },
-  { icon: 'badges/csr.svg',        alt: 'CSR',              tag: '#CSR',        type: 'tag' },
-  { icon: 'badges/late.svg',       alt: 'Late',             tag: '#Late',       type: 'tag' },
-  { icon: 'brands/eventbrite.svg', alt: 'Eventbrite',       tag: '#Eventbrite', type: 'tag' },
-
-  // Legacy tags — still matched from notes for pre-migration entries (stats field absent)
-  { icon: 'badges/regular.svg',    alt: 'Regular',          tag: '#Regular',    type: 'tag' },
-  { icon: 'badges/new.svg',        alt: 'New',              tag: '#New',        type: 'tag' },
-  { icon: 'badges/nophoto.svg',    alt: 'No Photo',         tag: '#NoPhoto',    type: 'tag', color: 'red' },
-  { icon: 'status/warning.svg',    alt: 'Duplicate Warning',tag: '#Duplicate',  type: 'tag', color: 'red' },
+  // Entry tags — displayed from stats; editable ones also appear in the picker
+  { icon: 'badges/child.svg',      alt: 'Child',            type: 'tag' },
+  { icon: 'badges/diglead.svg',    alt: 'Dig Lead',         type: 'tag', manualKey: 'digLead',    snapshotKey: 'isDigLead' },
+  { icon: 'badges/firstaider.svg', alt: 'First Aider',      type: 'tag', color: 'green', manualKey: 'firstAider', snapshotKey: 'isFirstAider', activeLabel: 'On Duty', availableLabel: 'Available' },
+  { icon: 'badges/csr.svg',        alt: 'CSR',              type: 'tag', manualKey: 'csr' },
+  { icon: 'badges/late.svg',       alt: 'Late',             type: 'tag', manualKey: 'late' },
+  { icon: 'brands/eventbrite.svg', alt: 'Eventbrite',       type: 'tag', manualKey: 'eventbrite' },
+  { icon: 'badges/regular.svg',    alt: 'Regular',          type: 'tag' },
+  { icon: 'badges/new.svg',        alt: 'New',              type: 'tag' },
+  { icon: 'badges/nophoto.svg',    alt: 'No Photo',         type: 'tag', color: 'red' },
+  { icon: 'status/warning.svg',    alt: 'Duplicate Warning',type: 'tag', color: 'red' },
 ]
 
-/** Tags shown via notes in picker (operational/manual only — not auto-computed) */
-export const EDITABLE_TAG_ICONS = TAG_ICONS.filter(t =>
-  t.type === 'tag' && ['#DigLead', '#FirstAider', '#CSR', '#Late', '#Eventbrite'].includes(t.tag ?? '')
-)
+/** Tags shown in the entry icon picker (manual/operational only) */
+export const EDITABLE_TAG_ICONS = TAG_ICONS.filter(t => t.manualKey !== undefined)
 
-/** Returns tag icons matched from an entry's notes string */
-export function iconsFromNotes(notes: string | undefined): TagIcon[] {
-  if (!notes) return []
-  return TAG_ICONS.filter(t =>
-    t.tag && new RegExp('\\' + t.tag + '\\b', 'i').test(notes)
-  )
-}
+/** Tags that have both a snapshot (available/qualified) and manual (active) state */
+const DUAL_STATE_TAGS = EDITABLE_TAG_ICONS.filter(t => t.snapshotKey !== undefined)
 
 interface EntryIconSource {
   isMember?: boolean
   isGroup?: boolean
   cardStatus?: string
-  notes?: string
   stats?: EntryStats
 }
 
-/** Builds the full icon list for an entry: profile badges + stats snapshot + notes tags */
+/** Builds the full icon list for an entry: profile badges + stats snapshot + stats manual */
 export function iconsForEntry(e: EntryIconSource): TagIcon[] {
   const icons: TagIcon[] = []
 
@@ -67,23 +59,30 @@ export function iconsForEntry(e: EntryIconSource): TagIcon[] {
     const { snapshot, manual } = e.stats
 
     // Snapshot: computed at session time
-    if (snapshot?.booking === 'New')     icons.push({ icon: 'badges/new.svg',        alt: 'New',              type: 'tag' })
-    if (snapshot?.booking === 'Regular') icons.push({ icon: 'badges/regular.svg',    alt: 'Regular',          type: 'tag' })
-    if (snapshot?.isChild)               icons.push({ icon: 'badges/child.svg',       alt: 'Child',            type: 'tag' })
-    if (manual?.duplicate)               icons.push({ icon: 'status/warning.svg',     alt: 'Duplicate Warning',type: 'tag', color: 'red' })
-    if (snapshot?.noPhoto)               icons.push({ icon: 'badges/nophoto.svg',     alt: 'No Photo',         type: 'tag', color: 'red' })
-    if (snapshot?.noConsent)             icons.push({ icon: 'badges/noconsent.svg',   alt: 'No Consent',       type: 'tag', color: 'red' })
-    // qualified (snapshot) OR took on role that day (manual) — show icon once for either
-    if (snapshot?.isDigLead   || manual?.digLead)    icons.push({ icon: 'badges/diglead.svg',    alt: 'Dig Lead',    type: 'tag' })
-    if (snapshot?.isFirstAider || manual?.firstAider) icons.push({ icon: 'badges/firstaider.svg', alt: 'First Aider', type: 'tag', color: 'green' })
+    if (snapshot?.booking === 'New')     icons.push({ icon: 'badges/new.svg',      alt: 'New',              type: 'tag' })
+    if (snapshot?.booking === 'Regular') icons.push({ icon: 'badges/regular.svg',  alt: 'Regular',          type: 'tag' })
+    if (snapshot?.isChild)               icons.push({ icon: 'badges/child.svg',     alt: 'Child',            type: 'tag' })
+    if (manual?.duplicate)               icons.push({ icon: 'status/warning.svg',   alt: 'Duplicate Warning',type: 'tag', color: 'red' })
+    if (snapshot?.noPhoto)               icons.push({ icon: 'badges/nophoto.svg',   alt: 'No Photo',         type: 'tag', color: 'red' })
+    if (snapshot?.noConsent)             icons.push({ icon: 'badges/noconsent.svg', alt: 'No Consent',       type: 'tag', color: 'red' })
 
-    // Manual: operational tags from the day
-    if (manual?.csr)       icons.push({ icon: 'badges/csr.svg',       alt: 'CSR',        type: 'tag' })
-    if (manual?.late)      icons.push({ icon: 'badges/late.svg',       alt: 'Late',       type: 'tag' })
+    // Dual-state tags: snapshot = available/qualified, manual = active on the day
+    for (const tag of DUAL_STATE_TAGS) {
+      const isActive    = !!manual?.[tag.manualKey!]
+      const isAvailable = !!snapshot?.[tag.snapshotKey!] && !isActive
+      if (isActive) {
+        const alt = tag.activeLabel ? `${tag.alt} (${tag.activeLabel})` : tag.alt
+        icons.push({ ...tag, alt })
+      } else if (isAvailable) {
+        const alt = tag.availableLabel ? `${tag.alt} (${tag.availableLabel})` : tag.alt
+        icons.push({ ...tag, alt, subdued: true })
+      }
+    }
+
+    // Manual-only tags
+    if (manual?.csr)        icons.push({ icon: 'badges/csr.svg',        alt: 'CSR',        type: 'tag' })
+    if (manual?.late)       icons.push({ icon: 'badges/late.svg',        alt: 'Late',       type: 'tag' })
     if (manual?.eventbrite) icons.push({ icon: 'brands/eventbrite.svg', alt: 'Eventbrite', type: 'tag' })
-  } else {
-    // No stats yet — fall back to Notes tags
-    icons.push(...iconsFromNotes(e.notes))
   }
 
   return icons

--- a/middleware/require-admin.ts
+++ b/middleware/require-admin.ts
@@ -5,6 +5,7 @@ const CHECKIN_ALLOWED_PATTERNS = [
   { method: 'PATCH', pattern: /^\/entries\/\d+$/ },           // check-in + set hours
   { method: 'PATCH', pattern: /^\/sessions\/[^/]+\/[^/]+$/ }, // edit session title/description
   { method: 'POST',  pattern: /^\/profiles\/[^/]+\/regulars$/ }, // add regular
+  { method: 'PATCH', pattern: /^\/regulars\/\d+$/ },          // update regular (e.g. accompanying adult)
   { method: 'DELETE', pattern: /^\/regulars\/\d+$/ },         // remove regular
   { method: 'POST',  pattern: /^\/sessions\/[^/]+\/[^/]+\/entries$/ }, // add entry
   { method: 'POST',  pattern: /^\/sessions\/[^/]+\/[^/]+\/refresh$/ }, // refresh session

--- a/routes/entries.ts
+++ b/routes/entries.ts
@@ -61,7 +61,7 @@ async function computeAndSaveSessionStats(sessionId: number, existingMedia: numb
   const cancelledRegular = sessionEntries.filter(e => {
     if (!e[ENTRY_CANCELLED]) return false;
     const es = parseEntryStatsField(e[ENTRY_STATS]);
-    return es ? es.snapshot?.booking === 'Regular' : /#Regular\b/i.test(String(e.Notes || ''));
+    return es?.snapshot?.booking === 'Regular';
   }).length;
   await sessionsRepository.updateStats(sessionId, {
     count: entryStats?.registrations || 0,
@@ -86,11 +86,6 @@ const ALLOWED_MIME_TYPES = new Set([
   'video/mp4', 'video/quicktime', 'video/x-m4v'
 ]);
 
-function appendNewTag(notes: string | undefined): string {
-  const base = notes || '';
-  if (/#New\b/i.test(base)) return base;
-  return base ? `${base} #New` : '#New';
-}
 
 router.get('/entries/recent', async (req: Request, res: Response) => {
   try {
@@ -127,7 +122,7 @@ router.get('/entries/recent', async (req: Request, res: Response) => {
     }
 
     const recent: RecentSignupResponse[] = entries
-      .filter(e => e[ENTRY_CANCELLED] || !/#Regular\b/i.test(e.Notes || ''))
+      .filter(e => e[ENTRY_CANCELLED] || parseEntryStatsField(e[ENTRY_STATS])?.snapshot?.booking !== 'Regular')
       .sort((a, b) => sortKey(b) - sortKey(a))
       .slice(0, 50)
       .flatMap(e => {
@@ -231,7 +226,8 @@ router.get('/entries', async (req: Request, res: Response) => {
           isGroup: profile?.IsGroup || false,
           hasAccompanyingAdult: hasAdult,
           accompanyingAdultId: safeParseLookupId(e.AccompanyingAdultLookupId),
-          cancelled: e.Cancelled || undefined
+          cancelled: e.Cancelled || undefined,
+          stats: parseEntryStatsField(e[ENTRY_STATS])
         }];
       })
       .sort((a, b) => b.date.localeCompare(a.date));
@@ -480,7 +476,7 @@ router.patch('/entries/:id', async (req: Request, res: Response) => {
       return;
     }
 
-    const { checkedIn, count, hours, notes, accompanyingAdultId, cancelled } = req.body;
+    const { checkedIn, count, hours, notes, accompanyingAdultId, cancelled, statsManual } = req.body;
     const fields: Record<string, any> = {};
 
     if (typeof cancelled === 'boolean') {
@@ -547,7 +543,9 @@ router.patch('/entries/:id', async (req: Request, res: Response) => {
       }
     }
 
-    if (Object.keys(fields).length === 0) {
+    const hasStatsManual = statsManual && typeof statsManual === 'object';
+    const hasAccompanyingAdult = accompanyingAdultId !== undefined;
+    if (Object.keys(fields).length === 0 && !hasStatsManual) {
       res.status(400).json({ success: false, error: 'No valid fields to update' });
       return;
     }
@@ -563,7 +561,19 @@ router.patch('/entries/:id', async (req: Request, res: Response) => {
 
     const profileId = spEntry ? safeParseLookupId(spEntry[PROFILE_LOOKUP]) : undefined;
 
-    await entriesRepository.updateFields(entryId, fields);
+    if (Object.keys(fields).length > 0) {
+      await entriesRepository.updateFields(entryId, fields);
+    }
+
+    // Synchronously write Stats when manual tags or isChild (from accompanyingAdultId) change
+    if (hasStatsManual || hasAccompanyingAdult) {
+      const existingStats = spEntry ? parseEntryStatsField(spEntry[ENTRY_STATS]) : undefined;
+      const mergedManual = hasStatsManual ? { ...existingStats?.manual, ...statsManual } : existingStats?.manual;
+      const mergedSnapshot = hasAccompanyingAdult
+        ? { ...existingStats?.snapshot, isChild: accompanyingAdultId !== null }
+        : existingStats?.snapshot;
+      await entriesRepository.updateStats(entryId, { snapshot: mergedSnapshot, manual: mergedManual });
+    }
 
     const statsChain = sessionId !== undefined
       ? computeAndSaveEntryStats(entryId).then(() => computeAndSaveSessionStats(sessionId, existingMedia))
@@ -711,11 +721,7 @@ router.post('/sessions/:group/:date/entries', async (req: Request, res: Response
       [SESSION_LOOKUP]: String(spSession.ID),
       [PROFILE_LOOKUP]: String(profile.ID)
     };
-    let entryNotes = typeof notes === 'string' && notes.trim() ? notes : undefined;
-
-    if (isFirstSession(profile, spSession.ID)) {
-      entryNotes = appendNewTag(entryNotes);
-    }
+    const entryNotes = typeof notes === 'string' && notes.trim() ? notes : undefined;
     if (entryNotes) fields.Notes = entryNotes;
 
     let existingMedia = 0;
@@ -775,40 +781,21 @@ router.post('/sessions/:group/:date/refresh', async (req: Request, res: Response
     );
 
     let addedRegulars = 0;
-    let regularTagged = 0;
     let addedFromEventbrite = 0;
     let newProfiles = 0;
     let updatedRecords = 0;
     let noPhotoTagged = 0;
     let firstAiderTagged = 0;
-    let fixedNewTags = 0;
 
-    // Step 0: Remove incorrect #New tags from existing entries
-    for (const entry of sessionEntries) {
-      const notes = String(entry.Notes || '');
-      if (!/#New\b/i.test(notes)) continue;
-      const pid = safeParseLookupId(entry[PROFILE_LOOKUP]);
-      if (pid === undefined) continue;
-      const entryProfile = profiles.find(p => p.ID === pid);
-      if (!entryProfile || isFirstSession(entryProfile, spSession.ID)) continue;
-      const fixedNotes = notes.replace(/#New\s*/gi, '').trim();
-      await entriesRepository.updateFields(entry.ID, { Notes: fixedNotes });
-      fixedNewTags++;
-    }
-
-    // Step 1: Add missing regulars; tag existing entries that are missing #Regular
+    // Step 1: Add missing regulars; update accompanying adult on existing entries if needed
     const groupRegulars = rawRegulars.filter(r => safeParseLookupId(r[GROUP_LOOKUP]) === spGroup.ID);
     for (const regular of groupRegulars) {
       const vid = safeParseLookupId(regular[PROFILE_LOOKUP]);
       if (vid === undefined) continue;
       if (!existingVolunteerIds.has(vid)) {
-        const regularProfile = profiles.find(p => p.ID === vid);
-        let notes = '#Regular';
-        if (regularProfile && isFirstSession(regularProfile, spSession.ID)) notes = appendNewTag(notes);
         const entryFields: Record<string, any> = {
           [SESSION_LOOKUP]: String(spSession.ID),
           [PROFILE_LOOKUP]: String(vid),
-          Notes: notes
         };
         const regularAdultId = safeParseLookupId(regular.AccompanyingAdultLookupId);
         if (regularAdultId !== undefined) entryFields[ACCOMPANYING_ADULT_LOOKUP] = String(regularAdultId);
@@ -819,11 +806,6 @@ router.post('/sessions/:group/:date/refresh', async (req: Request, res: Response
         const existingEntry = sessionEntries.find(e => safeParseLookupId(e[PROFILE_LOOKUP]) === vid);
         if (existingEntry) {
           const patchFields: Record<string, any> = {};
-          if (!/#Regular\b/i.test(existingEntry.Notes || '')) {
-            const notes = String(existingEntry.Notes || '');
-            patchFields.Notes = notes ? `${notes.trimEnd()} #Regular` : '#Regular';
-            regularTagged++;
-          }
           const regularAdultId = safeParseLookupId(regular.AccompanyingAdultLookupId);
           if (regularAdultId !== undefined && safeParseLookupId(existingEntry.AccompanyingAdultLookupId) === undefined) {
             patchFields[ACCOMPANYING_ADULT_LOOKUP] = String(regularAdultId);
@@ -944,10 +926,10 @@ router.post('/sessions/:group/:date/refresh', async (req: Request, res: Response
       console.error(`[Stats] Failed session stats after refresh:`, err)
     );
 
-    console.log(`[Refresh] Done: ${addedRegulars} regulars added, ${regularTagged} #Regular tagged, ${addedFromEventbrite} eventbrite, ${newProfiles} new profiles, ${updatedRecords} records, ${noPhotoTagged} #NoPhoto, ${firstAiderTagged} #FirstAider, ${fixedNewTags} #New fixed`);
+    console.log(`[Refresh] Done: ${addedRegulars} regulars added, ${addedFromEventbrite} eventbrite, ${newProfiles} new profiles, ${updatedRecords} records, ${noPhotoTagged} #NoPhoto, ${firstAiderTagged} #FirstAider`);
     res.json({
       success: true,
-      data: { addedRegulars, regularTagged, addedFromEventbrite, newProfiles, updatedRecords, noPhotoTagged, firstAiderTagged, fixedNewTags }
+      data: { addedRegulars, addedFromEventbrite, newProfiles, updatedRecords, noPhotoTagged, firstAiderTagged }
     });
   } catch (error: any) {
     console.error('Error refreshing session:', error);

--- a/routes/entries.ts
+++ b/routes/entries.ts
@@ -30,7 +30,8 @@ import {
   SESSION_STATS,
   PROFILE_LOOKUP, PROFILE_DISPLAY,
   ENTRY_CANCELLED,
-  ENTRY_STATS
+  ENTRY_STATS,
+  ACCOMPANYING_ADULT_LOOKUP
 } from '../services/field-names';
 import { computeAndSaveEntryStats, runEntryStatsRefresh } from '../services/entry-stats';
 import { parseEntryStatsField } from '../services/data-layer';
@@ -804,19 +805,32 @@ router.post('/sessions/:group/:date/refresh', async (req: Request, res: Response
         const regularProfile = profiles.find(p => p.ID === vid);
         let notes = '#Regular';
         if (regularProfile && isFirstSession(regularProfile, spSession.ID)) notes = appendNewTag(notes);
-        await entriesRepository.create({
+        const entryFields: Record<string, any> = {
           [SESSION_LOOKUP]: String(spSession.ID),
           [PROFILE_LOOKUP]: String(vid),
           Notes: notes
-        });
+        };
+        const regularAdultId = safeParseLookupId(regular.AccompanyingAdultLookupId);
+        if (regularAdultId !== undefined) entryFields[ACCOMPANYING_ADULT_LOOKUP] = String(regularAdultId);
+        await entriesRepository.create(entryFields);
         existingVolunteerIds.add(vid);
         addedRegulars++;
       } else {
         const existingEntry = sessionEntries.find(e => safeParseLookupId(e[PROFILE_LOOKUP]) === vid);
-        if (existingEntry && !/#Regular\b/i.test(existingEntry.Notes || '')) {
-          const notes = String(existingEntry.Notes || '');
-          await entriesRepository.updateFields(existingEntry.ID, { Notes: notes ? `${notes.trimEnd()} #Regular` : '#Regular' });
-          regularTagged++;
+        if (existingEntry) {
+          const patchFields: Record<string, any> = {};
+          if (!/#Regular\b/i.test(existingEntry.Notes || '')) {
+            const notes = String(existingEntry.Notes || '');
+            patchFields.Notes = notes ? `${notes.trimEnd()} #Regular` : '#Regular';
+            regularTagged++;
+          }
+          const regularAdultId = safeParseLookupId(regular.AccompanyingAdultLookupId);
+          if (regularAdultId !== undefined && safeParseLookupId(existingEntry.AccompanyingAdultLookupId) === undefined) {
+            patchFields[ACCOMPANYING_ADULT_LOOKUP] = String(regularAdultId);
+          }
+          if (Object.keys(patchFields).length > 0) {
+            await entriesRepository.updateFields(existingEntry.ID, patchFields);
+          }
         }
       }
     }

--- a/routes/eventbrite.ts
+++ b/routes/eventbrite.ts
@@ -158,25 +158,20 @@ async function runSyncAttendees(): Promise<SyncAttendeesResult> {
       // Create entry if not already registered
       const profileId = profile.ID;
       if (!existingProfileIds.has(profileId)) {
-        const noteTags: string[] = [];
-        if (isFirstSession(profile, session.ID)) noteTags.push('#New');
         const isChild = !!attendee.ticket_class_name?.toLowerCase().includes('child');
-        if (isChild) noteTags.push('#Child');
-        noteTags.push('#Eventbrite');
-        if (clash) noteTags.push('#Duplicate');
-        const sessionGroupId = safeParseLookupId(session[GROUP_LOOKUP]);
-        if (sessionGroupId !== undefined && regularSet.has(`${sessionGroupId}-${profileId}`)) noteTags.push('#Regular');
         const entryFields: Record<string, any> = {
           [SESSION_LOOKUP]: String(session.ID),
           [PROFILE_LOOKUP]: String(profileId),
-          Notes: noteTags.join(' '),
           BookedBy: bookingEmailFor(attendee)
         };
         if (isChild && attendee.order_id) {
           const adultProfile = resolveAccompanyingAdult(attendees, attendee.order_id, profiles);
           if (adultProfile) entryFields.AccompanyingAdultLookupId = adultProfile.ID;
         }
-        await entriesRepository.create(entryFields);
+        const newEntryId = await entriesRepository.create(entryFields);
+        const manual: Record<string, boolean> = { eventbrite: true };
+        if (clash) manual.duplicate = true;
+        await entriesRepository.updateStats(newEntryId, { manual });
         existingProfileIds.add(profileId);
         // Update in-memory profile stats so subsequent sessions in this batch see this entry
         addSessionToProfileStats(profile, session.ID, sessionDateMap);
@@ -503,16 +498,10 @@ router.post('/eventbrite/quick-sync', async (req: Request, res: Response) => {
         const { profile, clash } = await findOrCreateProfile(attendeeName, attendeeEmail, profiles, 'QuickSync');
 
         if (!existingProfileIds.has(profile.ID)) {
-          const noteTags: string[] = [];
           const isChild = !!attendee.ticket_class_name?.toLowerCase().includes('child');
-          if (isChild) noteTags.push('#Child');
-          noteTags.push('#Eventbrite');
-          if (clash) noteTags.push('#Duplicate');
-          if (sessionGroupId !== undefined && regularSet.has(`${sessionGroupId}-${profile.ID}`)) noteTags.push('#Regular');
           const entryFields: Record<string, any> = {
             [SESSION_LOOKUP]: String(session.ID),
             [PROFILE_LOOKUP]: String(profile.ID),
-            Notes: noteTags.join(' '),
             BookedBy: bookingEmailFor(attendee)
           };
           if (isChild && attendee.order_id) {
@@ -520,7 +509,10 @@ router.post('/eventbrite/quick-sync', async (req: Request, res: Response) => {
             const adultProfile = resolveAccompanyingAdult(sessionAttendees, attendee.order_id, profiles);
             if (adultProfile) entryFields.AccompanyingAdultLookupId = adultProfile.ID;
           }
-          await entriesRepository.create(entryFields);
+          const newEntryId = await entriesRepository.create(entryFields);
+          const manual: Record<string, boolean> = { eventbrite: true };
+          if (clash) manual.duplicate = true;
+          await entriesRepository.updateStats(newEntryId, { manual });
           existingProfileIds.add(profile.ID);
           added++;
         }

--- a/routes/groups.ts
+++ b/routes/groups.ts
@@ -231,15 +231,18 @@ router.get('/groups/:key', async (req: Request, res: Response) => {
     // Build profile lookup and regulars lookup for this group
     const profiles = validateArray(rawProfiles, validateProfile, 'Profile');
     const profileMap = new Map(profiles.map(p => [p.ID, p]));
-    const regularsForGroupMap = new Map<number, number>(); // profileId → regularId
+    const regularsForGroupMap = new Map<number, { regularId: number; accompanyingAdultId?: number }>(); // profileId → { regularId, accompanyingAdultId }
     for (const r of rawRegulars) {
       if (safeParseLookupId(r[GROUP_LOOKUP]) === groupId) {
         const pid = safeParseLookupId(r[PROFILE_LOOKUP]);
-        if (pid !== undefined) regularsForGroupMap.set(pid, r.ID);
+        if (pid !== undefined) {
+          const accompanyingAdultId = safeParseLookupId(r.AccompanyingAdultLookupId);
+          regularsForGroupMap.set(pid, { regularId: r.ID, ...(accompanyingAdultId !== undefined && { accompanyingAdultId }) });
+        }
       }
     }
 
-    // Filter to ≥6h, attach name/slug/isRegular/regularId
+    // Filter to ≥6h, attach name/slug/isRegular/regularId/accompanyingAdultId
     const MIN_REGULAR_HOURS = 6;
     const rollingRegulars: import('../types/api-responses').GroupRegularResponse[] = [];
     for (const [profileId, hours] of profileHoursMap) {
@@ -247,13 +250,15 @@ router.get('/groups/:key', async (req: Request, res: Response) => {
       const spProfile = profileMap.get(profileId);
       if (!spProfile) continue;
       const p = convertProfile(spProfile);
-      const regularId = regularsForGroupMap.get(profileId);
+      const regularInfo = regularsForGroupMap.get(profileId);
       rollingRegulars.push({
+        profileId: p.id,
         name: p.name || spProfile.Title || '',
         slug: profileSlug(p.name, p.id),
         hours: Math.round(hours * 10) / 10,
-        isRegular: regularId !== undefined,
-        ...(regularId !== undefined && { regularId }),
+        isRegular: regularInfo !== undefined,
+        ...(regularInfo !== undefined && { regularId: regularInfo.regularId }),
+        ...(regularInfo?.accompanyingAdultId !== undefined && { accompanyingAdultId: regularInfo.accompanyingAdultId }),
       });
     }
     rollingRegulars.sort((a, b) => b.hours - a.hours || a.name.localeCompare(b.name));

--- a/routes/regulars.ts
+++ b/routes/regulars.ts
@@ -92,23 +92,23 @@ router.patch('/regulars/:id', async (req: Request, res: Response) => {
     }
 
     const { accompanyingAdultId } = req.body;
-    if (accompanyingAdultId === undefined) {
-      res.status(400).json({ success: false, error: 'accompanyingAdultId is required' });
-      return;
-    }
-
     const fields: Record<string, any> = {};
-    if (accompanyingAdultId === null) {
-      fields.AccompanyingAdultLookupId = null;
-    } else {
-      if (typeof accompanyingAdultId !== 'number' || !Number.isInteger(accompanyingAdultId) || accompanyingAdultId < 1) {
-        res.status(400).json({ success: false, error: 'accompanyingAdultId must be a positive integer or null' });
-        return;
+
+    if (accompanyingAdultId !== undefined) {
+      if (accompanyingAdultId === null) {
+        fields.AccompanyingAdultLookupId = null;
+      } else {
+        if (typeof accompanyingAdultId !== 'number' || !Number.isInteger(accompanyingAdultId) || accompanyingAdultId < 1) {
+          res.status(400).json({ success: false, error: 'accompanyingAdultId must be a positive integer or null' });
+          return;
+        }
+        fields.AccompanyingAdultLookupId = accompanyingAdultId;
       }
-      fields.AccompanyingAdultLookupId = accompanyingAdultId;
     }
 
-    await regularsRepository.update(regularId, fields);
+    if (Object.keys(fields).length > 0) {
+      await regularsRepository.update(regularId, fields);
+    }
     res.json({ success: true } as ApiResponse<void>);
   } catch (error: any) {
     console.error('Error updating regular:', error);

--- a/routes/regulars.ts
+++ b/routes/regulars.ts
@@ -57,11 +57,20 @@ router.post('/profiles/:slug/regulars', async (req: Request, res: Response) => {
       return;
     }
 
-    const id = await regularsRepository.create({
+    const { accompanyingAdultId } = req.body;
+    const createFields: Record<string, any> = {
       [PROFILE_LOOKUP]: String(spProfile.ID),
       [GROUP_LOOKUP]: String(group.ID),
       Title: spProfile.Title || ''
-    });
+    };
+    if (accompanyingAdultId !== undefined && accompanyingAdultId !== null) {
+      if (typeof accompanyingAdultId !== 'number' || !Number.isInteger(accompanyingAdultId) || accompanyingAdultId < 1) {
+        res.status(400).json({ success: false, error: 'accompanyingAdultId must be a positive integer' });
+        return;
+      }
+      createFields.AccompanyingAdultLookupId = accompanyingAdultId;
+    }
+    const id = await regularsRepository.create(createFields);
 
     res.json({ success: true, data: { id } } as ApiResponse<{ id: number }>);
   } catch (error: any) {
@@ -69,6 +78,43 @@ router.post('/profiles/:slug/regulars', async (req: Request, res: Response) => {
     res.status(500).json({
       success: false,
       error: 'Failed to create regular',
+      message: error.message
+    });
+  }
+});
+
+router.patch('/regulars/:id', async (req: Request, res: Response) => {
+  try {
+    const regularId = parseInt(String(req.params.id), 10);
+    if (isNaN(regularId)) {
+      res.status(400).json({ success: false, error: 'Invalid regular ID' });
+      return;
+    }
+
+    const { accompanyingAdultId } = req.body;
+    if (accompanyingAdultId === undefined) {
+      res.status(400).json({ success: false, error: 'accompanyingAdultId is required' });
+      return;
+    }
+
+    const fields: Record<string, any> = {};
+    if (accompanyingAdultId === null) {
+      fields.AccompanyingAdultLookupId = null;
+    } else {
+      if (typeof accompanyingAdultId !== 'number' || !Number.isInteger(accompanyingAdultId) || accompanyingAdultId < 1) {
+        res.status(400).json({ success: false, error: 'accompanyingAdultId must be a positive integer or null' });
+        return;
+      }
+      fields.AccompanyingAdultLookupId = accompanyingAdultId;
+    }
+
+    await regularsRepository.update(regularId, fields);
+    res.json({ success: true } as ApiResponse<void>);
+  } catch (error: any) {
+    console.error('Error updating regular:', error);
+    res.status(500).json({
+      success: false,
+      error: 'Failed to update regular',
       message: error.message
     });
   }

--- a/services/data-layer.ts
+++ b/services/data-layer.ts
@@ -281,7 +281,6 @@ export function calculateSessionStats(entries: SharePointEntry[]): Map<string, E
     const stats = statsMap.get(sessionId)!;
     stats.registrations++;
     stats.hours += parseFloat(String(entry.Hours)) || 0;
-    const notes = String(entry.Notes || '');
     const entryStats = parseEntryStatsField(entry[ENTRY_STATS]);
 
     if (entryStats) {
@@ -289,11 +288,6 @@ export function calculateSessionStats(entries: SharePointEntry[]): Map<string, E
       if (entryStats.snapshot?.isChild)                stats.childCount++;
       if (entryStats.snapshot?.booking === 'Regular')  stats.regularCount++;
       if (entryStats.manual?.eventbrite)               stats.eventbriteCount++;
-    } else {
-      if (/#New\b/i.test(notes))       stats.newCount++;
-      if (/#Child\b/i.test(notes))     stats.childCount++;
-      if (/#Regular\b/i.test(notes))   stats.regularCount++;
-      if (/#Eventbrite\b/i.test(notes)) stats.eventbriteCount++;
     }
   });
 

--- a/services/entry-stats.ts
+++ b/services/entry-stats.ts
@@ -11,7 +11,7 @@ import { profilesRepository } from './repositories/profiles-repository';
 import { sessionsRepository } from './repositories/sessions-repository';
 import { recordsRepository } from './repositories/records-repository';
 import { regularsRepository } from './repositories/regulars-repository';
-import { safeParseLookupId } from './data-layer';
+import { safeParseLookupId, parseEntryStatsField } from './data-layer';
 import { SESSION_LOOKUP, PROFILE_LOOKUP, GROUP_LOOKUP, ACCOMPANYING_ADULT_LOOKUP, ENTRY_STATS, PROFILE_STATS } from './field-names';
 import type { SharePointEntry } from '../types/sharepoint';
 import type { SharePointProfile } from '../types/sharepoint';
@@ -44,8 +44,7 @@ export function serializeEntryStats(stats: EntryStats): string {
 /**
  * Pure function — derives EntryStats from live data.
  * snapshot: computed from profile/records data.
- * manual: read from Notes (#CSR, #Late, #DigLead, #FirstAider, #Eventbrite).
- * Notes is the write path for manual tags; stats is the read path everywhere else.
+ * manual: preserved from existingManual — never recomputed from Notes.
  */
 export function computeEntryStatsForEntry(
   entry: SharePointEntry,
@@ -54,7 +53,8 @@ export function computeEntryStatsForEntry(
   records: SharePointRecord[],
   sessionGroupId: number | undefined,
   regularGroupIds: number[],
-  sessionDate?: string
+  sessionDate?: string,
+  existingManual?: EntryStatsManual
 ): EntryStats {
   let profileStats: any = {};
   try { profileStats = JSON.parse(profileStatsJson || '{}'); } catch { /* malformed */ }
@@ -63,7 +63,6 @@ export function computeEntryStatsForEntry(
   // Falls back to today only if sessionDate is unavailable.
   const certReferenceDate = sessionDate ?? todayDate();
   const sessionId = safeParseLookupId(entry[SESSION_LOOKUP]);
-  const notes = String(entry.Notes || '');
 
   // --- snapshot ---
 
@@ -90,7 +89,7 @@ export function computeEntryStatsForEntry(
     if (r.Type === 'First Aid Certificate' && r.Status === 'Expires' && r.Date && r.Date.substring(0, 10) > certReferenceDate) isFirstAider = true;
   }
 
-  const isChild = !!entry[ACCOMPANYING_ADULT_LOOKUP] || /#Child\b/i.test(notes);
+  const isChild = !!entry[ACCOMPANYING_ADULT_LOOKUP];
 
   const snapshot: EntryStatsSnapshot = {};
   if (booking)                      snapshot.booking        = booking;
@@ -103,18 +102,11 @@ export function computeEntryStatsForEntry(
   if (isDigLead)                    snapshot.isDigLead      = true;
   if (isFirstAider)                 snapshot.isFirstAider   = true;
 
-  // --- manual: operational tags entered on the day, sourced from Notes ---
-  const manual: EntryStatsManual = {};
-  if (/#CSR\b/i.test(notes))        manual.csr        = true;
-  if (/#Late\b/i.test(notes))       manual.late       = true;
-  if (/#DigLead\b/i.test(notes))    manual.digLead    = true;
-  if (/#FirstAider\b/i.test(notes)) manual.firstAider = true;
-  if (/#Eventbrite\b/i.test(notes)) manual.eventbrite = true;
-  if (/#Duplicate\b/i.test(notes))  manual.duplicate  = true;
+  const manual = existingManual && Object.keys(existingManual).length > 0 ? existingManual : undefined;
 
   return {
     snapshot: Object.keys(snapshot).length > 0 ? snapshot : undefined,
-    manual: Object.keys(manual).length > 0 ? manual : undefined,
+    manual,
   };
 }
 
@@ -150,6 +142,9 @@ export async function computeAndSaveEntryStats(entryId: number): Promise<void> {
     .map(r => safeParseLookupId(r[GROUP_LOOKUP] as unknown as string))
     .filter((id): id is number => id !== undefined);
 
+  const existing = entry[ENTRY_STATS];
+  const existingManual = existing ? parseEntryStatsField(existing)?.manual : undefined;
+
   const newStats = computeEntryStatsForEntry(
     entry,
     profile ?? undefined,
@@ -157,11 +152,11 @@ export async function computeAndSaveEntryStats(entryId: number): Promise<void> {
     records,
     sessionGroupId,
     regularGroupIds,
-    sessionDate
+    sessionDate,
+    existingManual
   );
 
   // Skip write if unchanged
-  const existing = entry[ENTRY_STATS];
   if (existing) {
     try {
       if (JSON.stringify(JSON.parse(existing)) === JSON.stringify(newStats)) return;
@@ -247,6 +242,9 @@ export async function runEntryStatsRefresh(): Promise<EntryStatsRefreshResult> {
         const regularGroupIds = (profileId !== undefined ? regularGroupsByProfile.get(profileId) : undefined) ?? [];
         const sessionGroupId = sessionId !== undefined ? sessionGroupMap.get(sessionId) : undefined;
 
+        const existing = entry[ENTRY_STATS];
+        const existingManual = existing ? parseEntryStatsField(existing)?.manual : undefined;
+
         const newStats = computeEntryStatsForEntry(
           entry,
           profile,
@@ -254,11 +252,11 @@ export async function runEntryStatsRefresh(): Promise<EntryStatsRefreshResult> {
           records,
           sessionGroupId,
           regularGroupIds,
-          sessionDate
+          sessionDate,
+          existingManual
         );
 
         // Skip write if unchanged
-        const existing = entry[ENTRY_STATS];
         if (existing) {
           try {
             if (JSON.stringify(JSON.parse(existing)) === JSON.stringify(newStats)) return;

--- a/services/repositories/regulars-repository.ts
+++ b/services/repositories/regulars-repository.ts
@@ -16,13 +16,18 @@ class RegularsRepository {
   }
 
   private get selectFields(): string {
-    return `ID,Title,${PROFILE_DISPLAY},${PROFILE_LOOKUP},${GROUP_DISPLAY},${GROUP_LOOKUP},Created,Modified`;
+    return `ID,Title,${PROFILE_DISPLAY},${PROFILE_LOOKUP},${GROUP_DISPLAY},${GROUP_LOOKUP},AccompanyingAdultLookupId,AccompanyingAdult,Created,Modified`;
   }
 
   async create(fields: Record<string, any>): Promise<number> {
     const id = await sharePointClient.createListItem(this.listGuid, fields);
     sharePointClient.clearCacheKey('regulars');
     return id;
+  }
+
+  async update(regularId: number, fields: Record<string, any>): Promise<void> {
+    await sharePointClient.updateListItem(this.listGuid, regularId, fields);
+    sharePointClient.clearCacheKey('regulars');
   }
 
   async delete(regularId: number): Promise<void> {

--- a/types/api-responses.ts
+++ b/types/api-responses.ts
@@ -319,6 +319,7 @@ export interface EntryListItemResponse {
   hasAccompanyingAdult: boolean;
   accompanyingAdultId?: number;
   cancelled?: string;
+  stats?: import('./entry-stats').EntryStats;
 }
 
 export interface TagHoursItem {

--- a/types/api-responses.ts
+++ b/types/api-responses.ts
@@ -20,11 +20,13 @@ export interface SessionStats {
 }
 
 export interface GroupRegularResponse {
+  profileId: number;
   name: string;
   slug: string;
   hours: number;       // rolling-year hours for this group
   isRegular: boolean;
-  regularId?: number;  // present if isRegular is true
+  regularId?: number;           // present if isRegular is true
+  accompanyingAdultId?: number; // present if this regular is a child (profile ID of the adult)
 }
 
 export interface GroupResponse {

--- a/types/sharepoint.ts
+++ b/types/sharepoint.ts
@@ -106,6 +106,8 @@ export interface Entry {
  */
 export interface SharePointRegular extends SharePointBaseItem {
   Title?: string;
+  AccompanyingAdultLookupId?: number;
+  AccompanyingAdult?: string;
   /** Allow bracket access for dynamic field names (ProfileLookupId, GroupLookupId, etc.) */
   [key: string]: any;
 }


### PR DESCRIPTION
AccompanyingAdult is now the sole signal for child status on entries. The #Child tag is removed from the entry tag picker; the AccompanyingAdult dropdown in the Edit Entry Modal is always visible and no longer gated on the #Child tag being present. sessionAdults computed filters by !accompanyingAdultId rather than notes text.

Regulars now carry an AccompanyingAdult field. A new Regular Edit Modal on the Group Detail page replaces the checkbox-toggle pattern, allowing admins to set a default accompanying adult per regular. The session refresh step copies AccompanyingAdultLookupId from the regular record into newly created (and existing) session entries.

Backend:
- SharePointRegular: add AccompanyingAdultLookupId field
- regulars-repository: add to selectFields; add update() method
- GroupRegularResponse: add accompanyingAdultId
- routes/groups: include accompanyingAdultId in regularsForGroupMap and rollingRegulars
- routes/regulars: PATCH /api/regulars/:id; POST accepts accompanyingAdultId
- routes/entries: session refresh copies AccompanyingAdultLookupId from regular into new and existing entries (only if not already set)
- docs/sharepoint-schema.md: document AccompanyingAdult on Regulars list

Frontend:
- EntryIconPicker: remove #Child tag button
- EntryEditModal: remove hasChild guard; AccompanyingAdult dropdown always shown
- RegularItem: clickable card with full green background for regulars; emits edit
- RegularList: updated interface and emits for click-to-edit pattern
- RegularEditModal: new stateless modal (save/delete/close); shows "Accompanying adult for…" when regular is already acting as an adult for others
- GroupDetailPage: wire up RegularEditModal with PATCH/POST/DELETE handlers
- ProfileDetailPage: EditData type includes accompanyingAdultId
- Sandbox: updated RegularItem, RegularList, Modals fixtures