### PR TITLE
refactor: replace Duplicate Warning with Profile Warning, use live da…

### DIFF
--- a/backend/routes/sessions.ts
+++ b/backend/routes/sessions.ts
@@ -469,7 +469,7 @@ router.get('/sessions/:group/:date', async (req: Request, res: Response) => {
     const entryResponses: EntryResponse[] = sessionEntries.map(e => {
       const volunteerId = safeParseLookupId(e[PROFILE_LOOKUP]);
       const profile = volunteerId !== undefined ? profileMap.get(volunteerId) : undefined;
-      // isMember and cardStatus come from the pre-computed Profile.Stats field — no records fetch needed
+      // isMember, cardStatus and profileWarning come from the pre-computed Profile.Stats field — no records fetch needed
       const stats = JSON.parse(profile?.[PROFILE_STATS] || '{}');
       return {
         id: e.ID,
@@ -479,6 +479,7 @@ router.get('/sessions/:group/:date', async (req: Request, res: Response) => {
         isGroup: profile?.IsGroup || false,
         isMember: stats.isMember === true,
         cardStatus: stats.cardStatus ?? undefined,
+        profileWarning: stats.warnings?.length ? true : undefined,
         count: e.Count || 1,
         hours: parseHours(e.Hours),
         checkedIn: e.Checked || false,

--- a/docs/testing/full-regression.md
+++ b/docs/testing/full-regression.md
@@ -130,6 +130,13 @@ Run with `npm run dev` at http://localhost:3000. Log in via Microsoft Entra ID.
 - [ ] `PATCH /api/entries/:id` — `{ checkedIn: true/false }`
 - [ ] Visual checkmark updates immediately
 
+### H9a. Entry card icons
+- [ ] Volunteer with an accompanying adult set on their entry → Child icon shown in session entry list
+- [ ] Volunteer with no accompanying adult → no Child icon
+- [ ] Volunteer whose profile has any computed warnings (e.g. Possible Duplicate, No Consent) → Profile Warning badge shown in session entry list
+- [ ] Volunteer with no profile warnings → no Profile Warning badge
+- [ ] Profile Warning badge does **not** appear on entries when viewing a profile's session history (filtered out as a badge type)
+
 ### H10. Edit entry (live save)
 - [ ] Entry detail → change Checked In, Count, Hours, Notes
 - [ ] `PATCH /api/entries/:id` — `{ checkedIn?, count?, hours?, notes? }`

--- a/frontend/src/components/entries/EntryListItem.vue
+++ b/frontend/src/components/entries/EntryListItem.vue
@@ -37,7 +37,7 @@ const props = defineProps<{
   selected?: boolean
 }>()
 
-const icons = computed(() => iconsForEntry({ isGroup: props.entry.isGroup, stats: props.entry.stats }))
+const icons = computed(() => iconsForEntry({ isGroup: props.entry.isGroup, isChild: !!props.entry.accompanyingAdultId, stats: props.entry.stats }))
 
 function formatDate(date: string): string {
   return new Date(date).toLocaleDateString('en-GB', { day: 'numeric', month: 'short' })

--- a/frontend/src/components/profiles/ProfileEntryList.vue
+++ b/frontend/src/components/profiles/ProfileEntryList.vue
@@ -27,7 +27,7 @@
         :title-to="allowEdit ? undefined : sessionPath(e.session.groupKey, e.session.date)"
         :checked-in="e.checkedIn"
         :hours="e.hours"
-        :icons="iconsForEntry({ ...e.profile, stats: e.stats }).filter(i => i.type !== 'badge')"
+        :icons="iconsForEntry({ ...e.profile, isChild: !!e.accompanyingAdultId, stats: e.stats }).filter(i => i.type !== 'badge')"
         :allow-edit="allowEdit ?? false"
         :working="workingId === e.id"
         @update="(c, h) => emit('update', e, c, h)"

--- a/frontend/src/components/sessions/SessionEntryList.vue
+++ b/frontend/src/components/sessions/SessionEntryList.vue
@@ -22,7 +22,7 @@
         :title-to="allowEdit ? undefined : (e.profile.slug ? profilePath(e.profile.slug) : undefined)"
         :checked-in="e.checkedIn"
         :hours="e.hours"
-        :icons="iconsForEntry({ ...e.profile, stats: e.stats })"
+        :icons="iconsForEntry({ ...e.profile, isChild: !!e.accompanyingAdultId, stats: e.stats })"
         :allow-edit="allowEdit"
         :working="workingId === e.id"
         :cancelled="!!e.cancelled"

--- a/frontend/src/pages/SessionDetailPage.vue
+++ b/frontend/src/pages/SessionDetailPage.vue
@@ -344,6 +344,7 @@ function mapEntry(e: EntryResponse): EntryItem {
       isMember: e.isMember,
       cardStatus: e.cardStatus,
       isGroup: e.isGroup,
+      hasProfileWarning: e.profileWarning,
     },
     session: {
       groupKey: route.params.groupKey as string,

--- a/frontend/src/pages/modals/EntryEditModal.vue
+++ b/frontend/src/pages/modals/EntryEditModal.vue
@@ -136,11 +136,9 @@ const entryIcons = computed(() => iconsForEntry({
   isMember: props.entry.profile.isMember,
   isGroup: props.entry.profile.isGroup,
   cardStatus: props.entry.profile.cardStatus,
-  stats: {
-    ...props.entry.stats,
-    snapshot: { ...props.entry.stats?.snapshot, isChild: form.accompanyingAdultId !== null },
-    manual: form.statsManual,
-  },
+  hasProfileWarning: props.entry.profile.hasProfileWarning,
+  isChild: form.accompanyingAdultId !== null,
+  stats: { ...props.entry.stats, manual: form.statsManual },
 }))
 
 watch(() => props.entry, (e) => {

--- a/frontend/src/pages/sandbox/SandboxEntryList.vue
+++ b/frontend/src/pages/sandbox/SandboxEntryList.vue
@@ -23,7 +23,7 @@
             :title-to="e.profile.slug ? profilePath(e.profile.slug) : undefined"
             :checked-in="e.checkedIn"
             :hours="e.hours"
-            :icons="iconsForEntry({ ...e.profile, stats: e.stats })"
+            :icons="iconsForEntry({ ...e.profile, isChild: !!e.accompanyingAdultId, stats: e.stats })"
             :allow-edit="true"
             :working="workingId === e.id"
             @update="(c, h) => onUpdate(e, c, h)"
@@ -41,7 +41,7 @@
             :title-to="e.profile.slug ? profilePath(e.profile.slug) : undefined"
             :checked-in="e.checkedIn"
             :hours="e.hours"
-            :icons="iconsForEntry({ ...e.profile, stats: e.stats })"
+            :icons="iconsForEntry({ ...e.profile, isChild: !!e.accompanyingAdultId, stats: e.stats })"
           />
         </EntryList>
       </div>
@@ -55,7 +55,7 @@
             :title-to="e.profile.slug ? profilePath(e.profile.slug) : undefined"
             :checked-in="e.checkedIn"
             :hours="e.hours"
-            :icons="iconsForEntry({ ...e.profile, stats: e.stats })"
+            :icons="iconsForEntry({ ...e.profile, isChild: !!e.accompanyingAdultId, stats: e.stats })"
             :allow-cancel="true"
             @cancel="log(`cancel: id=${e.id} &quot;${e.profile.name}&quot;`)"
           />

--- a/frontend/src/types/entry.ts
+++ b/frontend/src/types/entry.ts
@@ -4,6 +4,7 @@ export interface EntryProfileSummary {
   isMember: boolean
   cardStatus?: string
   isGroup: boolean
+  hasProfileWarning?: boolean
 }
 
 export interface EntrySessionSummary {

--- a/frontend/src/utils/tagIcons.test.ts
+++ b/frontend/src/utils/tagIcons.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { iconsForEntry } from './tagIcons'
+
+describe('iconsForEntry — isChild', () => {
+  it('shows child icon when isChild is true', () => {
+    const icons = iconsForEntry({ isChild: true })
+    expect(icons.some(i => i.alt === 'Child')).toBe(true)
+  })
+
+  it('omits child icon when isChild is absent', () => {
+    const icons = iconsForEntry({})
+    expect(icons.some(i => i.alt === 'Child')).toBe(false)
+  })
+
+  it('omits child icon when snapshot.isChild is set but isChild is not passed', () => {
+    const icons = iconsForEntry({ stats: { snapshot: { isChild: true } } })
+    expect(icons.some(i => i.alt === 'Child')).toBe(false)
+  })
+})
+
+describe('iconsForEntry — Profile Warning', () => {
+  it('shows Profile Warning badge when hasProfileWarning is true', () => {
+    const icons = iconsForEntry({ hasProfileWarning: true })
+    const w = icons.find(i => i.alt === 'Profile Warning')
+    expect(w).toBeDefined()
+    expect(w?.type).toBe('badge')
+  })
+
+  it('omits Profile Warning when hasProfileWarning is absent', () => {
+    const icons = iconsForEntry({})
+    expect(icons.some(i => i.alt === 'Profile Warning')).toBe(false)
+  })
+
+  it('omits Duplicate Warning — manual.duplicate no longer drives a warning icon', () => {
+    const icons = iconsForEntry({ stats: { manual: { duplicate: true } } })
+    expect(icons.some(i => i.alt === 'Duplicate Warning')).toBe(false)
+    expect(icons.some(i => i.alt === 'Profile Warning')).toBe(false)
+  })
+})

--- a/frontend/src/utils/tagIcons.ts
+++ b/frontend/src/utils/tagIcons.ts
@@ -29,7 +29,7 @@ export const TAG_ICONS: TagIcon[] = [
   { icon: 'badges/regular.svg',    alt: 'Regular',          type: 'tag' },
   { icon: 'badges/new.svg',        alt: 'New',              type: 'tag' },
   { icon: 'badges/nophoto.svg',    alt: 'No Photo',         type: 'tag', color: 'red' },
-  { icon: 'status/warning.svg',    alt: 'Duplicate Warning',type: 'tag', color: 'red' },
+  { icon: 'status/warning.svg',    alt: 'Profile Warning',  type: 'badge', color: 'red' },
 ]
 
 /** Tags shown in the entry icon picker (manual/operational only) */
@@ -43,6 +43,8 @@ interface EntryIconSource {
   isGroup?: boolean
   cardStatus?: string
   stats?: EntryStats
+  isChild?: boolean
+  hasProfileWarning?: boolean
 }
 
 /** Builds the full icon list for an entry: profile badges + stats snapshot + stats manual */
@@ -54,17 +56,19 @@ export function iconsForEntry(e: EntryIconSource): TagIcon[] {
   if (e.cardStatus === 'Accepted')  icons.push({ icon: 'badges/card.svg', alt: 'Benefits Card', type: 'badge' })
   if (e.cardStatus === 'Invited')   icons.push({ icon: 'badges/card.svg', alt: 'Card Invited', type: 'badge', color: 'orange' })
   if (e.isGroup) icons.push({ icon: 'badges/group.svg', alt: 'Group / Company', type: 'badge' })
+  if (e.hasProfileWarning) icons.push({ icon: 'status/warning.svg', alt: 'Profile Warning', type: 'badge', color: 'red' })
+
+  // Entry-level tag: child (live from accompanyingAdultId, not frozen snapshot)
+  if (e.isChild) icons.push({ icon: 'badges/child.svg', alt: 'Child', type: 'tag' })
 
   if (e.stats) {
     const { snapshot, manual } = e.stats
 
     // Snapshot: computed at session time
-    if (snapshot?.booking === 'New')     icons.push({ icon: 'badges/new.svg',      alt: 'New',              type: 'tag' })
-    if (snapshot?.booking === 'Regular') icons.push({ icon: 'badges/regular.svg',  alt: 'Regular',          type: 'tag' })
-    if (snapshot?.isChild)               icons.push({ icon: 'badges/child.svg',     alt: 'Child',            type: 'tag' })
-    if (manual?.duplicate)               icons.push({ icon: 'status/warning.svg',   alt: 'Duplicate Warning',type: 'tag', color: 'red' })
-    if (snapshot?.noPhoto)               icons.push({ icon: 'badges/nophoto.svg',   alt: 'No Photo',         type: 'tag', color: 'red' })
-    if (snapshot?.noConsent)             icons.push({ icon: 'badges/noconsent.svg', alt: 'No Consent',       type: 'tag', color: 'red' })
+    if (snapshot?.booking === 'New')     icons.push({ icon: 'badges/new.svg',      alt: 'New',      type: 'tag' })
+    if (snapshot?.booking === 'Regular') icons.push({ icon: 'badges/regular.svg',  alt: 'Regular',  type: 'tag' })
+    if (snapshot?.noPhoto)               icons.push({ icon: 'badges/nophoto.svg',   alt: 'No Photo', type: 'tag', color: 'red' })
+    if (snapshot?.noConsent)             icons.push({ icon: 'badges/noconsent.svg', alt: 'No Consent', type: 'tag', color: 'red' })
 
     // Dual-state tags: snapshot = available/qualified, manual = active on the day
     for (const tag of DUAL_STATE_TAGS) {

--- a/types/api-responses.ts
+++ b/types/api-responses.ts
@@ -159,6 +159,7 @@ export interface EntryResponse {
   isGroup: boolean;
   isMember: boolean;
   cardStatus?: string;
+  profileWarning?: boolean;
   count: number;
   hours: number;
   checkedIn: boolean;

--- a/types/entry-stats.ts
+++ b/types/entry-stats.ts
@@ -14,7 +14,7 @@ export interface EntryStatsSnapshot {
   booking?: 'New' | 'Regular';
   /** Profile is a group/company account */
   isGroup?: boolean;
-  /** Child entry (AccompanyingAdult set or #Child in Notes) */
+  /** Child entry (AccompanyingAdult set) */
   isChild?: boolean;
   /** Accepted Charity Membership record at session time */
   isMember?: boolean;


### PR DESCRIPTION
…ta for child icon

The "Duplicate Warning" icon (driven by manual.duplicate Eventbrite tag) is replaced by a "Profile Warning" badge driven by profile.stats.warnings — the backend now surfaces this as a boolean (profileWarning) on each entry response so entries carry only what they need: whether a warning exists, not its content.

The child icon moves from snapshot.isChild (frozen at stats-compute time) to entry.accompanyingAdultId directly — the authoritative live field — via a new isChild param on EntryIconSource. Profile Warning is type 'badge' so it is automatically filtered out on the profile page where warnings are already shown.

Adds tagIcons.test.ts covering both new behaviours and regression-guarding the removed snapshot/manual.duplicate paths.