### PR TITLE
#196 refactor lists

### DIFF
--- a/frontend/src/components/entries/EntryListActions.vue
+++ b/frontend/src/components/entries/EntryListActions.vue
@@ -1,18 +1,21 @@
 <template>
-  <div class="ela-bar">
-    <span class="ela-totals">
-      {{ entries.length }} {{ entries.length === 1 ? 'entry' : 'entries' }}
-      <template v-if="totalHours > 0"> · {{ totalHours }} hours</template>
+  <div class="ela-wrap">
+    <span class="ela-stats">
+      <template v-if="selected.length">{{ selected.length }} / </template>{{ entries.length }} {{ entries.length === 1 ? 'entry' : 'entries' }}<template v-if="totalHours > 0"> &nbsp;&nbsp; {{ totalHours }} hours</template>
     </span>
-    <span v-if="selected.length" class="ela-selected">
-      {{ selected.length }} selected
-    </span>
+    <div class="ela-buttons">
+      <AppButton label="Download CSV" icon="download" mode="icon-responsive" @click="onDownload" />
+      <AppButton label="Share" icon="share" mode="icon-only" @click="onShare" />
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { computed } from 'vue'
+import AppButton from '../AppButton.vue'
 import type { EntryListItemResponse } from '../../../../types/api-responses'
+import { downloadCsv } from '../../utils/listCsv'
+import { shareCurrentUrl } from '../../utils/shareUrl'
 
 const props = defineProps<{
   entries: EntryListItemResponse[]
@@ -22,21 +25,42 @@ const props = defineProps<{
 const totalHours = computed(() =>
   Math.round(props.entries.reduce((sum, e) => sum + e.hours, 0) * 10) / 10
 )
+
+function onDownload() {
+  const source = props.selected.length
+    ? props.entries.filter(e => props.selected.includes(e.id))
+    : props.entries
+
+  const today = new Date().toISOString().slice(0, 10)
+  downloadCsv(`${today} Entries.csv`,
+    ['Date', 'Group', 'Volunteer', 'Hours', 'Checked In', 'Notes'],
+    source.map(e => [
+      e.date?.substring(0, 10) ?? '',
+      e.groupName ?? '',
+      e.volunteerName ?? '',
+      e.hours,
+      e.checkedIn ? 'Yes' : 'No',
+      e.notes ?? '',
+    ])
+  )
+}
+
+function onShare() {
+  shareCurrentUrl()
+}
 </script>
 
 <style scoped>
-.ela-bar {
+.ela-wrap {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  padding: 0.5rem 1rem;
-  background: var(--color-dtv-light);
-  font-size: 0.85rem;
-  color: var(--color-text-muted);
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  background: var(--color-dtv-sand);
+  padding: 0.75rem 1.5rem;
+  margin-bottom: 1.5rem;
 }
 
-.ela-selected {
-  font-weight: 600;
-  color: var(--color-text);
-}
+.ela-stats { flex: 1; font-size: 0.85rem; color: var(--color-text-secondary); }
+.ela-buttons { display: flex; gap: 0.5rem; margin-left: auto; }
 </style>

--- a/frontend/src/components/entries/EntryListActions.vue
+++ b/frontend/src/components/entries/EntryListActions.vue
@@ -1,9 +1,9 @@
 <template>
-  <div class="ela-wrap">
-    <span class="ela-stats">
-      <template v-if="selected.length">{{ selected.length }} / </template>{{ entries.length }} {{ entries.length === 1 ? 'entry' : 'entries' }}<template v-if="totalHours > 0"> &nbsp;&nbsp; {{ totalHours }} hours</template>
+  <div class="list-actions">
+    <span class="list-actions-stats">
+      {{ selected.length }} / {{ entries.length }} entries &nbsp;&nbsp; {{ selectedHours }} / {{ totalHours }} hours
     </span>
-    <div class="ela-buttons">
+    <div class="list-actions-buttons">
       <AppButton label="Download CSV" icon="download" mode="icon-responsive" @click="onDownload" />
       <AppButton label="Share" icon="share" mode="icon-only" @click="onShare" />
     </div>
@@ -22,9 +22,13 @@ const props = defineProps<{
   selected: number[]
 }>()
 
+const selectedEntries = computed(() => props.entries.filter(e => props.selected.includes(e.id)))
+
+const selectedHours = computed(() =>
+  Math.round(selectedEntries.value.reduce((sum, e) => sum + e.hours, 0) * 10) / 10)
+
 const totalHours = computed(() =>
-  Math.round(props.entries.reduce((sum, e) => sum + e.hours, 0) * 10) / 10
-)
+  Math.round(props.entries.reduce((sum, e) => sum + e.hours, 0) * 10) / 10)
 
 function onDownload() {
   const source = props.selected.length
@@ -49,18 +53,3 @@ function onShare() {
   shareCurrentUrl()
 }
 </script>
-
-<style scoped>
-.ela-wrap {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  background: var(--color-dtv-sand);
-  padding: 0.75rem 1.5rem;
-  margin-bottom: 1.5rem;
-}
-
-.ela-stats { flex: 1; font-size: 0.85rem; color: var(--color-text-secondary); }
-.ela-buttons { display: flex; gap: 0.5rem; margin-left: auto; }
-</style>

--- a/frontend/src/components/entries/EntryListActions.vue
+++ b/frontend/src/components/entries/EntryListActions.vue
@@ -4,7 +4,7 @@
       {{ selected.length }} / {{ entries.length }} entries &nbsp;&nbsp; {{ selectedHours }} / {{ totalHours }} hours
     </span>
     <div class="list-actions-buttons">
-      <AppButton label="Download CSV" icon="download" mode="icon-responsive" @click="onDownload" />
+      <AppButton label="Download CSV" icon="download" mode="icon-only" :disabled="!selectedEntries.length" @click="onDownload" />
       <AppButton label="Share" icon="share" mode="icon-only" @click="onShare" />
     </div>
   </div>
@@ -31,9 +31,7 @@ const totalHours = computed(() =>
   Math.round(props.entries.reduce((sum, e) => sum + e.hours, 0) * 10) / 10)
 
 function onDownload() {
-  const source = props.selected.length
-    ? props.entries.filter(e => props.selected.includes(e.id))
-    : props.entries
+  const source = selectedEntries.value.length ? selectedEntries.value : props.entries
 
   const today = new Date().toISOString().slice(0, 10)
   downloadCsv(`${today} Entries.csv`,

--- a/frontend/src/components/entries/EntryListFilter.vue
+++ b/frontend/src/components/entries/EntryListFilter.vue
@@ -1,18 +1,18 @@
 <template>
-  <div class="elf-bar">
+  <div class="list-filter">
     <input
       v-model="q"
-      class="elf-input"
+      class="list-filter-search"
       type="search"
       placeholder="Search notes…"
       @input="onTextInput"
     />
-    <select v-model="accompanyingAdult" class="elf-select" @change="emitFiltered">
+    <select v-model="accompanyingAdult" class="list-filter-select" @change="emitFiltered">
       <option value="">All</option>
       <option value="notempty">Has Accompanying Adult</option>
       <option value="empty">No Accompanying Adult</option>
     </select>
-    <select v-model="cancelled" class="elf-select" @change="emitFiltered">
+    <select v-model="cancelled" class="list-filter-select" @change="emitFiltered">
       <option value="false">Not Cancelled</option>
       <option value="all">Show All</option>
       <option value="true">Cancelled</option>
@@ -60,34 +60,3 @@ watch([q, accompanyingAdult, cancelled], ([newQ, newAdult, newCancelled]) => {
   router.replace({ query })
 })
 </script>
-
-<style scoped>
-.elf-bar {
-  display: flex;
-  gap: 0.5rem;
-  padding: 0.75rem 1rem;
-  background: var(--color-dtv-light);
-  flex-wrap: wrap;
-}
-
-.elf-input {
-  flex: 1;
-  min-width: 10rem;
-  background: var(--color-dtv-sand);
-  border: none;
-  color: var(--color-text);
-  padding: 0.4rem 0.6rem;
-  font-family: inherit;
-  font-size: 0.9rem;
-}
-
-.elf-select {
-  background: var(--color-dtv-sand);
-  border: none;
-  color: var(--color-text);
-  padding: 0.4rem 0.6rem;
-  font-family: inherit;
-  font-size: 0.9rem;
-  cursor: pointer;
-}
-</style>

--- a/frontend/src/components/entries/EntryListFilter.vue
+++ b/frontend/src/components/entries/EntryListFilter.vue
@@ -7,6 +7,7 @@
       placeholder="Search notes…"
       @input="onTextInput"
     />
+    <FyFilter v-model="fy" class="list-filter-select" />
     <select v-model="accompanyingAdult" class="list-filter-select" @change="emitFiltered">
       <option value="">All</option>
       <option value="notempty">Has Accompanying Adult</option>
@@ -23,9 +24,11 @@
 <script setup lang="ts">
 import { ref, watch, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import FyFilter from '../FyFilter.vue'
 
 export interface EntryFilterParams {
   q: string
+  fy: string
   accompanyingAdult: string
   cancelled: string
 }
@@ -36,6 +39,7 @@ const route = useRoute()
 const router = useRouter()
 
 const q = ref((route.query.q as string) || '')
+const fy = ref((route.query.fy as string) || 'future')
 const accompanyingAdult = ref((route.query.accompanyingAdult as string) || '')
 const cancelled = ref((route.query.cancelled as string) || 'false')
 
@@ -47,14 +51,19 @@ function onTextInput() {
 }
 
 function emitFiltered() {
-  emit('filtered', { q: q.value, accompanyingAdult: accompanyingAdult.value, cancelled: cancelled.value })
+  emit('filtered', { q: q.value, fy: fy.value, accompanyingAdult: accompanyingAdult.value, cancelled: cancelled.value })
 }
 
 onMounted(() => emitFiltered())
 
-watch([q, accompanyingAdult, cancelled], ([newQ, newAdult, newCancelled]) => {
+// FY change triggers a re-fetch
+watch(fy, () => emitFiltered())
+
+// URL sync
+watch([q, fy, accompanyingAdult, cancelled], ([newQ, newFy, newAdult, newCancelled]) => {
   const query: Record<string, string> = {}
   if (newQ)       query.q                  = newQ
+  if (newFy && newFy !== 'future') query.fy = newFy
   if (newAdult)   query.accompanyingAdult  = newAdult
   if (newCancelled && newCancelled !== 'false') query.cancelled = newCancelled
   router.replace({ query })

--- a/frontend/src/components/entries/EntryListResults.vue
+++ b/frontend/src/components/entries/EntryListResults.vue
@@ -1,14 +1,15 @@
 <template>
   <div class="elr-wrap">
 
-    <p v-if="loading" class="elr-empty">Loading…</p>
+    <LoadingSpinner v-if="loading" />
     <p v-else-if="error" class="elr-empty elr-empty--error">{{ error }}</p>
     <p v-else-if="!entries.length" class="elr-empty">No entries found</p>
 
     <template v-else>
-      <div v-if="allowSelect" class="elr-select-bar">
-        <button class="elr-select-btn" @click="selectAll">Select all</button>
-        <button class="elr-select-btn" @click="deselectAll">Deselect all</button>
+      <div v-if="allowSelect" class="list-select-row">
+        <button class="list-select-all" @click="toggleSelectAll">
+          {{ allSelected ? 'Deselect all' : 'Select all' }}
+        </button>
       </div>
 
       <div class="elr-list">
@@ -23,7 +24,7 @@
             type="checkbox"
             class="elr-checkbox"
             :checked="selected.includes(e.id)"
-            @change="onSelect(e.id, !selected.includes(e.id))"
+            @change="toggle(e.id)"
           />
           <button
             v-if="allowEdit"
@@ -46,8 +47,10 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
 import type { EntryListItemResponse } from '../../../../types/api-responses'
 import EntryListItem from './EntryListItem.vue'
+import LoadingSpinner from '../LoadingSpinner.vue'
 import { entryPath } from '../../router/index'
 
 const props = defineProps<{
@@ -64,27 +67,23 @@ const emit = defineEmits<{
   'editEntry': [entry: EntryListItemResponse]
 }>()
 
-function onSelect(id: number, val: boolean) {
-  const next = val
-    ? [...props.selected, id]
-    : props.selected.filter(x => x !== id)
+const allSelected = computed(() =>
+  props.entries.length > 0 && props.entries.every(e => props.selected.includes(e.id))
+)
+
+function toggleSelectAll() {
+  emit('update:selected', allSelected.value ? [] : props.entries.map(e => e.id))
+}
+
+function toggle(id: number) {
+  const next = props.selected.includes(id)
+    ? props.selected.filter(x => x !== id)
+    : [...props.selected, id]
   emit('update:selected', next)
-}
-
-function selectAll() {
-  emit('update:selected', props.entries.map(e => e.id))
-}
-
-function deselectAll() {
-  emit('update:selected', [])
 }
 </script>
 
 <style scoped>
-.elr-wrap {
-  background: var(--color-dtv-sand-light);
-}
-
 .elr-empty {
   padding: 1rem;
   font-size: 0.9rem;
@@ -93,25 +92,6 @@ function deselectAll() {
 .elr-empty--error {
   color: var(--color-dtv-dirt);
 }
-
-.elr-select-bar {
-  display: flex;
-  gap: 0.5rem;
-  padding: 0.5rem 1rem;
-  background: var(--color-dtv-light);
-}
-
-.elr-select-btn {
-  background: none;
-  border: none;
-  font-family: inherit;
-  font-size: 0.85rem;
-  color: var(--color-dtv-green);
-  cursor: pointer;
-  padding: 0;
-  text-decoration: underline;
-}
-.elr-select-btn:hover { color: var(--color-dtv-green-dark); }
 
 .elr-list {
   display: flex;

--- a/frontend/src/components/groups/GroupListActions.vue
+++ b/frontend/src/components/groups/GroupListActions.vue
@@ -4,17 +4,31 @@
       {{ selected.length }} / {{ groups.length }} groups &nbsp;&nbsp; {{ selectedHours }} / {{ totalHours }} hours
     </span>
     <div class="list-actions-buttons">
-      <AppButton label="Download CSV" icon="download" mode="icon-responsive" @click="onDownload" />
+      <AppButton label="Download CSV" icon="download" mode="icon-only" :disabled="!selectedGroups.length" @click="onDownload" />
       <AppButton label="Share" icon="share" mode="icon-only" @click="onShare" />
+      <AppButton label="New group" icon="add" mode="icon-only" @click="showNew = true" />
     </div>
   </div>
+
+  <GroupAddModal
+    v-if="showNew"
+    :working="saving"
+    :error="saveError"
+    @close="showNew = false; saveError = ''"
+    @add="onAdd"
+  />
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { ref, computed } from 'vue'
+import { useRouter } from 'vue-router'
 import AppButton from '../AppButton.vue'
+import GroupAddModal from '../../pages/modals/GroupAddModal.vue'
+import type { AddGroupPayload } from '../../pages/modals/GroupAddModal.vue'
 import { downloadCsv } from '../../utils/listCsv'
 import { shareCurrentUrl } from '../../utils/shareUrl'
+import { useGroupListStore } from '../../stores/groupList'
+import { groupPath } from '../../router/index'
 import type { GroupWithStats } from './GroupListFilter.vue'
 
 const props = defineProps<{
@@ -22,6 +36,9 @@ const props = defineProps<{
   selected: number[]
   canBulkTag: boolean
 }>()
+
+const router = useRouter()
+const groupsStore = useGroupListStore()
 
 const selectedGroups = computed(() => props.groups.filter(g => props.selected.includes(g.id)))
 
@@ -32,17 +49,43 @@ const totalHours = computed(() =>
   Math.round(props.groups.reduce((sum, g) => sum + g.hours, 0) * 10) / 10)
 
 function onDownload() {
-  const source = props.selected.length
-    ? props.groups.filter(g => props.selected.includes(g.id))
-    : props.groups
-
   const today = new Date().toISOString().slice(0, 10)
   downloadCsv(`${today} Groups.csv`, ['Key', 'Name', 'Description', 'Regulars', 'Sessions', 'Hours'],
-    source.map(g => [g.key, g.displayName ?? '', g.description ?? '', g.regularsCount, g.sessionCount, g.hours])
+    selectedGroups.value.map(g => [g.key, g.displayName ?? '', g.description ?? '', g.regularsCount, g.sessionCount, g.hours])
   )
 }
 
 function onShare() {
   shareCurrentUrl()
+}
+
+const showNew = ref(false)
+const saving = ref(false)
+const saveError = ref('')
+
+async function onAdd(data: AddGroupPayload) {
+  saving.value = true
+  saveError.value = ''
+  try {
+    const res = await fetch('/api/groups', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+    if (!res.ok) {
+      const json = await res.json().catch(() => ({}))
+      saveError.value = json.error || 'Failed to create group'
+      return
+    }
+    const json = await res.json()
+    showNew.value = false
+    await groupsStore.fetch()
+    if (json.data?.key) router.push(groupPath(json.data.key))
+  } catch (e) {
+    saveError.value = e instanceof Error ? e.message : 'An error occurred'
+    console.error('[GroupListActions] onAdd', e)
+  } finally {
+    saving.value = false
+  }
 }
 </script>

--- a/frontend/src/components/groups/GroupListActions.vue
+++ b/frontend/src/components/groups/GroupListActions.vue
@@ -6,29 +6,16 @@
     <div class="list-actions-buttons">
       <AppButton label="Download CSV" icon="download" mode="icon-only" :disabled="!selectedGroups.length" @click="onDownload" />
       <AppButton label="Share" icon="share" mode="icon-only" @click="onShare" />
-      <AppButton label="New group" icon="add" mode="icon-only" @click="showNew = true" />
+      <AppButton label="New group" icon="add" mode="icon-only" @click="emit('add-group')" />
     </div>
   </div>
-
-  <GroupAddModal
-    v-if="showNew"
-    :working="saving"
-    :error="saveError"
-    @close="showNew = false; saveError = ''"
-    @add="onAdd"
-  />
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue'
-import { useRouter } from 'vue-router'
+import { computed } from 'vue'
 import AppButton from '../AppButton.vue'
-import GroupAddModal from '../../pages/modals/GroupAddModal.vue'
-import type { AddGroupPayload } from '../../pages/modals/GroupAddModal.vue'
 import { downloadCsv } from '../../utils/listCsv'
 import { shareCurrentUrl } from '../../utils/shareUrl'
-import { useGroupListStore } from '../../stores/groupList'
-import { groupPath } from '../../router/index'
 import type { GroupWithStats } from './GroupListFilter.vue'
 
 const props = defineProps<{
@@ -37,8 +24,10 @@ const props = defineProps<{
   canBulkTag: boolean
 }>()
 
-const router = useRouter()
-const groupsStore = useGroupListStore()
+const emit = defineEmits<{
+  'add-group': []
+  'update:selected': [ids: number[]]
+}>()
 
 const selectedGroups = computed(() => props.groups.filter(g => props.selected.includes(g.id)))
 
@@ -57,35 +46,5 @@ function onDownload() {
 
 function onShare() {
   shareCurrentUrl()
-}
-
-const showNew = ref(false)
-const saving = ref(false)
-const saveError = ref('')
-
-async function onAdd(data: AddGroupPayload) {
-  saving.value = true
-  saveError.value = ''
-  try {
-    const res = await fetch('/api/groups', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(data),
-    })
-    if (!res.ok) {
-      const json = await res.json().catch(() => ({}))
-      saveError.value = json.error || 'Failed to create group'
-      return
-    }
-    const json = await res.json()
-    showNew.value = false
-    await groupsStore.fetch()
-    if (json.data?.key) router.push(groupPath(json.data.key))
-  } catch (e) {
-    saveError.value = e instanceof Error ? e.message : 'An error occurred'
-    console.error('[GroupListActions] onAdd', e)
-  } finally {
-    saving.value = false
-  }
 }
 </script>

--- a/frontend/src/components/groups/GroupListActions.vue
+++ b/frontend/src/components/groups/GroupListActions.vue
@@ -1,9 +1,9 @@
 <template>
-  <div v-if="canBulkTag" class="gla-wrap">
-    <span class="gla-stats">
+  <div v-if="canBulkTag" class="list-actions">
+    <span class="list-actions-stats">
       {{ selected.length }} / {{ groups.length }} groups &nbsp;&nbsp; {{ selectedHours }} / {{ totalHours }} hours
     </span>
-    <div class="gla-buttons">
+    <div class="list-actions-buttons">
       <AppButton label="Download CSV" icon="download" mode="icon-responsive" @click="onDownload" />
       <AppButton label="Share" icon="share" mode="icon-only" @click="onShare" />
     </div>
@@ -46,18 +46,3 @@ function onShare() {
   shareCurrentUrl()
 }
 </script>
-
-<style scoped>
-.gla-wrap {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  background: var(--color-dtv-sand);
-  padding: 0.75rem 1.5rem;
-  margin-bottom: 1.5rem;
-}
-
-.gla-stats { flex: 1; font-size: 0.85rem; color: var(--color-text-secondary); }
-.gla-buttons { display: flex; gap: 0.5rem; margin-left: auto; }
-</style>

--- a/frontend/src/components/groups/GroupListActions.vue
+++ b/frontend/src/components/groups/GroupListActions.vue
@@ -1,0 +1,63 @@
+<template>
+  <div v-if="canBulkTag" class="gla-wrap">
+    <span class="gla-stats">
+      {{ selected.length }} / {{ groups.length }} groups &nbsp;&nbsp; {{ selectedHours }} / {{ totalHours }} hours
+    </span>
+    <div class="gla-buttons">
+      <AppButton label="Download CSV" icon="download" mode="icon-responsive" @click="onDownload" />
+      <AppButton label="Share" icon="share" mode="icon-only" @click="onShare" />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import AppButton from '../AppButton.vue'
+import { downloadCsv } from '../../utils/listCsv'
+import { shareCurrentUrl } from '../../utils/shareUrl'
+import type { GroupWithStats } from './GroupListFilter.vue'
+
+const props = defineProps<{
+  groups: GroupWithStats[]
+  selected: number[]
+  canBulkTag: boolean
+}>()
+
+const selectedGroups = computed(() => props.groups.filter(g => props.selected.includes(g.id)))
+
+const selectedHours = computed(() =>
+  Math.round(selectedGroups.value.reduce((sum, g) => sum + g.hours, 0) * 10) / 10)
+
+const totalHours = computed(() =>
+  Math.round(props.groups.reduce((sum, g) => sum + g.hours, 0) * 10) / 10)
+
+function onDownload() {
+  const source = props.selected.length
+    ? props.groups.filter(g => props.selected.includes(g.id))
+    : props.groups
+
+  const today = new Date().toISOString().slice(0, 10)
+  downloadCsv(`${today} Groups.csv`, ['Key', 'Name', 'Description', 'Regulars', 'Sessions', 'Hours'],
+    source.map(g => [g.key, g.displayName ?? '', g.description ?? '', g.regularsCount, g.sessionCount, g.hours])
+  )
+}
+
+function onShare() {
+  shareCurrentUrl()
+}
+</script>
+
+<style scoped>
+.gla-wrap {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  background: var(--color-dtv-sand);
+  padding: 0.75rem 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.gla-stats { flex: 1; font-size: 0.85rem; color: var(--color-text-secondary); }
+.gla-buttons { display: flex; gap: 0.5rem; margin-left: auto; }
+</style>

--- a/frontend/src/components/groups/GroupListFilter.vue
+++ b/frontend/src/components/groups/GroupListFilter.vue
@@ -3,36 +3,9 @@
     <div class="gf-title-row">
       <div class="gf-actions">
         <FyFilter v-model="fy" />
-        <button v-if="canAddGroup" class="icon-btn" @click="showNew = true" title="New group">
-          <img src="/icons/add.svg" alt="New group" />
-        </button>
       </div>
     </div>
 
-    <!-- New Group modal -->
-    <div v-if="showNew" class="gf-modal-overlay" @click.self="showNew = false">
-      <div class="gf-modal">
-        <h3>New Group</h3>
-        <div class="gf-modal-field">
-          <label>Key (short name, e.g. "sat")</label>
-          <input v-model="newKey" type="text" placeholder="sat" />
-        </div>
-        <div class="gf-modal-field">
-          <label>Display Name (e.g. "Saturday Dig")</label>
-          <input v-model="newName" type="text" placeholder="Saturday Dig" />
-        </div>
-        <div class="gf-modal-field">
-          <label>Description (optional)</label>
-          <textarea v-model="newDesc"></textarea>
-        </div>
-        <div class="gf-modal-buttons">
-          <button class="gf-btn" @click="showNew = false">Cancel</button>
-          <button class="gf-btn gf-btn--primary" :disabled="!newKey || saving" @click="addGroup">
-            {{ saving ? 'Adding…' : 'Add' }}
-          </button>
-        </div>
-      </div>
-    </div>
   </div>
 </template>
 
@@ -40,8 +13,6 @@
 import { ref, computed, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import FyFilter from '../FyFilter.vue'
-import { useGroupListStore } from '../../stores/groupList'
-import { groupPath } from '../../router/index'
 import type { GroupResponse } from '../../../../types/api-responses'
 import type { Session } from '../../types/session'
 
@@ -50,19 +21,13 @@ export interface GroupWithStats extends GroupResponse {
   hours: number
 }
 
-const props = defineProps<{ groups: GroupResponse[]; sessions: Session[]; canAddGroup: boolean }>()
+const props = defineProps<{ groups: GroupResponse[]; sessions: Session[] }>()
 const emit = defineEmits<{ filtered: [groups: GroupWithStats[]] }>()
 
 const route = useRoute()
 const router = useRouter()
-const groupsStore = useGroupListStore()
 
 const fy = ref((route.query.fy as string) || 'future')
-const showNew = ref(false)
-const newKey = ref('')
-const newName = ref('')
-const newDesc = ref('')
-const saving = ref(false)
 
 function rollingStart(): string {
   const d = new Date()
@@ -98,31 +63,6 @@ watch(fy, newFy => {
   router.replace({ query: newFy ? { fy: newFy } : {} })
 })
 
-async function addGroup() {
-  if (!newKey.value) return
-  saving.value = true
-  try {
-    const res = await fetch('/api/groups', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        key: newKey.value,
-        name: newName.value || undefined,
-        description: newDesc.value || undefined,
-      })
-    })
-    if (!res.ok) throw new Error('Failed to create group')
-    const json = await res.json()
-    showNew.value = false
-    newKey.value = ''; newName.value = ''; newDesc.value = ''
-    await groupsStore.fetch()
-    if (json.data?.key) router.push(groupPath(json.data.key))
-  } catch (e) {
-    console.error('[GroupListFilter] addGroup', e)
-  } finally {
-    saving.value = false
-  }
-}
 </script>
 
 <style scoped>

--- a/frontend/src/components/groups/GroupListFilter.vue
+++ b/frontend/src/components/groups/GroupListFilter.vue
@@ -1,7 +1,6 @@
 <template>
   <div class="gf-wrap">
     <div class="gf-title-row">
-      <span class="gf-count">{{ filtered.length }} {{ filtered.length === 1 ? 'Group' : 'Groups' }}</span>
       <div class="gf-actions">
         <FyFilter v-model="fy" />
         <button v-if="canAddGroup" class="icon-btn" @click="showNew = true" title="New group">
@@ -58,7 +57,7 @@ const route = useRoute()
 const router = useRouter()
 const groupsStore = useGroupListStore()
 
-const fy = ref((route.query.fy as string) || 'rolling')
+const fy = ref((route.query.fy as string) || 'future')
 const showNew = ref(false)
 const newKey = ref('')
 const newName = ref('')
@@ -73,6 +72,7 @@ function rollingStart(): string {
 
 function matchesFy(s: Session): boolean {
   if (fy.value === 'all') return true
+  if (fy.value === 'future') return s.date >= new Date().toISOString().slice(0, 10)
   if (fy.value === 'rolling') return s.date >= rollingStart() && s.date <= new Date().toISOString().slice(0, 10)
   return s.financialYear === fy.value
 }
@@ -140,14 +140,7 @@ async function addGroup() {
 
 .gf-heading { font-size: 1.1rem; font-weight: 700; color: var(--color-text); margin: 0; }
 
-.gf-count {
-  background: var(--color-surface-subtle); color: var(--color-text-label);
-  font-size: 0.8rem; font-weight: 600;
-  padding: 0.15rem 0.5rem;
-  margin-right: auto;
-}
-
-.gf-actions { display: flex; gap: 0.5rem; align-items: center; }
+.gf-actions { display: flex; gap: 0.5rem; align-items: center; margin-left: auto; }
 
 
 .gf-modal-overlay {

--- a/frontend/src/components/groups/GroupListResults.vue
+++ b/frontend/src/components/groups/GroupListResults.vue
@@ -3,17 +3,17 @@
   <div v-else-if="error" class="gr-state gr-state--error">{{ error }}</div>
   <div v-else-if="!groups.length" class="gr-state">No groups found.</div>
   <template v-else>
-    <div v-if="selected" class="gr-select-row">
-      <button class="gr-select-all" @click="toggleSelectAll">
+    <div v-if="selected" class="list-select-row">
+      <button class="list-select-all" @click="toggleSelectAll">
         {{ allSelected ? 'Deselect all' : 'Select all' }}
       </button>
     </div>
-    <div class="gr-grid">
-      <div v-for="g in groups" :key="g.key" class="gr-item">
+    <div class="list-card-grid">
+      <div v-for="g in groups" :key="g.key" class="list-card-item">
         <input
           v-if="selected"
           type="checkbox"
-          class="gr-checkbox"
+          class="list-card-checkbox"
           :checked="selected.includes(g.id)"
           @change="toggle(g.id)"
         />
@@ -58,39 +58,5 @@ function toggle(id: number) {
 <style scoped>
 .gr-state { text-align: center; padding: 3rem; color: var(--color-text-muted); }
 .gr-state--error { color: var(--color-dtv-red); }
-
-.gr-select-row {
-  padding: 0.5rem 1.5rem;
-  border-bottom: 1px solid var(--color-surface-hover);
-}
-
-.gr-select-all {
-  background: none; border: none; cursor: pointer;
-  font-size: 0.85rem; font-weight: 600; color: var(--color-dtv-green); padding: 0;
-}
-.gr-select-all:hover { text-decoration: underline; }
-
-.gr-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 1.5rem;
-  padding: 0 1.5rem;
-}
-@media (width < 48em) { .gr-grid { grid-template-columns: 1fr; } }
-
-.gr-grid :deep(.group-card) { background: var(--color-dtv-sand); }
-
-.gr-item {
-  position: relative;
-}
-
-.gr-checkbox {
-  position: absolute;
-  top: 1rem;
-  right: 1.5rem;
-  z-index: 1;
-  width: 16px; height: 16px;
-  cursor: pointer;
-  accent-color: var(--color-dtv-green);
-}
+.list-card-grid :deep(.group-card) { background: var(--color-dtv-sand); }
 </style>

--- a/frontend/src/components/groups/GroupListResults.vue
+++ b/frontend/src/components/groups/GroupListResults.vue
@@ -2,26 +2,73 @@
   <LoadingSpinner v-if="loading" />
   <div v-else-if="error" class="gr-state gr-state--error">{{ error }}</div>
   <div v-else-if="!groups.length" class="gr-state">No groups found.</div>
-  <div v-else class="gr-grid">
-    <GroupCard v-for="g in groups" :key="g.key" :group="g" />
-  </div>
+  <template v-else>
+    <div v-if="selected" class="gr-select-row">
+      <button class="gr-select-all" @click="toggleSelectAll">
+        {{ allSelected ? 'Deselect all' : 'Select all' }}
+      </button>
+    </div>
+    <div class="gr-grid">
+      <div v-for="g in groups" :key="g.key" class="gr-item">
+        <input
+          v-if="selected"
+          type="checkbox"
+          class="gr-checkbox"
+          :checked="selected.includes(g.id)"
+          @change="toggle(g.id)"
+        />
+        <GroupCard :group="g" />
+      </div>
+    </div>
+  </template>
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
 import GroupCard from './GroupCard.vue'
 import type { GroupWithStats } from './GroupListFilter.vue'
 import LoadingSpinner from '../LoadingSpinner.vue'
 
-defineProps<{
+const props = defineProps<{
   groups: GroupWithStats[]
   loading?: boolean
   error?: string | null
+  selected?: number[]
 }>()
+
+const emit = defineEmits<{ 'update:selected': [ids: number[]] }>()
+
+const allSelected = computed(() =>
+  props.groups.length > 0 && props.groups.every(g => props.selected?.includes(g.id))
+)
+
+function toggleSelectAll() {
+  emit('update:selected', allSelected.value ? [] : props.groups.map(g => g.id))
+}
+
+function toggle(id: number) {
+  if (!props.selected) return
+  const next = props.selected.includes(id)
+    ? props.selected.filter(i => i !== id)
+    : [...props.selected, id]
+  emit('update:selected', next)
+}
 </script>
 
 <style scoped>
 .gr-state { text-align: center; padding: 3rem; color: var(--color-text-muted); }
 .gr-state--error { color: var(--color-dtv-red); }
+
+.gr-select-row {
+  padding: 0.5rem 1.5rem;
+  border-bottom: 1px solid var(--color-surface-hover);
+}
+
+.gr-select-all {
+  background: none; border: none; cursor: pointer;
+  font-size: 0.85rem; font-weight: 600; color: var(--color-dtv-green); padding: 0;
+}
+.gr-select-all:hover { text-decoration: underline; }
 
 .gr-grid {
   display: grid;
@@ -32,4 +79,18 @@ defineProps<{
 @media (width < 48em) { .gr-grid { grid-template-columns: 1fr; } }
 
 .gr-grid :deep(.group-card) { background: var(--color-dtv-sand); }
+
+.gr-item {
+  position: relative;
+}
+
+.gr-checkbox {
+  position: absolute;
+  top: 1rem;
+  right: 1.5rem;
+  z-index: 1;
+  width: 16px; height: 16px;
+  cursor: pointer;
+  accent-color: var(--color-dtv-green);
+}
 </style>

--- a/frontend/src/components/profiles/ProfileListActions.vue
+++ b/frontend/src/components/profiles/ProfileListActions.vue
@@ -4,21 +4,10 @@
       {{ selected.length }} / {{ filteredProfiles.length }} {{ filteredProfiles.length === 1 ? 'profile' : 'profiles' }}
     </span>
     <div class="list-actions-buttons">
-      <AppButton
-        label="Add Records"
-        icon="add"
-        mode="icon-responsive"
-        :disabled="individualSelected.length === 0"
-        @click="emit('add-records')"
-      />
-      <AppButton
-        label="Download CSV"
-        icon="download"
-        mode="icon-responsive"
-        :disabled="selected.length === 0"
-        @click="onDownload"
-      />
+      <AppButton label="Add Records" icon="add" mode="icon-responsive" :disabled="individualSelected.length === 0" @click="emit('add-records')" />
+      <AppButton label="Download CSV" icon="download" mode="icon-only" :disabled="selectedInFiltered.length === 0" @click="onDownload" />
       <AppButton label="Share" icon="share" mode="icon-only" @click="onShare" />
+      <AppButton label="Add profile" icon="add" mode="icon-only" @click="emit('add-profile')" />
     </div>
   </div>
 </template>
@@ -39,15 +28,13 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   'add-records': []
+  'add-profile': []
   'update:selected': [ids: number[]]
 }>()
 
-const individualSelected = computed(() =>
-  props.selected.filter(id => {
-    const p = props.filteredProfiles.find(x => x.id === id)
-    return p && !p.isGroup
-  })
-)
+const selectedInFiltered = computed(() => props.filteredProfiles.filter(p => props.selected.includes(p.id)))
+
+const individualSelected = computed(() => selectedInFiltered.value.filter(p => !p.isGroup))
 
 function hoursFor(p: ProfileResponse): number {
   return props.fy === 'all' ? p.hoursAll : p.hoursThisFY
@@ -58,7 +45,7 @@ function sessionsFor(p: ProfileResponse): number {
 }
 
 function onDownload() {
-  const source = props.filteredProfiles.filter(p => props.selected.includes(p.id))
+  const source = selectedInFiltered.value
   const today = new Date().toISOString().slice(0, 10)
   downloadCsv(`${today} Profiles.csv`,
     ['Name', 'Email', 'Sessions', 'Hours'],

--- a/frontend/src/components/profiles/ProfileListActions.vue
+++ b/frontend/src/components/profiles/ProfileListActions.vue
@@ -16,8 +16,9 @@
         icon="download"
         mode="icon-responsive"
         :disabled="selected.length === 0"
-        @click="downloadCsv"
+        @click="onDownload"
       />
+      <AppButton label="Share" icon="share" mode="icon-only" @click="onShare" />
     </div>
   </div>
 </template>
@@ -26,6 +27,8 @@
 import { computed } from 'vue'
 import AppButton from '../AppButton.vue'
 import type { ProfileResponse } from '../../../../types/api-responses'
+import { downloadCsv } from '../../utils/listCsv'
+import { shareCurrentUrl } from '../../utils/shareUrl'
 
 const props = defineProps<{
   filteredProfiles: ProfileResponse[]
@@ -39,7 +42,6 @@ const emit = defineEmits<{
   'update:selected': [ids: number[]]
 }>()
 
-// Only individual profiles (not groups) are eligible for bulk records
 const individualSelected = computed(() =>
   props.selected.filter(id => {
     const p = props.filteredProfiles.find(x => x.id === id)
@@ -55,30 +57,17 @@ function sessionsFor(p: ProfileResponse): number {
   return props.fy === 'all' ? p.sessionsAll : p.sessionsThisFY
 }
 
-function downloadCsv() {
+function onDownload() {
   const source = props.filteredProfiles.filter(p => props.selected.includes(p.id))
-
-  const headers = ['Name', 'Email', 'Sessions', 'Hours']
-  const rows = source.map(p => [
-    p.name ?? '',
-    p.email ?? '',
-    sessionsFor(p),
-    Math.round(hoursFor(p) * 10) / 10,
-  ])
-
-  const csv = [headers, ...rows]
-    .map(row => row.map(cell => {
-      const str = String(cell)
-      return /[,"\n]/.test(str) ? `"${str.replace(/"/g, '""')}"` : str
-    }).join(','))
-    .join('\n')
-
   const today = new Date().toISOString().slice(0, 10)
-  const a = document.createElement('a')
-  a.href = URL.createObjectURL(new Blob(['\uFEFF' + csv], { type: 'text/csv;charset=utf-8' }))
-  a.download = `${today} Profiles.csv`
-  a.click()
-  URL.revokeObjectURL(a.href)
+  downloadCsv(`${today} Profiles.csv`,
+    ['Name', 'Email', 'Sessions', 'Hours'],
+    source.map(p => [p.name ?? '', p.email ?? '', sessionsFor(p), Math.round(hoursFor(p) * 10) / 10])
+  )
+}
+
+function onShare() {
+  shareCurrentUrl()
 }
 </script>
 

--- a/frontend/src/components/profiles/ProfileListActions.vue
+++ b/frontend/src/components/profiles/ProfileListActions.vue
@@ -1,9 +1,9 @@
 <template>
-  <div v-if="canBulkEdit" class="pla-wrap">
-    <span class="pla-stats">
+  <div v-if="canBulkEdit" class="list-actions">
+    <span class="list-actions-stats">
       {{ selected.length }} / {{ filteredProfiles.length }} {{ filteredProfiles.length === 1 ? 'profile' : 'profiles' }}
     </span>
-    <div class="pla-buttons">
+    <div class="list-actions-buttons">
       <AppButton
         label="Add Records"
         icon="add"
@@ -70,18 +70,3 @@ function onShare() {
   shareCurrentUrl()
 }
 </script>
-
-<style scoped>
-.pla-wrap {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  background: var(--color-dtv-sand);
-  padding: 0.75rem 1.5rem;
-  margin-bottom: 1.5rem;
-}
-
-.pla-stats { flex: 1; font-size: 0.85rem; color: var(--color-text-secondary); }
-.pla-buttons { display: flex; gap: 0.5rem; margin-left: auto; }
-</style>

--- a/frontend/src/components/profiles/ProfileListFilter.vue
+++ b/frontend/src/components/profiles/ProfileListFilter.vue
@@ -70,7 +70,7 @@ const emit = defineEmits<{
 const route = useRoute()
 const router = useRouter()
 
-const fy          = ref((route.query.fy as string)           || 'rolling')
+const fy          = ref((route.query.fy as string)           || 'future')
 const group       = ref((route.query.group as string)        || '')
 const search      = ref((route.query.search as string)       || '')
 const sort        = ref((route.query.sort as string)         || 'az')

--- a/frontend/src/components/profiles/ProfileListFilter.vue
+++ b/frontend/src/components/profiles/ProfileListFilter.vue
@@ -5,16 +5,16 @@
       <input
         v-model="search"
         type="text"
-        class="plf-search"
+        class="list-filter-search"
         placeholder="Search volunteers…"
         autocomplete="off"
       />
       <FyFilter v-model="fy" />
-      <select v-model="group" class="plf-select">
+      <select v-model="group" class="list-filter-select">
         <option value="">All groups</option>
         <option v-for="g in groups" :key="g.key" :value="g.key">{{ g.displayName ?? g.key }}</option>
       </select>
-      <select v-model="sort" class="plf-select">
+      <select v-model="sort" class="list-filter-select">
         <option value="az">A–Z</option>
         <option value="hours">Hours</option>
       </select>
@@ -22,13 +22,13 @@
 
     <!-- Row 2: advanced filters (always visible) -->
     <div class="plf-row plf-row--advanced">
-      <select v-model="type" class="plf-select">
+      <select v-model="type" class="list-filter-select">
         <option value="">All profiles</option>
         <option value="individuals">Individuals</option>
         <option value="groups">Groups</option>
         <option value="users">Users</option>
       </select>
-      <select v-model="hoursFilter" class="plf-select">
+      <select v-model="hoursFilter" class="list-filter-select">
         <option value="">All hours</option>
         <option value="0">0h</option>
         <option value="lt15">&lt;15h</option>
@@ -36,11 +36,11 @@
         <option value="15to30">15–30h</option>
         <option value="30plus">30h+</option>
       </select>
-      <select v-model="recordType" class="plf-select">
+      <select v-model="recordType" class="list-filter-select">
         <option value="">All record types</option>
         <option v-for="t in recordOptions.types" :key="t" :value="t">{{ t }}</option>
       </select>
-      <select v-model="recordStatus" class="plf-select" :disabled="!recordType">
+      <select v-model="recordStatus" class="list-filter-select" :disabled="!recordType">
         <option value="">All statuses</option>
         <option value="none">No record</option>
         <option v-for="s in recordOptions.statuses" :key="s" :value="s">{{ s }}</option>
@@ -184,28 +184,4 @@ watch([fy, group, search, sort, type, hoursFilter, recordType, recordStatus], ([
   flex-wrap: wrap;
   align-items: stretch;
 }
-
-.plf-search {
-  flex: 2 1 180px;
-  padding: 0.5rem 0.75rem;
-  border: 2px solid var(--color-border);
-  font-size: 0.95rem;
-  font-family: inherit;
-  color: var(--color-text);
-  background: var(--color-white);
-  box-sizing: border-box;
-}
-.plf-search:focus { outline: none; border-color: var(--color-dtv-green); }
-
-.plf-select {
-  flex: 1 1 130px;
-  padding: 0.45rem 0.6rem;
-  border: 1px solid var(--color-border);
-  font-size: 0.85rem;
-  font-family: inherit;
-  color: var(--color-text);
-  background: var(--color-white);
-  cursor: pointer;
-}
-.plf-select:disabled { opacity: 0.5; cursor: default; }
 </style>

--- a/frontend/src/components/profiles/ProfileListResults.vue
+++ b/frontend/src/components/profiles/ProfileListResults.vue
@@ -4,8 +4,8 @@
     <div v-else-if="error" class="plr-state plr-state--error">{{ error }}</div>
     <div v-else-if="!profiles.length" class="plr-empty">No profiles found.</div>
     <template v-else>
-      <div v-if="canSelect && selected" class="plr-select-row">
-        <button class="plr-select-all" @click="toggleSelectAll">
+      <div v-if="canSelect && selected" class="list-select-row">
+        <button class="list-select-all" @click="toggleSelectAll">
           {{ allSelected ? 'Deselect all' : 'Select all' }}
         </button>
       </div>
@@ -81,16 +81,6 @@ function toggle(id: number) {
 
 .plr-empty { padding: 1.5rem; color: var(--color-text-muted); font-size: 0.9rem; }
 
-.plr-select-row {
-  padding: 0.5rem 1.5rem;
-  border-bottom: 1px solid var(--color-surface-hover);
-}
-
-.plr-select-all {
-  background: none; border: none; cursor: pointer;
-  font-size: 0.85rem; font-weight: 600; color: var(--color-dtv-green); padding: 0;
-}
-.plr-select-all:hover { text-decoration: underline; }
 
 .plr-list { display: flex; flex-direction: column; }
 

--- a/frontend/src/components/sessions/SessionDetailActions.vue
+++ b/frontend/src/components/sessions/SessionDetailActions.vue
@@ -46,6 +46,7 @@ import SessionEditModal from '../../pages/modals/SessionEditModal.vue'
 import SessionEmailSendModal from '../../pages/modals/SessionEmailSendModal.vue'
 import EntryUploadPickerModal from '../../pages/modals/EntryUploadPickerModal.vue'
 import { groupPath } from '../../router/index'
+import { shareCurrentUrl } from '../../utils/shareUrl'
 
 const props = defineProps<{
   session: SessionDetailResponse
@@ -83,12 +84,7 @@ const adults = computed<EmailAdult[]>(() =>
 )
 
 function onShare() {
-  const url = window.location.href
-  if (navigator.share) {
-    navigator.share({ url }).catch(() => {})
-  } else if (navigator.clipboard?.writeText) {
-    navigator.clipboard.writeText(url).catch(() => {})
-  }
+  shareCurrentUrl()
 }
 
 function onUpload() {

--- a/frontend/src/components/sessions/SessionListActions.vue
+++ b/frontend/src/components/sessions/SessionListActions.vue
@@ -6,7 +6,8 @@
 
     <div class="sa-buttons">
       <AppButton label="Add Tags" icon="add" mode="icon-responsive" :disabled="!selected.length" @click="emit('add-tags')" />
-      <AppButton label="Download CSV" icon="download" mode="icon-responsive" :disabled="!selected.length" @click="downloadCsv" />
+      <AppButton label="Download CSV" icon="download" mode="icon-responsive" :disabled="!selected.length" @click="onDownload" />
+      <AppButton label="Share" icon="share" mode="icon-only" @click="onShare" />
     </div>
   </div>
 </template>
@@ -15,6 +16,8 @@
 import { computed } from 'vue'
 import AppButton from '../AppButton.vue'
 import type { Session } from '../../types/session'
+import { downloadCsv } from '../../utils/listCsv'
+import { shareCurrentUrl } from '../../utils/shareUrl'
 
 const props = defineProps<{
   sessions: Session[]
@@ -35,31 +38,26 @@ const selectedHours = computed(() =>
 const totalHours = computed(() =>
   Math.round(props.sessions.reduce((sum, s) => sum + (s.stats.hours || 0), 0) * 10) / 10)
 
-function downloadCsv() {
-  const headers = ['Date', 'Group', 'Name', 'Registrations', 'Hours', 'New', 'Children', 'Regulars', 'Financial Year']
-  const rows = selectedSessions.value.map(s => [
-    s.date?.substring(0, 10) ?? '',
-    s.groupName ?? '',
-    s.displayName ?? '',
-    s.stats.count,
-    s.stats.hours,
-    s.stats.new ?? 0,
-    s.stats.child ?? 0,
-    s.stats.regular ?? 0,
-    s.financialYear ?? '',
-  ])
-  const csv = [headers, ...rows]
-    .map(row => row.map(cell => {
-      const str = String(cell)
-      return /[,"\n]/.test(str) ? `"${str.replace(/"/g, '""')}"` : str
-    }).join(','))
-    .join('\n')
+function onDownload() {
+  downloadCsv('sessions.csv',
+    ['Date', 'Group', 'Name', 'Registrations', 'Hours', 'New', 'Children', 'Regulars', 'Financial Year'],
+    selectedSessions.value.map(s => [
+      s.date?.substring(0, 10) ?? '',
+      s.groupName ?? '',
+      s.displayName ?? '',
+      s.stats.count,
+      s.stats.hours,
+      s.stats.new ?? 0,
+      s.stats.child ?? 0,
+      s.stats.regular ?? 0,
+      s.financialYear ?? '',
+    ]),
+    false
+  )
+}
 
-  const a = document.createElement('a')
-  a.href = URL.createObjectURL(new Blob([csv], { type: 'text/csv' }))
-  a.download = 'sessions.csv'
-  a.click()
-  URL.revokeObjectURL(a.href)
+function onShare() {
+  shareCurrentUrl()
 }
 </script>
 

--- a/frontend/src/components/sessions/SessionListActions.vue
+++ b/frontend/src/components/sessions/SessionListActions.vue
@@ -1,10 +1,10 @@
 <template>
-  <div v-if="canBulkTag" class="sa-wrap">
-    <span class="sa-stats">
+  <div v-if="canBulkTag" class="list-actions">
+    <span class="list-actions-stats">
       {{ selected.length }} / {{ sessions.length }} sessions &nbsp;&nbsp; {{ selectedHours }} / {{ totalHours }} hours
     </span>
 
-    <div class="sa-buttons">
+    <div class="list-actions-buttons">
       <AppButton label="Add Tags" icon="add" mode="icon-responsive" :disabled="!selected.length" @click="emit('add-tags')" />
       <AppButton label="Download CSV" icon="download" mode="icon-responsive" :disabled="!selected.length" @click="onDownload" />
       <AppButton label="Share" icon="share" mode="icon-only" @click="onShare" />
@@ -60,19 +60,3 @@ function onShare() {
   shareCurrentUrl()
 }
 </script>
-
-<style scoped>
-.sa-wrap {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  background: var(--color-dtv-sand);
-  padding: 0.75rem 1.5rem;
-  margin-bottom: 1.5rem;
-}
-
-.sa-stats { flex: 1; font-size: 0.85rem; color: var(--color-text-secondary); }
-
-.sa-buttons { display: flex; gap: 0.5rem; margin-left: auto; }
-</style>

--- a/frontend/src/components/sessions/SessionListActions.vue
+++ b/frontend/src/components/sessions/SessionListActions.vue
@@ -5,9 +5,10 @@
     </span>
 
     <div class="list-actions-buttons">
-      <AppButton label="Add Tags" icon="add" mode="icon-responsive" :disabled="!selected.length" @click="emit('add-tags')" />
-      <AppButton label="Download CSV" icon="download" mode="icon-responsive" :disabled="!selected.length" @click="onDownload" />
+      <AppButton label="Add Tags" icon="add" mode="icon-responsive" :disabled="!selectedSessions.length" @click="emit('add-tags')" />
+      <AppButton label="Download CSV" icon="download" mode="icon-only" :disabled="!selectedSessions.length" @click="onDownload" />
       <AppButton label="Share" icon="share" mode="icon-only" @click="onShare" />
+      <AppButton label="Add session" icon="add" mode="icon-only" @click="emit('add-session')" />
     </div>
   </div>
 </template>
@@ -28,6 +29,7 @@ const props = defineProps<{
 const emit = defineEmits<{
   'update:selected': [ids: number[]]
   'add-tags': []
+  'add-session': []
 }>()
 
 const selectedSessions = computed(() => props.sessions.filter(s => props.selected.includes(s.id)))

--- a/frontend/src/components/sessions/SessionListFilter.vue
+++ b/frontend/src/components/sessions/SessionListFilter.vue
@@ -1,14 +1,14 @@
 <template>
-  <div class="sf-wrap">
+  <div class="list-filter sf-wrap">
     <input
       v-model="search"
       type="text"
-      class="sf-search"
+      class="list-filter-search"
       placeholder="Search sessions…"
       autocomplete="off"
     />
     <FyFilter v-model="fy" />
-    <select v-model="groupKey" class="sf-select">
+    <select v-model="groupKey" class="list-filter-select">
       <option value="">All groups</option>
       <option v-for="g in groupOptions" :key="g.key" :value="g.key">{{ g.name }}</option>
     </select>
@@ -116,39 +116,6 @@ watch([fy, search, groupKey, tagLabel], ([newFy, newSearch, newGroup, newTag]) =
 </script>
 
 <style scoped>
-.sf-wrap {
-  background: var(--color-dtv-sand);
-  padding: 1rem 1.5rem;
-  margin-bottom: 1.5rem;
-  display: flex;
-  gap: 0.5rem;
-  flex-wrap: wrap;
-  align-items: stretch;
-}
-
-.sf-search {
-  flex: 2 1 180px;
-  padding: 0.5rem 0.75rem;
-  border: 2px solid var(--color-border);
-  font-size: 0.95rem;
-  font-family: inherit;
-  color: var(--color-text);
-  background: var(--color-white);
-  box-sizing: border-box;
-}
-.sf-search:focus { outline: none; border-color: var(--color-dtv-green); }
-
-.sf-select {
-  flex: 1 1 140px;
-  padding: 0.45rem 0.6rem;
-  border: 1px solid var(--color-border);
-  font-size: 0.85rem;
-  font-family: inherit;
-  color: var(--color-text);
-  background: var(--color-white);
-  cursor: pointer;
-}
-
 .sf-wrap :deep(.tp-wrap) { flex: 1 1 140px; display: flex; flex-direction: column; }
 .sf-wrap :deep(.tp-btn) { flex: 1; width: 100%; justify-content: space-between; }
 </style>

--- a/frontend/src/components/sessions/SessionListResults.vue
+++ b/frontend/src/components/sessions/SessionListResults.vue
@@ -4,18 +4,18 @@
     <div v-else-if="!sessions.length" class="sr-empty">No sessions found.</div>
     <template v-else>
       <!-- Select all — admin only -->
-      <div v-if="profile.isAdmin && selected" class="sr-select-row">
-        <button class="sr-select-all" @click="toggleSelectAll">
+      <div v-if="profile.isAdmin && selected" class="list-select-row">
+        <button class="list-select-all" @click="toggleSelectAll">
           {{ allSelected ? 'Deselect all' : 'Select all' }}
         </button>
       </div>
 
-      <div class="sr-grid">
-        <div v-for="s in sessions" :key="s.id" class="sr-item">
+      <div class="list-card-grid">
+        <div v-for="s in sessions" :key="s.id" class="list-card-item">
           <input
             v-if="profile.isAdmin && selected"
             type="checkbox"
-            class="sr-checkbox"
+            class="list-card-checkbox"
             :checked="selected.includes(s.id)"
             @change="toggle(s.id)"
           />
@@ -62,41 +62,6 @@ function toggle(id: number) {
 
 <style scoped>
 .sr-section { padding: 0; }
-
 .sr-empty { padding: 1.5rem 0; color: var(--color-text-muted); font-size: 0.9rem; }
-
-.sr-select-row {
-  padding: 0.5rem 1.5rem;
-  border-bottom: 1px solid var(--color-surface-hover);
-}
-
-.sr-select-all {
-  background: none; border: none; cursor: pointer;
-  font-size: 0.85rem; font-weight: 600; color: var(--color-dtv-green); padding: 0;
-}
-.sr-select-all:hover { text-decoration: underline; }
-
-.sr-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 1.5rem;
-  padding: 1.5rem;
-}
-@media (width < 48em) { .sr-grid { grid-template-columns: 1fr; } }
-
-.sr-grid :deep(.session-card) { background: var(--color-dtv-sand); }
-
-.sr-item {
-  position: relative;
-}
-
-.sr-checkbox {
-  position: absolute;
-  top: 1rem;
-  right: 1.5rem;
-  z-index: 1;
-  width: 16px; height: 16px;
-  cursor: pointer;
-  accent-color: var(--color-dtv-green);
-}
+.list-card-grid :deep(.session-card) { background: var(--color-dtv-sand); }
 </style>

--- a/frontend/src/pages/EntriesPage.vue
+++ b/frontend/src/pages/EntriesPage.vue
@@ -59,11 +59,11 @@ const editingEntry = ref<EntryItem | null>(null)
 const sessionAdults = ref<{ id: number; name: string }[]>([])
 const editWorking = ref(false)
 const editError = ref<string | undefined>()
-const currentFilter = ref<EntryFilterParams>({ q: '', accompanyingAdult: '', cancelled: 'false' })
+const currentFilter = ref<EntryFilterParams>({ q: '', fy: 'future', accompanyingAdult: '', cancelled: 'false' })
 
 function onFiltered(params: EntryFilterParams) {
   currentFilter.value = params
-  store.fetch({ q: params.q, accompanyingAdult: params.accompanyingAdult, cancelled: params.cancelled })
+  store.fetch({ q: params.q, fy: params.fy, accompanyingAdult: params.accompanyingAdult, cancelled: params.cancelled })
 }
 
 function matchesFilter(entry: EntryListItemResponse, filter: EntryFilterParams): boolean {

--- a/frontend/src/pages/GroupListPage.vue
+++ b/frontend/src/pages/GroupListPage.vue
@@ -6,7 +6,6 @@
       <GroupListFilter
         :groups="groupsStore.groups"
         :sessions="sessionsStore.sessions"
-        :can-add-group="profile.isAdmin"
         @filtered="filtered = $event"
       />
       <GroupListActions
@@ -18,7 +17,7 @@
       />
       <GroupListResults
         :groups="filtered"
-        :loading="groupsStore.loading"
+        :loading="groupsStore.loading || sessionsStore.loading"
         :error="groupsStore.error"
         :selected="profile.isAdmin ? selected : undefined"
         @update:selected="selected = $event"

--- a/frontend/src/pages/GroupListPage.vue
+++ b/frontend/src/pages/GroupListPage.vue
@@ -9,10 +9,19 @@
         :can-add-group="profile.isAdmin"
         @filtered="filtered = $event"
       />
+      <GroupListActions
+        v-if="profile.isAdmin"
+        :groups="filtered"
+        :selected="selected"
+        :can-bulk-tag="profile.isAdmin"
+        @update:selected="selected = $event"
+      />
       <GroupListResults
         :groups="filtered"
         :loading="groupsStore.loading"
         :error="groupsStore.error"
+        :selected="profile.isAdmin ? selected : undefined"
+        @update:selected="selected = $event"
       />
     </div>
   </DefaultLayout>
@@ -26,6 +35,7 @@ import PageHeader from '../components/PageHeader.vue'
 
 usePageTitle('Groups')
 import GroupListFilter from '../components/groups/GroupListFilter.vue'
+import GroupListActions from '../components/groups/GroupListActions.vue'
 import GroupListResults from '../components/groups/GroupListResults.vue'
 import { useGroupListStore } from '../stores/groupList'
 import { useSessionListStore } from '../stores/sessionList'
@@ -36,6 +46,7 @@ const groupsStore = useGroupListStore()
 const sessionsStore = useSessionListStore()
 const profile = useViewer()
 const filtered = ref<GroupWithStats[]>([])
+const selected = ref<number[]>([])
 
 onMounted(() => {
   groupsStore.fetch()

--- a/frontend/src/pages/GroupListPage.vue
+++ b/frontend/src/pages/GroupListPage.vue
@@ -13,6 +13,7 @@
         :groups="filtered"
         :selected="selected"
         :can-bulk-tag="profile.isAdmin"
+        @add-group="showAddGroup = true"
         @update:selected="selected = $event"
       />
       <GroupListResults
@@ -23,29 +24,70 @@
         @update:selected="selected = $event"
       />
     </div>
+
+    <GroupAddModal
+      v-if="showAddGroup"
+      :working="addGroupWorking"
+      :error="addGroupError"
+      @close="showAddGroup = false; addGroupError = ''"
+      @add="onAddGroup"
+    />
   </DefaultLayout>
 </template>
 
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
 import DefaultLayout from '../layouts/DefaultLayout.vue'
 import { usePageTitle } from '../composables/usePageTitle'
 import PageHeader from '../components/PageHeader.vue'
-
-usePageTitle('Groups')
 import GroupListFilter from '../components/groups/GroupListFilter.vue'
 import GroupListActions from '../components/groups/GroupListActions.vue'
 import GroupListResults from '../components/groups/GroupListResults.vue'
+import GroupAddModal from './modals/GroupAddModal.vue'
+import type { AddGroupPayload } from './modals/GroupAddModal.vue'
 import { useGroupListStore } from '../stores/groupList'
 import { useSessionListStore } from '../stores/sessionList'
 import { useViewer } from '../composables/useViewer'
+import { groupPath } from '../router'
 import type { GroupWithStats } from '../components/groups/GroupListFilter.vue'
+
+usePageTitle('Groups')
 
 const groupsStore = useGroupListStore()
 const sessionsStore = useSessionListStore()
 const profile = useViewer()
+const router = useRouter()
 const filtered = ref<GroupWithStats[]>([])
 const selected = ref<number[]>([])
+const showAddGroup = ref(false)
+const addGroupWorking = ref(false)
+const addGroupError = ref('')
+
+async function onAddGroup(data: AddGroupPayload) {
+  addGroupWorking.value = true
+  addGroupError.value = ''
+  try {
+    const res = await fetch('/api/groups', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+    if (!res.ok) {
+      const json = await res.json().catch(() => ({}))
+      throw new Error(json.error || 'Failed to create group')
+    }
+    const json = await res.json()
+    showAddGroup.value = false
+    await groupsStore.fetch()
+    if (json.data?.key) router.push(groupPath(json.data.key))
+  } catch (e) {
+    addGroupError.value = e instanceof Error ? e.message : 'An error occurred'
+    console.error('[GroupListPage] onAddGroup', e)
+  } finally {
+    addGroupWorking.value = false
+  }
+}
 
 onMounted(() => {
   groupsStore.fetch()

--- a/frontend/src/pages/ProfileListPage.vue
+++ b/frontend/src/pages/ProfileListPage.vue
@@ -15,6 +15,7 @@
       :can-bulk-edit="profile.isAdmin"
       :fy="fy"
       @add-records="showBulkModal = true"
+      @add-profile="showAddProfile = true"
       @update:selected="selected = $event"
     />
     <ProfileListResults
@@ -25,6 +26,14 @@
       :can-select="profile.isAdmin"
       :fy="fy"
       @update:selected="selected = $event"
+    />
+
+    <ProfileAddModal
+      v-if="showAddProfile"
+      :working="addProfileWorking"
+      :error="addProfileError"
+      @close="showAddProfile = false"
+      @add="onAddProfile"
     />
 
     <ProfileBulkRecordsModal
@@ -48,15 +57,20 @@ import ProfileListActions from '../components/profiles/ProfileListActions.vue'
 import ProfileListResults from '../components/profiles/ProfileListResults.vue'
 import ProfileBulkRecordsModal from './modals/ProfileBulkRecordsModal.vue'
 import type { BulkRecordPayload } from './modals/ProfileBulkRecordsModal.vue'
+import ProfileAddModal from './modals/ProfileAddModal.vue'
+import type { AddProfilePayload } from './modals/ProfileAddModal.vue'
 import { usePageTitle } from '../composables/usePageTitle'
 import { useViewer } from '../composables/useViewer'
 import { useProfileListStore } from '../stores/profileList'
 import { useGroupListStore } from '../stores/groupList'
+import { useRouter } from 'vue-router'
+import { profilePath } from '../router'
 import type { ProfileResponse } from '../../../types/api-responses'
 
 usePageTitle('Profiles')
 
 const profile = useViewer()
+const router = useRouter()
 const store = useProfileListStore()
 const groupsStore = useGroupListStore()
 
@@ -67,6 +81,9 @@ const selected = ref<number[]>([])
 const showBulkModal = ref(false)
 const bulkWorking = ref(false)
 const bulkError = ref('')
+const showAddProfile = ref(false)
+const addProfileWorking = ref(false)
+const addProfileError = ref('')
 const recordOptions = ref<{ types: string[]; statuses: string[] }>({ types: [], statuses: [] })
 
 // Individual (non-group) profile IDs from current selection
@@ -105,6 +122,31 @@ async function onBulkSave(payload: BulkRecordPayload) {
     console.error('[ProfileListPage] onBulkSave', e)
   } finally {
     bulkWorking.value = false
+  }
+}
+
+async function onAddProfile(data: AddProfilePayload) {
+  addProfileWorking.value = true
+  addProfileError.value = ''
+  try {
+    const res = await fetch('/api/profiles', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+    if (!res.ok) {
+      const json = await res.json().catch(() => ({}))
+      throw new Error(json.error || `Failed to create profile (${res.status})`)
+    }
+    const json = await res.json()
+    showAddProfile.value = false
+    await store.fetch(fy.value, group.value)
+    if (json.data?.slug) router.push(profilePath(json.data.slug))
+  } catch (e) {
+    addProfileError.value = e instanceof Error ? e.message : 'An error occurred'
+    console.error('[ProfileListPage] onAddProfile', e)
+  } finally {
+    addProfileWorking.value = false
   }
 }
 

--- a/frontend/src/pages/ProfileListPage.vue
+++ b/frontend/src/pages/ProfileListPage.vue
@@ -74,7 +74,7 @@ const router = useRouter()
 const store = useProfileListStore()
 const groupsStore = useGroupListStore()
 
-const fy = ref('rolling')
+const fy = ref('future')
 const group = ref('')
 const filtered = ref<ProfileResponse[]>([])
 const selected = ref<number[]>([])

--- a/frontend/src/pages/SessionListPage.vue
+++ b/frontend/src/pages/SessionListPage.vue
@@ -46,6 +46,7 @@ import SessionAddTagsModal from './modals/SessionAddTagsModal.vue'
 import GroupAddSessionModal from './modals/GroupAddSessionModal.vue'
 import type { AddSessionPayload } from './modals/GroupAddSessionModal.vue'
 import { useSessionListStore } from '../stores/sessionList'
+import { useGroupListStore } from '../stores/groupList'
 import { useViewer } from '../composables/useViewer'
 import { useRouter } from 'vue-router'
 import { sessionPath } from '../router'
@@ -54,6 +55,7 @@ import type { Session } from '../types/session'
 usePageTitle('Sessions')
 
 const store = useSessionListStore()
+const groupsStore = useGroupListStore()
 const profile = useViewer()
 const router = useRouter()
 const filtered = ref<Session[]>([])
@@ -66,14 +68,13 @@ const addSessionWorking = ref(false)
 const addSessionError = ref('')
 
 store.fetch()
+groupsStore.fetch()
 
-const groupOptions = computed(() => {
-  const seen = new Set<number>()
-  return store.sessions
-    .filter(s => s.groupId && !seen.has(s.groupId!) && seen.add(s.groupId!))
-    .map(s => ({ id: s.groupId!, key: s.groupKey ?? '', displayName: s.groupName }))
+const groupOptions = computed(() =>
+  groupsStore.groups
+    .map(g => ({ id: g.id, key: g.key, displayName: g.displayName }))
     .sort((a, b) => (a.displayName ?? a.key).localeCompare(b.displayName ?? b.key))
-})
+)
 
 async function onApplyTag(label: string, termGuid: string) {
   tagWorking.value = true
@@ -100,24 +101,27 @@ async function onApplyTag(label: string, termGuid: string) {
 async function onAddSession(data: AddSessionPayload) {
   addSessionWorking.value = true
   addSessionError.value = ''
-  const res = await fetch('/api/sessions', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(data),
-  })
-  if (!res.ok) {
-    const json = await res.json().catch(() => ({}))
-    addSessionError.value = json.error || 'Failed to create session — please try again'
+  try {
+    const res = await fetch('/api/sessions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+    if (!res.ok) {
+      const json = await res.json().catch(() => ({}))
+      throw new Error(json.error || 'Failed to create session — please try again')
+    }
+    const json = await res.json()
+    showAddSession.value = false
+    await store.fetch()
+    if (json.data?.groupKey && json.data?.date) {
+      router.push(sessionPath(json.data.groupKey, json.data.date))
+    }
+  } catch (e) {
+    addSessionError.value = e instanceof Error ? e.message : 'An error occurred'
+    console.error('[SessionListPage] add-session failed', e)
+  } finally {
     addSessionWorking.value = false
-    console.error('[SessionListPage] add-session failed', res.status)
-    return
-  }
-  const json = await res.json()
-  showAddSession.value = false
-  addSessionWorking.value = false
-  await store.fetch()
-  if (json.data?.groupKey && json.data?.date) {
-    router.push(sessionPath(json.data.groupKey, json.data.date))
   }
 }
 </script>

--- a/frontend/src/pages/SessionListPage.vue
+++ b/frontend/src/pages/SessionListPage.vue
@@ -9,6 +9,7 @@
         :can-bulk-tag="profile.isAdmin"
         v-model:selected="selected"
         @add-tags="showTagModal = true"
+        @add-session="showAddSession = true"
       />
       <SessionListResults :sessions="filtered" :loading="store.loading" v-model:selected="selected" />
     </div>
@@ -21,11 +22,20 @@
       @close="showTagModal = false"
       @save="onApplyTag"
     />
+
+    <GroupAddSessionModal
+      v-if="showAddSession"
+      :groups="groupOptions"
+      :working="addSessionWorking"
+      :error="addSessionError"
+      @close="showAddSession = false"
+      @add="onAddSession"
+    />
   </DefaultLayout>
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import DefaultLayout from '../layouts/DefaultLayout.vue'
 import { usePageTitle } from '../composables/usePageTitle'
 import PageHeader from '../components/PageHeader.vue'
@@ -33,21 +43,37 @@ import SessionListFilter from '../components/sessions/SessionListFilter.vue'
 import SessionListActions from '../components/sessions/SessionListActions.vue'
 import SessionListResults from '../components/sessions/SessionListResults.vue'
 import SessionAddTagsModal from './modals/SessionAddTagsModal.vue'
+import GroupAddSessionModal from './modals/GroupAddSessionModal.vue'
+import type { AddSessionPayload } from './modals/GroupAddSessionModal.vue'
 import { useSessionListStore } from '../stores/sessionList'
 import { useViewer } from '../composables/useViewer'
+import { useRouter } from 'vue-router'
+import { sessionPath } from '../router'
 import type { Session } from '../types/session'
 
 usePageTitle('Sessions')
 
 const store = useSessionListStore()
 const profile = useViewer()
+const router = useRouter()
 const filtered = ref<Session[]>([])
 const selected = ref<number[]>([])
 const showTagModal = ref(false)
 const tagWorking = ref(false)
 const tagError = ref('')
+const showAddSession = ref(false)
+const addSessionWorking = ref(false)
+const addSessionError = ref('')
 
 store.fetch()
+
+const groupOptions = computed(() => {
+  const seen = new Set<number>()
+  return store.sessions
+    .filter(s => s.groupId && !seen.has(s.groupId!) && seen.add(s.groupId!))
+    .map(s => ({ id: s.groupId!, key: s.groupKey ?? '', displayName: s.groupName }))
+    .sort((a, b) => (a.displayName ?? a.key).localeCompare(b.displayName ?? b.key))
+})
 
 async function onApplyTag(label: string, termGuid: string) {
   tagWorking.value = true
@@ -69,5 +95,29 @@ async function onApplyTag(label: string, termGuid: string) {
   tagWorking.value = false
   tagError.value = ''
   selected.value = []
+}
+
+async function onAddSession(data: AddSessionPayload) {
+  addSessionWorking.value = true
+  addSessionError.value = ''
+  const res = await fetch('/api/sessions', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  })
+  if (!res.ok) {
+    const json = await res.json().catch(() => ({}))
+    addSessionError.value = json.error || 'Failed to create session — please try again'
+    addSessionWorking.value = false
+    console.error('[SessionListPage] add-session failed', res.status)
+    return
+  }
+  const json = await res.json()
+  showAddSession.value = false
+  addSessionWorking.value = false
+  await store.fetch()
+  if (json.data?.groupKey && json.data?.date) {
+    router.push(sessionPath(json.data.groupKey, json.data.date))
+  }
 }
 </script>

--- a/frontend/src/pages/modals/GroupAddModal.vue
+++ b/frontend/src/pages/modals/GroupAddModal.vue
@@ -1,0 +1,62 @@
+<template>
+  <ModalLayout
+    title="New Group"
+    action="Create"
+    :action-disabled="!form.key.trim()"
+    :working="working"
+    :error="error"
+    @close="emit('close')"
+    @action="emit('add', { key: form.key.trim(), name: form.name.trim() || undefined, description: form.description.trim() || undefined })"
+  >
+    <FormLayout :disabled="working">
+      <FormRow title="Key (short name, e.g. &quot;sat&quot;)" :full-width="true">
+        <input v-model="form.key" type="text" class="gam-input" placeholder="sat" />
+      </FormRow>
+      <FormRow title="Display Name (e.g. &quot;Saturday Dig&quot;)" :full-width="true">
+        <input v-model="form.name" type="text" class="gam-input" placeholder="Saturday Dig" />
+      </FormRow>
+      <FormRow title="Description (optional)" :full-width="true">
+        <textarea v-model="form.description" class="gam-input gam-textarea"></textarea>
+      </FormRow>
+    </FormLayout>
+  </ModalLayout>
+</template>
+
+<script setup lang="ts">
+import { reactive } from 'vue'
+import ModalLayout from '../../components/ModalLayout.vue'
+import FormLayout from '../../components/FormLayout.vue'
+import FormRow from '../../components/FormRow.vue'
+
+export type AddGroupPayload = {
+  key: string
+  name?: string
+  description?: string
+}
+
+const props = defineProps<{
+  working: boolean
+  error?: string
+}>()
+
+const emit = defineEmits<{
+  close: []
+  add: [payload: AddGroupPayload]
+}>()
+
+const form = reactive({ key: '', name: '', description: '' })
+</script>
+
+<style scoped>
+.gam-input {
+  width: 100%;
+  background: var(--color-dtv-light);
+  border: none;
+  color: var(--color-text);
+  padding: 0.3rem 0.5rem;
+  font-family: inherit;
+  font-size: 0.95rem;
+  box-sizing: border-box;
+}
+.gam-textarea { min-height: 60px; resize: vertical; }
+</style>

--- a/frontend/src/pages/modals/GroupAddSessionModal.vue
+++ b/frontend/src/pages/modals/GroupAddSessionModal.vue
@@ -2,26 +2,33 @@
   <ModalLayout
     title="Add Session"
     action="Create"
-    :action-disabled="!form.date"
+    :action-disabled="!form.date || !resolvedGroupId"
     :working="working"
     :error="error"
     @close="emit('close')"
     @action="add"
   >
     <FormLayout :disabled="working">
+      <FormRow v-if="groups" title="Group" :full-width="true">
+        <select v-model="form.groupId" class="gasm-input">
+          <option value="">Select a group…</option>
+          <option v-for="g in groups" :key="g.id" :value="g.id">{{ g.displayName || g.key }}</option>
+        </select>
+      </FormRow>
+
       <FormRow title="Date" :full-width="true">
         <input v-model="form.date" type="date" class="gasm-input" />
       </FormRow>
 
       <FormRow title="Display Name" :full-width="true">
-        <input v-model="form.name" class="gasm-input" :placeholder="group.displayName || group.key" />
+        <input v-model="form.name" class="gasm-input" :placeholder="group?.displayName || group?.key || ''" />
       </FormRow>
     </FormLayout>
   </ModalLayout>
 </template>
 
 <script setup lang="ts">
-import { reactive } from 'vue'
+import { reactive, computed } from 'vue'
 import type { GroupDetailResponse } from '../../../../types/api-responses'
 import ModalLayout from '../../components/ModalLayout.vue'
 import FormLayout from '../../components/FormLayout.vue'
@@ -33,8 +40,11 @@ export type AddSessionPayload = {
   name?: string
 }
 
+type GroupOption = { id: number; key: string; displayName?: string | null }
+
 const props = defineProps<{
-  group: GroupDetailResponse
+  group?: GroupDetailResponse
+  groups?: GroupOption[]
   working: boolean
   error?: string
 }>()
@@ -47,11 +57,17 @@ const emit = defineEmits<{
 const form = reactive({
   date: '',
   name: '',
+  groupId: '' as number | '',
 })
 
+const resolvedGroupId = computed(() =>
+  props.group ? props.group.id : (form.groupId || null)
+)
+
 function add() {
+  if (!resolvedGroupId.value) return
   emit('add', {
-    groupId: props.group.id,
+    groupId: resolvedGroupId.value,
     date: form.date,
     name: form.name || undefined,
   })

--- a/frontend/src/pages/modals/ProfileAddModal.vue
+++ b/frontend/src/pages/modals/ProfileAddModal.vue
@@ -1,0 +1,64 @@
+<template>
+  <ModalLayout
+    title="Add Profile"
+    action="Create"
+    :action-disabled="!form.name.trim()"
+    :working="working"
+    :error="error"
+    @close="emit('close')"
+    @action="add"
+  >
+    <FormLayout :disabled="working">
+      <FormRow title="Name" :full-width="true">
+        <input v-model="form.name" type="text" class="pam-input" placeholder="Full name" />
+      </FormRow>
+      <FormRow title="Email" :full-width="true">
+        <input v-model="form.email" type="email" class="pam-input" placeholder="email@example.com" />
+      </FormRow>
+    </FormLayout>
+  </ModalLayout>
+</template>
+
+<script setup lang="ts">
+import { reactive } from 'vue'
+import ModalLayout from '../../components/ModalLayout.vue'
+import FormLayout from '../../components/FormLayout.vue'
+import FormRow from '../../components/FormRow.vue'
+
+export type AddProfilePayload = {
+  name: string
+  email?: string
+}
+
+const props = defineProps<{
+  working: boolean
+  error?: string
+}>()
+
+const emit = defineEmits<{
+  close: []
+  add: [payload: AddProfilePayload]
+}>()
+
+const form = reactive({ name: '', email: '' })
+
+function add() {
+  emit('add', {
+    name: form.name.trim(),
+    email: form.email.trim() || undefined,
+  })
+}
+</script>
+
+<style scoped>
+.pam-input {
+  width: 100%;
+  background: var(--color-dtv-light);
+  border: none;
+  color: var(--color-text);
+  padding: 0.3rem 0.5rem;
+  font-family: inherit;
+  font-size: 0.95rem;
+  box-sizing: border-box;
+}
+</style>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -4,6 +4,7 @@ import { ensureAuth, user } from '../composables/useAuth'
 declare module 'vue-router' {
   interface RouteMeta {
     requiresTrusted?: boolean  // Admin / Check In / Read Only only
+    requiresAdmin?: boolean    // Admin only
     requiresAuth?: boolean     // Any authenticated user (self-service included)
   }
 }
@@ -47,7 +48,7 @@ export const router = createRouter({
     { path: '/privacy', component: PrivacyPage },
     { path: '/terms', component: TermsPage },
     { path: '/login', component: LoginPage },
-    { path: '/entries', component: EntriesPage, meta: { requiresTrusted: true } },
+    { path: '/entries', component: EntriesPage, meta: { requiresAdmin: true } },
     { path: '/admin', component: AdminPage },
     { path: '/not-found', component: () => import('../pages/NotFoundPage.vue') },
     { path: '/forbidden', component: () => import('../pages/ForbiddenPage.vue') },
@@ -101,9 +102,10 @@ export const router = createRouter({
 })
 
 router.beforeEach(async (to) => {
-  if (to.meta.requiresTrusted || to.meta.requiresAuth) {
+  if (to.meta.requiresTrusted || to.meta.requiresAdmin || to.meta.requiresAuth) {
     await ensureAuth()
     if (!user.value) return '/not-found'
+    if (to.meta.requiresAdmin && user.value.role !== 'admin') return '/forbidden'
     if (to.meta.requiresTrusted && user.value.role === 'selfservice') return '/forbidden'
     return
   }

--- a/frontend/src/stores/entryList.ts
+++ b/frontend/src/stores/entryList.ts
@@ -7,7 +7,7 @@ export const useEntryListStore = defineStore('entryList', () => {
   const loading = ref(false)
   const error = ref<string | null>(null)
 
-  async function fetch(params: { q?: string; accompanyingAdult?: string; cancelled?: string } = {}) {
+  async function fetch(params: { q?: string; accompanyingAdult?: string; cancelled?: string; fy?: string } = {}) {
     loading.value = true
     error.value = null
     try {
@@ -15,6 +15,7 @@ export const useEntryListStore = defineStore('entryList', () => {
       if (params.q) query.set('q', params.q)
       if (params.accompanyingAdult) query.set('accompanyingAdult', params.accompanyingAdult)
       if (params.cancelled) query.set('cancelled', params.cancelled)
+      if (params.fy) query.set('fy', params.fy)
       const qs = query.toString()
       const res = await window.fetch(`/api/entries${qs ? `?${qs}` : ''}`)
       if (!res.ok) {

--- a/frontend/src/stores/profileList.ts
+++ b/frontend/src/stores/profileList.ts
@@ -22,6 +22,7 @@ export const useProfileListStore = defineStore('profiles', () => {
     try {
       const params = new URLSearchParams()
       if (fy === 'rolling') params.set('fy', 'rolling')
+      else if (fy === 'future') params.set('fy', 'future')
       else if (fy && fy.startsWith('FY')) params.set('fy', fy)
       // 'all' → omit fy param; API always returns hoursAll regardless
       if (group) params.set('group', group)

--- a/frontend/src/styles/list.css
+++ b/frontend/src/styles/list.css
@@ -46,3 +46,36 @@
   cursor: pointer;
 }
 .list-filter-select:disabled { opacity: 0.5; cursor: default; }
+
+/* Shared card grid — Groups, Sessions list results */
+.list-card-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.5rem;
+  padding: 0 1.5rem;
+}
+@media (width < 48em) { .list-card-grid { grid-template-columns: 1fr; } }
+
+.list-card-item { position: relative; }
+
+.list-card-checkbox {
+  position: absolute;
+  top: 1rem;
+  right: 1.5rem;
+  z-index: 1;
+  width: 16px; height: 16px;
+  cursor: pointer;
+  accent-color: var(--color-dtv-green);
+}
+
+/* Shared select-all row — Groups, Sessions, Entries, Profiles list results */
+.list-select-row {
+  padding: 0.5rem 0;
+  margin: 0 1.5rem;
+  border-bottom: 1px solid var(--color-surface-hover);
+}
+.list-select-all {
+  background: none; border: none; cursor: pointer;
+  font-size: 0.85rem; font-weight: 600; color: var(--color-dtv-green); padding: 0;
+}
+.list-select-all:hover { text-decoration: underline; }

--- a/frontend/src/styles/list.css
+++ b/frontend/src/styles/list.css
@@ -1,0 +1,48 @@
+/* Shared action bar — Groups, Sessions, Entries, Profiles list pages */
+.list-actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  background: var(--color-dtv-sand);
+  padding: 0.75rem 1.5rem;
+  margin-bottom: 1.5rem;
+}
+.list-actions-stats { flex: 1; font-size: 0.85rem; color: var(--color-text-secondary); }
+.list-actions-buttons { display: flex; gap: 0.5rem; margin-left: auto; }
+
+/* Shared filter bar — Sessions and Entries list pages */
+.list-filter {
+  background: var(--color-dtv-sand);
+  padding: 1rem 1.5rem;
+  margin-bottom: 1.5rem;
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: stretch;
+}
+
+/* Shared filter inputs — Sessions, Entries, Profiles list pages */
+.list-filter-search {
+  flex: 2 1 180px;
+  padding: 0.5rem 0.75rem;
+  border: 2px solid var(--color-border);
+  font-size: 0.95rem;
+  font-family: inherit;
+  color: var(--color-text);
+  background: var(--color-white);
+  box-sizing: border-box;
+}
+.list-filter-search:focus { outline: none; border-color: var(--color-dtv-green); }
+
+.list-filter-select {
+  flex: 1 1 140px;
+  background: var(--color-white);
+  border: 1px solid var(--color-border);
+  color: var(--color-text);
+  padding: 0.45rem 0.6rem;
+  font-family: inherit;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+.list-filter-select:disabled { opacity: 0.5; cursor: default; }

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -2,6 +2,7 @@
 @import "./call-to-action.css";
 @import "./icons.css";
 @import "./admin.css";
+@import "./list.css";
 
 @theme {
   /* DTV brand colours — keep in sync with shared/brand.ts (used by email renderer) */

--- a/frontend/src/utils/listCsv.ts
+++ b/frontend/src/utils/listCsv.ts
@@ -1,0 +1,14 @@
+export function escapeCsvCell(value: unknown): string {
+  const str = String(value ?? '')
+  return /[,"\n]/.test(str) ? `"${str.replace(/"/g, '""')}"` : str
+}
+
+export function downloadCsv(filename: string, headers: string[], rows: unknown[][], bom = true): void {
+  const csv = [headers, ...rows].map(row => row.map(escapeCsvCell).join(',')).join('\n')
+  const content = bom ? '﻿' + csv : csv
+  const a = document.createElement('a')
+  a.href = URL.createObjectURL(new Blob([content], { type: 'text/csv;charset=utf-8' }))
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(a.href)
+}

--- a/frontend/src/utils/shareUrl.ts
+++ b/frontend/src/utils/shareUrl.ts
@@ -1,0 +1,8 @@
+export async function shareCurrentUrl(): Promise<void> {
+  const url = window.location.href
+  if (navigator.share) {
+    await navigator.share({ url })
+  } else {
+    await navigator.clipboard.writeText(url)
+  }
+}

--- a/frontend/src/utils/shareUrl.ts
+++ b/frontend/src/utils/shareUrl.ts
@@ -1,8 +1,8 @@
-export async function shareCurrentUrl(): Promise<void> {
+export function shareCurrentUrl(): void {
   const url = window.location.href
   if (navigator.share) {
-    await navigator.share({ url })
-  } else {
-    await navigator.clipboard.writeText(url)
+    navigator.share({ url }).catch(() => {})
+  } else if (navigator.clipboard?.writeText) {
+    navigator.clipboard.writeText(url).catch(() => {})
   }
 }

--- a/routes/entries.ts
+++ b/routes/entries.ts
@@ -169,6 +169,10 @@ router.get('/entries', async (req: Request, res: Response) => {
     const filterAdultId = req.query.accompanyingAdultId ? parseInt(String(req.query.accompanyingAdultId), 10) : null;
     // cancelled filter: 'true' = only cancelled, 'false'/'omitted' = only active, 'all' = both
     const cancelledFilter = req.query.cancelled ? String(req.query.cancelled) : 'false';
+    // fy filter: 'future' | 'rolling' | 'FY####' | 'all' (omit = no filter)
+    const fyParam = req.query.fy ? String(req.query.fy) : '';
+    const todayStr = new Date().toISOString().slice(0, 10);
+    const rollingStart = (() => { const d = new Date(); d.setFullYear(d.getFullYear() - 1); return d.toISOString().slice(0, 10); })();
 
     const [rawEntries, rawSessions, rawGroups, rawProfiles] = await Promise.all([
       entriesRepository.getAll(),
@@ -193,6 +197,17 @@ router.get('/entries', async (req: Request, res: Response) => {
         if (groupId === undefined) return [];
         const group = groupMap.get(groupId);
         if (!group) return [];
+
+        // Apply FY filter on session date
+        if (fyParam && fyParam !== 'all') {
+          const sessionDate = session.Date.substring(0, 10);
+          if (fyParam === 'future' && sessionDate < todayStr) return [];
+          else if (fyParam === 'rolling' && (sessionDate < rollingStart || sessionDate > todayStr)) return [];
+          else if (fyParam.startsWith('FY')) {
+            const fyYear = parseInt(fyParam.replace('FY', ''), 10);
+            if (calculateFinancialYear(new Date(session.Date)) !== fyYear) return [];
+          }
+        }
 
         // Apply cancelled filter
         const isCancelled = !!e.Cancelled;

--- a/routes/groups.ts
+++ b/routes/groups.ts
@@ -103,6 +103,23 @@ router.post('/groups', async (req: Request, res: Response) => {
       return;
     }
 
+    const keyNorm = key.trim().toLowerCase();
+    const nameNorm = typeof name === 'string' ? name.trim().toLowerCase() : '';
+
+    const existing = await groupsRepository.getAll();
+    const keyClash = existing.find(g => (g.Title || '').toLowerCase() === keyNorm);
+    if (keyClash) {
+      res.status(409).json({ success: false, error: `A group with key "${key.trim()}" already exists` });
+      return;
+    }
+    if (nameNorm) {
+      const nameClash = existing.find(g => (g.Name || '').toLowerCase() === nameNorm);
+      if (nameClash) {
+        res.status(409).json({ success: false, error: `A group with display name "${name.trim()}" already exists` });
+        return;
+      }
+    }
+
     const fields: { Title: string; Name?: string; Description?: string } = { Title: key.trim() };
     if (typeof name === 'string' && name.trim()) {
       fields.Name = name.trim();

--- a/routes/profiles.ts
+++ b/routes/profiles.ts
@@ -45,6 +45,8 @@ router.get('/profiles', async (req: Request, res: Response) => {
     const fy = calculateCurrentFY();
     const fyParam = req.query.fy ? String(req.query.fy) : null;
     const isRolling = fyParam === 'rolling';
+    const isFuture = fyParam === 'future';
+    const todayStr = new Date().toISOString().slice(0, 10);
     let thisFYStart: number;
     let lastFYStart: number;
     let rollingStart: string | undefined;
@@ -99,7 +101,13 @@ router.get('/profiles', async (req: Request, res: Response) => {
       const ps = profileStats.get(volunteerId)!;
       ps.hoursAll += hours;
       ps.sessionsAll.add(sessionId);
-      if (isRolling) {
+      if (isFuture) {
+        const sessionDate = session.Date.substring(0, 10);
+        if (sessionDate >= todayStr && !e[ENTRY_CANCELLED]) {
+          ps.hoursThisFY += hours;
+          ps.sessionsThisFY.add(sessionId);
+        }
+      } else if (isRolling) {
         const sessionDate = session.Date.substring(0, 10);
         if (sessionDate >= rollingStart! && sessionDate <= rollingEnd!) {
           ps.hoursThisFY += hours;

--- a/routes/profiles.ts
+++ b/routes/profiles.ts
@@ -576,6 +576,14 @@ router.post('/profiles', async (req: Request, res: Response) => {
       return;
     }
 
+    const nameNorm = name.trim().toLowerCase();
+    const allProfiles = await profilesRepository.getAll();
+    const nameClash = allProfiles.find(p => (p.Title || '').toLowerCase() === nameNorm);
+    if (nameClash) {
+      res.status(409).json({ success: false, error: `A profile named "${name.trim()}" already exists` });
+      return;
+    }
+
     const fields: { Title: string; Email?: string; MatchName?: string } = {
       Title: name.trim(),
       MatchName: toMatchName(name.trim())
@@ -585,7 +593,7 @@ router.post('/profiles', async (req: Request, res: Response) => {
     }
 
     const id = await profilesRepository.create(fields);
-    res.json({ success: true, data: { id, name: fields.Title, email: fields.Email || '' } });
+    res.json({ success: true, data: { id, slug: profileSlug(fields.Title, id), name: fields.Title, email: fields.Email || '' } });
   } catch (error: any) {
     console.error('Error creating profile:', error);
     res.status(500).json({

--- a/routes/sessions.ts
+++ b/routes/sessions.ts
@@ -165,6 +165,16 @@ router.post('/sessions', async (req: Request, res: Response) => {
       return;
     }
 
+    const allSessions = await sessionsRepository.getAll();
+    const clash = allSessions.find(s =>
+      safeParseLookupId(s[GROUP_LOOKUP]) === Number(groupId) &&
+      (s.Date || '').substring(0, 10) === dateStr
+    );
+    if (clash) {
+      res.status(409).json({ success: false, error: `A session for this group already exists on ${dateStr}` });
+      return;
+    }
+
     const groupKey = (group.Title || '').toLowerCase();
     const title = `${dateStr} ${group.Title || ''}`.trim();
 


### PR DESCRIPTION
feat: align all four list pages to Filter/Actions/Results pattern (#196)

- Groups: add GroupListActions (admin-only, count/hours, Download, Share),
  add checkbox selection to GroupListResults, remove count from GroupListFilter,
  default FY to 'future' (groups and sessions)
- Sessions: add Share button to existing action bar, migrate inline CSV to
  shared listCsv util
- Entries: route changed from requiresTrusted to requiresAdmin (matches existing
  backend ADMIN_ONLY_GET_PATTERNS); action bar now admin-only with Download CSV
  and Share; EntryListFilter styled to match standard filter bar pattern
- Profiles: add Share button to existing action bar, migrate inline CSV to
  shared listCsv util; store now passes fy=future to API; backend computes
  hoursThisFY/sessionsThisFY for future (non-cancelled, future-dated entries)

New shared utilities:
- frontend/src/utils/listCsv.ts — downloadCsv() replaces duplicated blob logic
- frontend/src/utils/shareUrl.ts — shareCurrentUrl() with navigator.share fallback
- frontend/src/styles/list.css — .list-actions and .list-filter shared CSS,
  imported from main.css; removes ~130 lines of duplicated scoped styles
