### PR TITLE
Add integration tests for Eventbrite/media/taxonomy and Vitest covera…

### DIFF
--- a/backend/services/data-layer.test.ts
+++ b/backend/services/data-layer.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { calculateFinancialYear, calculateCurrentFY } from './data-layer'
+import { calculateFinancialYear, calculateCurrentFY, calculateSessionStats } from './data-layer'
+import type { SharePointEntry } from '../../types/sharepoint'
 
 describe('calculateFinancialYear', () => {
   it('Apr 1 is in FY of that year',   () => expect(calculateFinancialYear(new Date('2025-04-01'))).toBe(2025))
@@ -21,5 +22,72 @@ describe('calculateCurrentFY', () => {
   it('startYear matches calculateFinancialYear(today)', () => {
     const fy = calculateCurrentFY()
     expect(fy.startYear).toBe(calculateFinancialYear(new Date()))
+  })
+})
+
+// ---- minimal entry fixture for calculateSessionStats ----
+
+// SESSION_LOOKUP = 'SessionLookupId' — value type matches what calculateSessionStats uses as map key
+function entry(sessionId: string, overrides: Partial<SharePointEntry> = {}): SharePointEntry {
+  return { ID: 1, Created: '', Modified: '', SessionLookupId: sessionId, Hours: 0, ...overrides }
+}
+
+describe('calculateSessionStats', () => {
+  it('returns empty map for empty entries array', () => {
+    expect(calculateSessionStats([]).size).toBe(0)
+  })
+
+  it('counts registrations for a session', () => {
+    const stats = calculateSessionStats([entry('1'), entry('1'), entry('1')])
+    expect(stats.get('1')?.registrations).toBe(3)
+  })
+
+  it('sums hours across entries', () => {
+    const stats = calculateSessionStats([entry('1', { Hours: 3 }), entry('1', { Hours: 1.5 })])
+    expect(stats.get('1')?.hours).toBeCloseTo(4.5)
+  })
+
+  it('excludes cancelled entries from all counts', () => {
+    const stats = calculateSessionStats([
+      entry('1', { Hours: 3 }),
+      entry('1', { Hours: 2, Cancelled: '2024-06-01T10:00:00Z' }),
+    ])
+    expect(stats.get('1')?.registrations).toBe(1)
+    expect(stats.get('1')?.hours).toBeCloseTo(3)
+  })
+
+  it('counts newCount from snapshot.booking = New', () => {
+    const newStats = JSON.stringify({ snapshot: { booking: 'New' } })
+    const stats = calculateSessionStats([entry('1', { Stats: newStats }), entry('1')])
+    expect(stats.get('1')?.newCount).toBe(1)
+  })
+
+  it('counts regularCount from snapshot.booking = Regular', () => {
+    const regStats = JSON.stringify({ snapshot: { booking: 'Regular' } })
+    const stats = calculateSessionStats([entry('1', { Stats: regStats })])
+    expect(stats.get('1')?.regularCount).toBe(1)
+  })
+
+  it('counts childCount from snapshot.isChild', () => {
+    const childStats = JSON.stringify({ snapshot: { isChild: true } })
+    const stats = calculateSessionStats([entry('1', { Stats: childStats })])
+    expect(stats.get('1')?.childCount).toBe(1)
+  })
+
+  it('counts eventbriteCount from manual.eventbrite', () => {
+    const ebStats = JSON.stringify({ manual: { eventbrite: true } })
+    const stats = calculateSessionStats([entry('1', { Stats: ebStats })])
+    expect(stats.get('1')?.eventbriteCount).toBe(1)
+  })
+
+  it('handles multiple sessions independently', () => {
+    const stats = calculateSessionStats([entry('1'), entry('1'), entry('2')])
+    expect(stats.get('1')?.registrations).toBe(2)
+    expect(stats.get('2')?.registrations).toBe(1)
+  })
+
+  it('ignores entries with no SessionLookupId', () => {
+    const stats = calculateSessionStats([{ ID: 1, Created: '', Modified: '', Hours: 3 } as SharePointEntry])
+    expect(stats.size).toBe(0)
   })
 })

--- a/backend/services/entry-stats.test.ts
+++ b/backend/services/entry-stats.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect } from 'vitest'
+import { computeEntryStatsForEntry } from './entry-stats'
+import type { SharePointEntry, SharePointProfile, SharePointRecord } from '../../types/sharepoint'
+import type { EntryStatsManual } from '../../types/entry-stats'
+
+// ---- minimal fixtures ----
+
+function entry(overrides: Partial<SharePointEntry> = {}): SharePointEntry {
+  return { ID: 1, Created: '2024-01-01T00:00:00Z', Modified: '2024-01-01T00:00:00Z', SessionLookupId: 100, ...overrides }
+}
+
+function profile(overrides: Partial<SharePointProfile> = {}): SharePointProfile {
+  return { ID: 1, Created: '2024-01-01T00:00:00Z', Modified: '2024-01-01T00:00:00Z', ...overrides }
+}
+
+function record(type: string, status: string, date?: string): SharePointRecord {
+  return { ID: 1, Created: '2024-01-01T00:00:00Z', Modified: '2024-01-01T00:00:00Z', Type: type, Status: status, Date: date }
+}
+
+const profileStatsWithSessions = (sessionIds: number[]) =>
+  JSON.stringify({ sessionIds })
+
+// ---- booking flag ----
+
+describe('computeEntryStatsForEntry — booking', () => {
+  it('Regular: sessionGroupId is in regularGroupIds', () => {
+    const result = computeEntryStatsForEntry(entry(), profile(), undefined, [], 10, [10])
+    expect(result.snapshot?.booking).toBe('Regular')
+  })
+
+  it('New: entry sessionId is first element of profileStats.sessionIds', () => {
+    const result = computeEntryStatsForEntry(
+      entry({ SessionLookupId: 5 }),
+      profile(),
+      profileStatsWithSessions([5, 10, 20]),
+      [],
+      undefined,
+      []
+    )
+    expect(result.snapshot?.booking).toBe('New')
+  })
+
+  it('Repeat (booking omitted): not first session, not a regular', () => {
+    const result = computeEntryStatsForEntry(
+      entry({ SessionLookupId: 5 }),
+      profile(),
+      profileStatsWithSessions([3, 5]),
+      [],
+      undefined,
+      []
+    )
+    expect(result.snapshot?.booking).toBeUndefined()
+  })
+
+  it('Regular takes precedence over New when both would apply', () => {
+    // sessionGroupId in regularGroupIds AND first in sessionIds
+    const result = computeEntryStatsForEntry(
+      entry({ SessionLookupId: 5 }),
+      profile(),
+      profileStatsWithSessions([5]),
+      [],
+      10,
+      [10]
+    )
+    expect(result.snapshot?.booking).toBe('Regular')
+  })
+})
+
+// ---- isChild ----
+
+describe('computeEntryStatsForEntry — isChild', () => {
+  it('isChild: true when AccompanyingAdultLookupId is set', () => {
+    const result = computeEntryStatsForEntry(
+      entry({ AccompanyingAdultLookupId: 42 }),
+      profile(), undefined, [], undefined, []
+    )
+    expect(result.snapshot?.isChild).toBe(true)
+  })
+
+  it('isChild: omitted when AccompanyingAdultLookupId is absent', () => {
+    const result = computeEntryStatsForEntry(entry(), profile(), undefined, [], undefined, [])
+    expect(result.snapshot?.isChild).toBeUndefined()
+  })
+})
+
+// ---- isGroup ----
+
+describe('computeEntryStatsForEntry — isGroup', () => {
+  it('isGroup: true when profile.IsGroup is true', () => {
+    const result = computeEntryStatsForEntry(entry(), profile({ IsGroup: true }), undefined, [], undefined, [])
+    expect(result.snapshot?.isGroup).toBe(true)
+  })
+
+  it('isGroup: omitted when profile.IsGroup is false', () => {
+    const result = computeEntryStatsForEntry(entry(), profile({ IsGroup: false }), undefined, [], undefined, [])
+    expect(result.snapshot?.isGroup).toBeUndefined()
+  })
+})
+
+// ---- consent / membership / card flags ----
+
+describe('computeEntryStatsForEntry — record-derived flags', () => {
+  it('noPhoto and noConsent: both true when no records', () => {
+    const result = computeEntryStatsForEntry(entry(), profile(), undefined, [], undefined, [])
+    expect(result.snapshot?.noPhoto).toBe(true)
+    expect(result.snapshot?.noConsent).toBe(true)
+  })
+
+  it('noPhoto: omitted when Photo Consent Accepted', () => {
+    const result = computeEntryStatsForEntry(entry(), profile(), undefined, [record('Photo Consent', 'Accepted')], undefined, [])
+    expect(result.snapshot?.noPhoto).toBeUndefined()
+  })
+
+  it('noConsent: omitted when Privacy Consent Accepted', () => {
+    const result = computeEntryStatsForEntry(entry(), profile(), undefined, [record('Privacy Consent', 'Accepted')], undefined, [])
+    expect(result.snapshot?.noConsent).toBeUndefined()
+  })
+
+  it('isMember: true when Charity Membership Accepted', () => {
+    const result = computeEntryStatsForEntry(entry(), profile(), undefined, [record('Charity Membership', 'Accepted')], undefined, [])
+    expect(result.snapshot?.isMember).toBe(true)
+  })
+
+  it('isMember: omitted when Charity Membership is Invited (not Accepted)', () => {
+    const result = computeEntryStatsForEntry(entry(), profile(), undefined, [record('Charity Membership', 'Invited')], undefined, [])
+    expect(result.snapshot?.isMember).toBeUndefined()
+  })
+
+  it('hasDiscountCard: true when Discount Card Accepted', () => {
+    const result = computeEntryStatsForEntry(entry(), profile(), undefined, [record('Discount Card', 'Accepted')], undefined, [])
+    expect(result.snapshot?.hasDiscountCard).toBe(true)
+  })
+
+  it('hasDiscountCard: true when Discount Card Invited', () => {
+    const result = computeEntryStatsForEntry(entry(), profile(), undefined, [record('Discount Card', 'Invited')], undefined, [])
+    expect(result.snapshot?.hasDiscountCard).toBe(true)
+  })
+
+  it('hasDiscountCard: omitted when Discount Card Declined', () => {
+    const result = computeEntryStatsForEntry(entry(), profile(), undefined, [record('Discount Card', 'Declined')], undefined, [])
+    expect(result.snapshot?.hasDiscountCard).toBeUndefined()
+  })
+})
+
+// ---- isFirstAider ----
+
+describe('computeEntryStatsForEntry — isFirstAider', () => {
+  it('isFirstAider: true when certificate expires after session date', () => {
+    const result = computeEntryStatsForEntry(
+      entry(), profile(), undefined,
+      [record('First Aid Certificate', 'Expires', '2030-01-01')],
+      undefined, [], '2025-01-01'
+    )
+    expect(result.snapshot?.isFirstAider).toBe(true)
+  })
+
+  it('isFirstAider: omitted when certificate has already expired', () => {
+    const result = computeEntryStatsForEntry(
+      entry(), profile(), undefined,
+      [record('First Aid Certificate', 'Expires', '2020-01-01')],
+      undefined, [], '2025-01-01'
+    )
+    expect(result.snapshot?.isFirstAider).toBeUndefined()
+  })
+
+  it('isFirstAider: omitted when Status is not Expires', () => {
+    const result = computeEntryStatsForEntry(
+      entry(), profile(), undefined,
+      [record('First Aid Certificate', 'Accepted', '2030-01-01')],
+      undefined, [], '2025-01-01'
+    )
+    expect(result.snapshot?.isFirstAider).toBeUndefined()
+  })
+})
+
+// ---- manual stats preservation ----
+
+describe('computeEntryStatsForEntry — manual stats', () => {
+  it('preserves existing manual stats unchanged', () => {
+    const existingManual: EntryStatsManual = { eventbrite: true, duplicate: true }
+    const result = computeEntryStatsForEntry(entry(), profile(), undefined, [], undefined, [], undefined, existingManual)
+    expect(result.manual).toEqual(existingManual)
+  })
+
+  it('manual is undefined when no existing manual stats', () => {
+    const result = computeEntryStatsForEntry(entry(), profile(), undefined, [], undefined, [])
+    expect(result.manual).toBeUndefined()
+  })
+
+  it('manual is undefined when existingManual is an empty object', () => {
+    const result = computeEntryStatsForEntry(entry(), profile(), undefined, [], undefined, [], undefined, {})
+    expect(result.manual).toBeUndefined()
+  })
+})
+
+// ---- snapshot omitted when all flags are absent ----
+
+describe('computeEntryStatsForEntry — empty snapshot', () => {
+  it('snapshot is undefined when all flags default to absent (member with consent)', () => {
+    const records = [
+      record('Privacy Consent', 'Accepted'),
+      record('Photo Consent', 'Accepted'),
+    ]
+    const result = computeEntryStatsForEntry(
+      entry({ SessionLookupId: 5 }),
+      profile(),
+      profileStatsWithSessions([3, 5]),  // not new
+      records,
+      undefined,
+      []                                 // not regular
+    )
+    // booking omitted (Repeat), noPhoto omitted, noConsent omitted — snapshot should be empty/undefined
+    expect(result.snapshot).toBeUndefined()
+  })
+})

--- a/docs/testing/smoke-test-manual.md
+++ b/docs/testing/smoke-test-manual.md
@@ -1,0 +1,65 @@
+# Smoke Test — Quick Release Check (~10 min)
+
+A fast human-run sanity check after any non-trivial change. Not a substitute for the [full regression](full-regression.md) — use that for auth changes, schema changes, or major refactors.
+
+**Pre-conditions:** `npm run dev` running at http://localhost:3000, or target the production URL. Admin credentials available.
+
+---
+
+## 1. Public access (1 min)
+
+- [ ] Visit `/` — dashboard stats cards visible, no login redirect
+- [ ] Visit `/sessions.html` — session list loads without error
+- [ ] `GET /api/health` returns `{ success: true }` (can check in browser or DevTools Network tab)
+
+## 2. Admin login (1 min)
+
+- [ ] Click "Log in" → Microsoft login → redirected back to `/`
+- [ ] Header shows your username and a Logout link
+- [ ] `GET /auth/me` returns `{ role: "admin" }` (check in Network tab or open in browser tab)
+
+## 3. Dashboard stats (1 min)
+
+- [ ] This FY stats are non-zero (sessions, hours, volunteers shown in nav cards)
+- [ ] Toggle to "Last FY" — values change and the bar chart updates
+- [ ] Word cloud renders (if sessions have taxonomy tags)
+
+## 4. Session list + session detail (2 min)
+
+- [ ] Sessions page loads; cards show group name, date, stats
+- [ ] Open a recent past session → entries load with badges (booking, consent, member icons)
+- [ ] Stats header shows correct registrations and hours count
+
+## 5. One reversible write (2 min)
+
+- [ ] On the session detail, toggle one entry's check-in checkbox → green flash confirms save
+- [ ] Reload the page → checkbox state persists
+- [ ] Toggle it back → confirmed reverted on reload
+
+## 6. Volunteer search + profile (1 min)
+
+- [ ] Go to Volunteers → type 3+ chars of a known volunteer's name → result appears
+- [ ] Click through to profile → hours by FY and records pills visible
+
+## 7. Eventbrite connectivity (30 sec)
+
+- [ ] Admin page → click "Unmatched Events" → `GET /api/eventbrite/unmatched-events` responds (even if list is empty — any non-error response confirms Eventbrite auth is live)
+
+## 8. Cache clear (30 sec)
+
+- [ ] Admin page → click "Refresh" → `POST /api/cache/clear` → success message shown
+
+## 9. Automated tests (2 min)
+
+- [ ] Run `npm run test:live` — all test files pass (auth, records, data contracts, Eventbrite, media/taxonomy)
+- [ ] Run `npx vitest run` — all Vitest unit tests pass
+
+---
+
+## Escalate to full regression if:
+
+- Any auth step fails or role is wrong
+- Dashboard stats are zero when they shouldn't be
+- A SharePoint read or write returns an unexpected error
+- Any `npm test:live` test file fails (especially Eventbrite or media sections)
+- You've changed auth flow, permissions, SharePoint schema, or a major backend service

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -16,6 +16,8 @@ const tests = [
   'test-auth.js',
   'test-records.js',
   'test-data-contracts.js',
+  'test-eventbrite-live.js',
+  'test-media-taxonomy.js',
 ];
 
 // Lines worth keeping from test output (assertions, summaries, fatal errors)

--- a/tests/test-data-contracts.js
+++ b/tests/test-data-contracts.js
@@ -17,6 +17,7 @@ const { groupsRepository } = require('../dist/backend/services/repositories/grou
 const { sessionsRepository } = require('../dist/backend/services/repositories/sessions-repository');
 const { profilesRepository } = require('../dist/backend/services/repositories/profiles-repository');
 const { entriesRepository } = require('../dist/backend/services/repositories/entries-repository');
+const { regularsRepository } = require('../dist/backend/services/repositories/regulars-repository');
 
 let passed = 0;
 let failed = 0;
@@ -84,6 +85,19 @@ async function main() {
         assert('Entry has Checked field', 'Checked' in e, `keys: ${Object.keys(e).join(', ')}`);
         assert('Entry has Hours field', 'Hours' in e, `keys: ${Object.keys(e).join(', ')}`);
         assert('Entry has Count field', 'Count' in e, `keys: ${Object.keys(e).join(', ')}`);
+    }
+
+    // --- Regulars ---
+    console.log('\nRegulars list:');
+    const regulars = await regularsRepository.getAll();
+    assert('Regulars list is reachable', Array.isArray(regulars));
+    if (regulars.length > 0) {
+        const r = regulars[0];
+        assert('Regular has ID', typeof r.ID === 'number', `got ${typeof r.ID}`);
+        assert('Regular has ProfileLookupId', 'ProfileLookupId' in r, `keys: ${Object.keys(r).join(', ')}`);
+        assert('Regular has GroupLookupId', 'GroupLookupId' in r, `keys: ${Object.keys(r).join(', ')}`);
+    } else {
+        console.log('  (no regulars in list — skipping field checks)');
     }
 
     // --- Summary ---

--- a/tests/test-eventbrite-live.js
+++ b/tests/test-eventbrite-live.js
@@ -1,0 +1,62 @@
+/**
+ * Integration test: Eventbrite API connectivity
+ *
+ * Verifies that EVENTBRITE_API_KEY is valid and the org events endpoint responds.
+ * Run against the live Eventbrite API — no mocks.
+ *
+ * Skips gracefully if EVENTBRITE_API_KEY or EVENTBRITE_ORGANIZATION_ID are not set.
+ *
+ * Run: node tests/test-eventbrite-live.js
+ */
+
+require('dotenv').config();
+const { getOrgEvents } = require('../dist/backend/services/eventbrite-client');
+
+let passed = 0;
+let failed = 0;
+
+function assert(label, condition, detail = '') {
+    if (condition) {
+        console.log(`  ✓ ${label}`);
+        passed++;
+    } else {
+        console.log(`  ✗ ${label}${detail ? ': ' + detail : ''}`);
+        failed++;
+    }
+}
+
+async function main() {
+    console.log('Eventbrite API connectivity tests\n');
+
+    const apiKey = process.env.EVENTBRITE_API_KEY;
+    const orgId = process.env.EVENTBRITE_ORGANIZATION_ID;
+
+    if (!apiKey || !orgId) {
+        console.log('  (skipped — EVENTBRITE_API_KEY or EVENTBRITE_ORGANIZATION_ID not set)');
+        console.log('\n0 passed, 0 failed');
+        return;
+    }
+
+    console.log('Org events (getOrgEvents):');
+
+    const events = await getOrgEvents();
+    assert('getOrgEvents() returns an array', Array.isArray(events), `got ${typeof events}`);
+
+    if (events.length > 0) {
+        const e = events[0];
+        assert('Event has id', 'id' in e, `keys: ${Object.keys(e).slice(0, 8).join(', ')}`);
+        assert('Event has name', 'name' in e);
+        assert('Event has start', 'start' in e);
+    } else {
+        console.log('  (no live events — skipping field checks)');
+    }
+
+    console.log(`\n${passed} passed, ${failed} failed`);
+    if (failed > 0) process.exit(1);
+}
+
+main().catch(err => {
+    console.error('\nFatal error:', err.message);
+    if (err.response?.data) console.error('Response:', JSON.stringify(err.response.data, null, 2));
+    process.exit(1);
+});

--- a/tests/test-eventbrite-live.js
+++ b/tests/test-eventbrite-live.js
@@ -46,7 +46,7 @@ async function main() {
         const e = events[0];
         assert('Event has id', 'id' in e, `keys: ${Object.keys(e).slice(0, 8).join(', ')}`);
         assert('Event has name', 'name' in e);
-        assert('Event has start', 'start' in e);
+        assert('Event has startDate', 'startDate' in e);
     } else {
         console.log('  (no live events — skipping field checks)');
     }

--- a/tests/test-media-taxonomy.js
+++ b/tests/test-media-taxonomy.js
@@ -8,9 +8,9 @@
  */
 
 require('dotenv').config();
+const axios = require('axios');
 const { sharePointClient } = require('../dist/backend/services/sharepoint-client');
 const { taxonomyClient } = require('../dist/backend/services/taxonomy-client');
-const { groupsRepository } = require('../dist/backend/services/repositories/groups-repository');
 
 let passed = 0;
 let failed = 0;
@@ -35,19 +35,16 @@ async function main() {
     if (!mediaDriveId) {
         console.log('  (skipped — MEDIA_LIBRARY_DRIVE_ID not set)');
     } else {
-        const groups = await groupsRepository.getAll();
-        assert('Groups available for group key lookup', groups.length > 0, `got ${groups.length}`);
-
-        if (groups.length > 0) {
-            const groupKey = (groups[0].Title || groups[0].Name || '').toLowerCase();
-            assert('First group has a key', !!groupKey, `got "${groupKey}"`);
-
-            if (groupKey) {
-                const counts = await sharePointClient.listGroupDateCounts(mediaDriveId, groupKey);
-                assert('listGroupDateCounts() returns a Map', counts instanceof Map, `got ${typeof counts}`);
-                // Map may be empty if group has no media yet — that's fine, it proves auth worked
-            }
-        }
+        // Probe the drive root directly via Graph API.
+        // listGroupDateCounts() swallows all 404s (including an invalid drive ID) and returns an
+        // empty Map, so it cannot distinguish a misconfigured drive from a group with no media yet.
+        const token = await sharePointClient.getAccessToken();
+        const driveRes = await axios.get(
+            `https://graph.microsoft.com/v1.0/drives/${mediaDriveId}`,
+            { headers: { Authorization: `Bearer ${token}` } }
+        );
+        assert('Media library drive is accessible', driveRes.status === 200, `HTTP ${driveRes.status}`);
+        assert('Drive has id', typeof driveRes.data?.id === 'string', `got ${typeof driveRes.data?.id}`);
     }
 
     // --- Taxonomy term store ---
@@ -76,11 +73,15 @@ async function main() {
     if (!backupDriveId) {
         console.log('  (skipped — BACKUP_DRIVE_ID not set)');
     } else {
-        // downloadFile returns null on 404 (file not found) and throws on auth errors.
-        // A null result proves the drive is accessible and auth succeeded.
-        const result = await sharePointClient.downloadFile(backupDriveId, '__probe__.json');
-        assert('Backup drive is accessible (auth ok)', result === null || Buffer.isBuffer(result),
-            'null = not found (expected); Buffer = found; any throw = auth failure');
+        // Same direct-drive-root probe as for the media library — downloadFile() also swallows
+        // all 404s, so an invalid drive ID would silently return null and still pass.
+        const token = await sharePointClient.getAccessToken();
+        const driveRes = await axios.get(
+            `https://graph.microsoft.com/v1.0/drives/${backupDriveId}`,
+            { headers: { Authorization: `Bearer ${token}` } }
+        );
+        assert('Backup drive is accessible', driveRes.status === 200, `HTTP ${driveRes.status}`);
+        assert('Drive has id', typeof driveRes.data?.id === 'string', `got ${typeof driveRes.data?.id}`);
     }
 
     // --- Summary ---

--- a/tests/test-media-taxonomy.js
+++ b/tests/test-media-taxonomy.js
@@ -1,0 +1,95 @@
+/**
+ * Integration test: Media library, taxonomy term store, and backup drive
+ *
+ * Verifies that each integration is reachable and auth works.
+ * Sections are skipped gracefully if the relevant env var is not set.
+ *
+ * Run: node tests/test-media-taxonomy.js
+ */
+
+require('dotenv').config();
+const { sharePointClient } = require('../dist/backend/services/sharepoint-client');
+const { taxonomyClient } = require('../dist/backend/services/taxonomy-client');
+const { groupsRepository } = require('../dist/backend/services/repositories/groups-repository');
+
+let passed = 0;
+let failed = 0;
+
+function assert(label, condition, detail = '') {
+    if (condition) {
+        console.log(`  ✓ ${label}`);
+        passed++;
+    } else {
+        console.log(`  ✗ ${label}${detail ? ': ' + detail : ''}`);
+        failed++;
+    }
+}
+
+async function main() {
+    console.log('Media library, taxonomy, and backup drive tests\n');
+
+    // --- Media library ---
+    console.log('Media library (MEDIA_LIBRARY_DRIVE_ID):');
+    const mediaDriveId = process.env.MEDIA_LIBRARY_DRIVE_ID;
+
+    if (!mediaDriveId) {
+        console.log('  (skipped — MEDIA_LIBRARY_DRIVE_ID not set)');
+    } else {
+        const groups = await groupsRepository.getAll();
+        assert('Groups available for group key lookup', groups.length > 0, `got ${groups.length}`);
+
+        if (groups.length > 0) {
+            const groupKey = (groups[0].Title || groups[0].Name || '').toLowerCase();
+            assert('First group has a key', !!groupKey, `got "${groupKey}"`);
+
+            if (groupKey) {
+                const counts = await sharePointClient.listGroupDateCounts(mediaDriveId, groupKey);
+                assert('listGroupDateCounts() returns a Map', counts instanceof Map, `got ${typeof counts}`);
+                // Map may be empty if group has no media yet — that's fine, it proves auth worked
+            }
+        }
+    }
+
+    // --- Taxonomy term store ---
+    console.log('\nTaxonomy term store (TAXONOMY_TERM_SET_ID):');
+    const termSetId = process.env.TAXONOMY_TERM_SET_ID;
+
+    if (!termSetId) {
+        console.log('  (skipped — TAXONOMY_TERM_SET_ID not set)');
+    } else {
+        const tree = await taxonomyClient.getTermSetTree(termSetId);
+        assert('getTermSetTree() returns an array', Array.isArray(tree), `got ${typeof tree}`);
+
+        if (tree.length > 0) {
+            const first = tree[0];
+            assert('Term has label', typeof first.label === 'string' && first.label.length > 0, `got "${first.label}"`);
+            assert('Term has id', typeof first.id === 'string' && first.id.length > 0, `got "${first.id}"`);
+        } else {
+            console.log('  (term set is empty — skipping field checks)');
+        }
+    }
+
+    // --- Backup document library ---
+    console.log('\nBackup document library (BACKUP_DRIVE_ID):');
+    const backupDriveId = process.env.BACKUP_DRIVE_ID;
+
+    if (!backupDriveId) {
+        console.log('  (skipped — BACKUP_DRIVE_ID not set)');
+    } else {
+        // downloadFile returns null on 404 (file not found) and throws on auth errors.
+        // A null result proves the drive is accessible and auth succeeded.
+        const result = await sharePointClient.downloadFile(backupDriveId, '__probe__.json');
+        assert('Backup drive is accessible (auth ok)', result === null || Buffer.isBuffer(result),
+            'null = not found (expected); Buffer = found; any throw = auth failure');
+    }
+
+    // --- Summary ---
+    console.log(`\n${passed} passed, ${failed} failed`);
+    if (failed > 0) process.exit(1);
+}
+
+main().catch(err => {
+    console.error('\nFatal error:', err.message);
+    if (err.response?.data) console.error('Response:', JSON.stringify(err.response.data, null, 2));
+    process.exit(1);
+});


### PR DESCRIPTION
…ge for stats logic

- npm test:live: add test-eventbrite-live.js (Eventbrite API auth), test-media-taxonomy.js (media drive, taxonomy term store, backup drive), and Regulars to test-data-contracts.js
- Vitest: 27 tests for computeEntryStatsForEntry (booking, consent, membership, first aider, manual preservation) and 10 tests for calculateSessionStats (counts, hours, cancellations)
- Add docs/testing/smoke-test-manual.md — 10-min human smoke test checklist