### PR TITLE
feat: use EventbriteAttendeeID as source of truth for Eventbrite icon

### DIFF
--- a/backend/middleware/require-admin.ts
+++ b/backend/middleware/require-admin.ts
@@ -10,7 +10,6 @@ const CHECKIN_ALLOWED_PATTERNS = [
   { method: 'POST',  pattern: /^\/sessions\/[^/]+\/[^/]+\/entries$/ }, // add entry
   { method: 'POST',  pattern: /^\/sessions\/[^/]+\/[^/]+\/refresh$/ }, // refresh session
   { method: 'POST',  pattern: /^\/sessions\/[^/]+\/[^/]+\/stats$/ },   // recompute session stats
-  { method: 'POST',  pattern: /^\/eventbrite\/quick-sync$/ },        // lightweight Eventbrite sync
   { method: 'DELETE', pattern: /^\/sessions\/[^/]+\/[^/]+\/unchecked-entries$/ }, // remove no-shows
   { method: 'POST',  pattern: /^\/profiles$/ },               // create profile
   { method: 'PATCH', pattern: /^\/profiles\/[^/]+$/ },        // edit profile

--- a/backend/routes/entries.ts
+++ b/backend/routes/entries.ts
@@ -26,7 +26,7 @@ import {
   GROUP_LOOKUP, GROUP_DISPLAY,
   SESSION_LOOKUP,
   SESSION_STATS,
-  PROFILE_LOOKUP, PROFILE_DISPLAY,
+  PROFILE_LOOKUP, PROFILE_DISPLAY, PROFILE_STATS,
   ENTRY_CANCELLED,
   ENTRY_STATS,
   ENTRY_EVENTBRITE_ATTENDEE_ID,
@@ -34,7 +34,7 @@ import {
 } from '../services/field-names';
 import { computeAndSaveEntryStats, runEntryStatsRefresh } from '../services/entry-stats';
 import { parseEntryStatsField } from '../services/data-layer';
-import { getAttendees } from '../services/eventbrite-client';
+import { getAttendees, getCancelledAttendees } from '../services/eventbrite-client';
 import { sendEmail } from '../services/graph-mail';
 import { renderEmail } from '../services/email-renderer';
 import { buildPreSessionVars, buildPostSessionVars } from '../services/email-vars';
@@ -94,15 +94,17 @@ router.get('/entries/recent', async (req: Request, res: Response) => {
     const cutoff = new Date(Date.now() - hours * 60 * 60 * 1000);
 
     // Fetch both recently created entries and recently cancelled entries in parallel
-    const [rawRecent, rawCancelled, rawSessions, rawGroups] = await Promise.all([
+    const [rawRecent, rawCancelled, rawSessions, rawGroups, rawProfiles] = await Promise.all([
       entriesRepository.getRecent(cutoff),
       entriesRepository.getRecentlyCancelled(cutoff),
       sessionsRepository.getAll(),
-      groupsRepository.getAll()
+      groupsRepository.getAll(),
+      profilesRepository.getAll(),
     ]);
 
     const sessionMap = new Map(rawSessions.map(s => [s.ID, s]));
     const groupMap = new Map(rawGroups.map(g => [g.ID, g]));
+    const profileMap = new Map(rawProfiles.map((p: any) => [p.ID, p]));
 
     // Merge, deduplicate by ID (an entry could appear in both if cancelled after being recently created)
     const seenIds = new Set<number>();
@@ -136,6 +138,8 @@ router.get('/entries/recent', async (req: Request, res: Response) => {
         const name = e[PROFILE_DISPLAY] || 'Unknown';
         const vid = safeParseLookupId(e[PROFILE_LOOKUP]);
         const slug = vid !== undefined ? profileSlug(name, vid) : undefined;
+        const profile = vid !== undefined ? profileMap.get(vid) : undefined;
+        const profileStats = JSON.parse(profile?.[PROFILE_STATS] || '{}');
         return [{
           id: e.ID,
           volunteerName: name,
@@ -147,8 +151,14 @@ router.get('/entries/recent', async (req: Request, res: Response) => {
           checkedIn: e.Checked || false,
           hours: parseHours(e.Hours),
           count: e.Count || 1,
+          isGroup: profile?.IsGroup || false,
+          isMember: profileStats.isMember === true,
+          cardStatus: profileStats.cardStatus ?? undefined,
+          hasProfileWarning: profileStats.warnings?.length ? true : undefined,
           accompanyingAdultId: safeParseLookupId(e.AccompanyingAdultLookupId),
-          cancelled: e.Cancelled || undefined
+          cancelled: e.Cancelled || undefined,
+          stats: parseEntryStatsField(e[ENTRY_STATS]),
+          eventbriteAttendeeId: e[ENTRY_EVENTBRITE_ATTENDEE_ID] || undefined,
         }];
       });
 
@@ -222,6 +232,7 @@ router.get('/entries', async (req: Request, res: Response) => {
         const profileId = safeParseLookupId(e[PROFILE_LOOKUP]);
         if (filterProfileId !== null && profileId !== filterProfileId) return [];
         const profile = profileId !== undefined ? profileMap.get(profileId) : undefined;
+        const profileStats = JSON.parse(profile?.[PROFILE_STATS] || '{}');
         const name = e[PROFILE_DISPLAY] || 'Unknown';
         const slug = profileId !== undefined ? profileSlug(name, profileId) : undefined;
 
@@ -238,6 +249,9 @@ router.get('/entries', async (req: Request, res: Response) => {
           hours: parseHours(e.Hours),
           count: e.Count || 1,
           isGroup: profile?.IsGroup || false,
+          isMember: profileStats.isMember === true,
+          cardStatus: profileStats.cardStatus ?? undefined,
+          hasProfileWarning: profileStats.warnings?.length ? true : undefined,
           hasAccompanyingAdult: hasAdult,
           accompanyingAdultId: safeParseLookupId(e.AccompanyingAdultLookupId),
           cancelled: e.Cancelled || undefined,
@@ -715,13 +729,16 @@ router.post('/sessions/:group/:date/refresh', async (req: Request, res: Response
 
     // Step 2: Sync Eventbrite attendees (if session has an Eventbrite ID)
     if (spSession.EventbriteEventID) {
-      const attendees = await getAttendees(spSession.EventbriteEventID);
-      console.log(`[Refresh] Session ${spSession.ID} (${spSession.EventbriteEventID}): ${attendees.length} attendees`);
+      const [attendees, cancelledAttendees] = await Promise.all([
+        getAttendees(spSession.EventbriteEventID),
+        getCancelledAttendees(spSession.EventbriteEventID),
+      ]);
+      console.log(`[Refresh] Session ${spSession.ID} (${spSession.EventbriteEventID}): ${attendees.length} attendees, ${cancelledAttendees.length} cancelled`);
 
       // Re-fetch so syncAttendeesForSession sees regulars added in Step 1
       const freshForEB = await entriesRepository.getBySessionIds([spSession.ID]);
       const ebResult = await syncAttendeesForSession(
-        spSession.ID, attendees, validateArray(freshForEB, validateEntry, 'Entry'), profiles, rawRecords, new Map()
+        spSession.ID, attendees, validateArray(freshForEB, validateEntry, 'Entry'), profiles, rawRecords, new Map(), cancelledAttendees
       );
       addedFromEventbrite += ebResult.newEntries;
       newProfiles += ebResult.newProfiles;

--- a/backend/routes/entries.ts
+++ b/backend/routes/entries.ts
@@ -718,8 +718,10 @@ router.post('/sessions/:group/:date/refresh', async (req: Request, res: Response
       const attendees = await getAttendees(spSession.EventbriteEventID);
       console.log(`[Refresh] Session ${spSession.ID} (${spSession.EventbriteEventID}): ${attendees.length} attendees`);
 
+      // Re-fetch so syncAttendeesForSession sees regulars added in Step 1
+      const freshForEB = await entriesRepository.getBySessionIds([spSession.ID]);
       const ebResult = await syncAttendeesForSession(
-        spSession.ID, attendees, sessionEntries, profiles, rawRecords, new Map()
+        spSession.ID, attendees, validateArray(freshForEB, validateEntry, 'Entry'), profiles, rawRecords, new Map()
       );
       addedFromEventbrite += ebResult.newEntries;
       newProfiles += ebResult.newProfiles;

--- a/backend/routes/entries.ts
+++ b/backend/routes/entries.ts
@@ -21,7 +21,7 @@ import {
   parseEmails,
   calculateSessionStats
 } from '../services/data-layer';
-import { isFirstSession, addSessionToProfileStats, findOrCreateProfile, upsertConsentRecords } from '../services/eventbrite-sync';
+import { syncAttendeesForSession } from '../services/eventbrite-sync';
 import {
   GROUP_LOOKUP, GROUP_DISPLAY,
   SESSION_LOOKUP,
@@ -29,6 +29,7 @@ import {
   PROFILE_LOOKUP, PROFILE_DISPLAY,
   ENTRY_CANCELLED,
   ENTRY_STATS,
+  ENTRY_EVENTBRITE_ATTENDEE_ID,
   ACCOMPANYING_ADULT_LOOKUP
 } from '../services/field-names';
 import { computeAndSaveEntryStats, runEntryStatsRefresh } from '../services/entry-stats';
@@ -240,7 +241,8 @@ router.get('/entries', async (req: Request, res: Response) => {
           hasAccompanyingAdult: hasAdult,
           accompanyingAdultId: safeParseLookupId(e.AccompanyingAdultLookupId),
           cancelled: e.Cancelled || undefined,
-          stats: parseEntryStatsField(e[ENTRY_STATS])
+          stats: parseEntryStatsField(e[ENTRY_STATS]),
+          eventbriteAttendeeId: e[ENTRY_EVENTBRITE_ATTENDEE_ID] || undefined,
         }];
       })
       .sort((a, b) => b.date.localeCompare(a.date));
@@ -716,35 +718,12 @@ router.post('/sessions/:group/:date/refresh', async (req: Request, res: Response
       const attendees = await getAttendees(spSession.EventbriteEventID);
       console.log(`[Refresh] Session ${spSession.ID} (${spSession.EventbriteEventID}): ${attendees.length} attendees`);
 
-      for (const attendee of attendees) {
-        const attendeeName = attendee.profile?.name;
-        const attendeeEmail = attendee.profile?.email;
-        if (!attendeeName) continue;
-
-        const { profile, isNew, clash } = await findOrCreateProfile(attendeeName, attendeeEmail, profiles, 'Refresh');
-        if (isNew) newProfiles++;
-
-        // Create entry if not already registered
-        const profileId = profile.ID;
-        if (!existingVolunteerIds.has(profileId)) {
-          const noteTags: string[] = [];
-          if (isFirstSession(profile, spSession.ID)) noteTags.push('#New');
-          if (attendee.ticket_class_name?.toLowerCase().includes('child')) noteTags.push('#Child');
-          noteTags.push('#Eventbrite');
-          if (clash) noteTags.push('#Duplicate');
-          await entriesRepository.create({
-            [SESSION_LOOKUP]: String(spSession.ID),
-            [PROFILE_LOOKUP]: String(profileId),
-            Notes: noteTags.join(' ')
-          });
-          existingVolunteerIds.add(profileId);
-          addedFromEventbrite++;
-        }
-
-        // Upsert consent records from Eventbrite answers
-        const { created, updated } = await upsertConsentRecords(profileId, attendee, rawRecords);
-        updatedRecords += created + updated;
-      }
+      const ebResult = await syncAttendeesForSession(
+        spSession.ID, attendees, sessionEntries, profiles, rawRecords, new Map()
+      );
+      addedFromEventbrite += ebResult.newEntries;
+      newProfiles += ebResult.newProfiles;
+      updatedRecords += ebResult.newRecords + ebResult.updatedRecords;
     }
 
     // Step 3: Tag #NoPhoto on entries where volunteer lacks photo consent
@@ -757,10 +736,14 @@ router.post('/sessions/:group/:date/refresh', async (req: Request, res: Response
       }
     }
 
-    // Re-fetch entries since steps 1+2 may have added new ones
+    // Re-fetch entries since steps 1+2 may have added new ones; rebuild volunteer ID set for stats
     const freshEntries = await entriesRepository.getAll();
     const freshValidEntries = validateArray(freshEntries, validateEntry, 'Entry');
     sessionEntries = freshValidEntries.filter(e => safeParseLookupId(e[SESSION_LOOKUP]) === spSession.ID);
+    for (const e of sessionEntries) {
+      const vid = safeParseLookupId(e[PROFILE_LOOKUP]);
+      if (vid !== undefined) existingVolunteerIds.add(vid);
+    }
 
     for (const entry of sessionEntries) {
       const vid = safeParseLookupId(entry[PROFILE_LOOKUP]);

--- a/backend/routes/eventbrite.ts
+++ b/backend/routes/eventbrite.ts
@@ -5,10 +5,10 @@ import { entriesRepository } from '../services/repositories/entries-repository';
 import { profilesRepository } from '../services/repositories/profiles-repository';
 import { recordsRepository } from '../services/repositories/records-repository';
 import { regularsRepository } from '../services/repositories/regulars-repository';
-import { validateArray, validateSession, validateEntry, validateProfile, validateGroup, safeParseLookupId, toMatchName } from '../services/data-layer';
+import { validateArray, validateSession, validateEntry, validateProfile, validateGroup, safeParseLookupId } from '../services/data-layer';
 import { GROUP_LOOKUP, SESSION_LOOKUP, PROFILE_LOOKUP, ENTRY_CANCELLED, ENTRY_EVENTBRITE_ATTENDEE_ID } from '../services/field-names';
 import { getAttendees, getOrgAttendees, getOrgEvents, getEventConfigCheck, getCancelledAttendees, EventbriteConfigCheck } from '../services/eventbrite-client';
-import { syncAttendeesForSession, findProfileByAttendee } from '../services/eventbrite-sync';
+import { syncAttendeesForSession } from '../services/eventbrite-sync';
 import { computeAndSaveProfileStats } from '../services/profile-stats';
 import { runSessionStatsRefresh } from '../services/session-stats';
 import { runProfileStatsRefresh } from '../services/profile-stats';
@@ -140,24 +140,16 @@ async function runSyncAttendees(): Promise<SyncAttendeesResult> {
     if (cancelledAttendees.length > 0) {
       console.log(`[Eventbrite Sync] Session ${session.ID}: ${cancelledAttendees.length} cancelled attendees to check`);
 
-      // Primary: match by EventbriteAttendeeID; fallback: name match via findProfileByAttendee
       const entryByAttendeeId = new Map<string, { id: number; profileId: number; alreadyCancelled: boolean }>();
-      const entryByProfileId = new Map<number, { id: number; profileId: number; alreadyCancelled: boolean }>();
       for (const entry of sessionEntries) {
         const pid = safeParseLookupId(entry[PROFILE_LOOKUP]);
         if (pid === undefined) continue;
-        const info = { id: entry.ID, profileId: pid, alreadyCancelled: !!entry[ENTRY_CANCELLED] };
-        if (entry[ENTRY_EVENTBRITE_ATTENDEE_ID]) entryByAttendeeId.set(entry[ENTRY_EVENTBRITE_ATTENDEE_ID], info);
-        entryByProfileId.set(pid, info);
+        if (entry[ENTRY_EVENTBRITE_ATTENDEE_ID])
+          entryByAttendeeId.set(entry[ENTRY_EVENTBRITE_ATTENDEE_ID], { id: entry.ID, profileId: pid, alreadyCancelled: !!entry[ENTRY_CANCELLED] });
       }
 
       for (const attendee of cancelledAttendees) {
-        let entryInfo = entryByAttendeeId.get(attendee.id);
-        if (!entryInfo) {
-          // Fallback for pre-backfill entries without EventbriteAttendeeID
-          const profile = findProfileByAttendee(attendee, profiles);
-          if (profile) entryInfo = entryByProfileId.get(profile.ID);
-        }
+        const entryInfo = entryByAttendeeId.get(attendee.id);
         if (!entryInfo || entryInfo.alreadyCancelled) continue;
 
         await entriesRepository.updateFields(entryInfo.id, { [ENTRY_CANCELLED]: new Date().toISOString() });
@@ -450,71 +442,6 @@ router.post('/eventbrite/quick-sync', async (req: Request, res: Response) => {
     res.status(500).json({ success: false, error: error.message || 'Quick sync failed' });
   } finally {
     syncInProgress = false;
-  }
-});
-
-// One-time backfill: write EventbriteAttendeeID onto existing entries across all Eventbrite sessions.
-// Responds immediately and runs in the background — check server logs for progress and final count.
-// Safe to run multiple times — skips entries that already have the ID set.
-router.post('/eventbrite/backfill-attendee-ids', async (req: Request, res: Response) => {
-  try {
-    const [sessionsRaw, entriesRaw, profilesRaw] = await Promise.all([
-      sessionsRepository.getAll(),
-      entriesRepository.getAll(),
-      profilesRepository.getAll(),
-    ]);
-
-    const sessions = validateArray(sessionsRaw, validateSession, 'Session');
-    const entries = validateArray(entriesRaw, validateEntry, 'Entry');
-    const profiles = validateArray(profilesRaw, validateProfile, 'Profile');
-
-    const eventbriteSessions = sessions.filter(s => s.EventbriteEventID);
-    console.log(`[Backfill] Starting — ${eventbriteSessions.length} Eventbrite sessions to check`);
-
-    // Respond immediately; process in background so the request doesn't time out
-    res.json({ success: true, data: { message: `Backfill started for ${eventbriteSessions.length} sessions — check server logs for result` } });
-
-    let updated = 0;
-    let skipped = 0;
-    let sessionsProcessed = 0;
-
-    for (const session of eventbriteSessions) {
-      const sessionEntries = entries.filter(e =>
-        safeParseLookupId(e[SESSION_LOOKUP]) === session.ID &&
-        !e[ENTRY_EVENTBRITE_ATTENDEE_ID]
-      );
-
-      if (!sessionEntries.length) continue;
-
-      const attendees = await getAttendees(session.EventbriteEventID!);
-      sessionsProcessed++;
-
-      for (const entry of sessionEntries) {
-        const profileId = safeParseLookupId(entry[PROFILE_LOOKUP]);
-        if (profileId === undefined) { skipped++; continue; }
-        const profile = profiles.find(p => p.ID === profileId);
-        if (!profile) { skipped++; continue; }
-
-        const profileNameKey = toMatchName(profile.Title || '');
-        const profileMatchKey = toMatchName(profile.MatchName || '');
-        const matched = attendees.find(a => {
-          if (!a.profile?.name) return false;
-          const nameKey = toMatchName(a.profile.name);
-          return nameKey === profileNameKey || (profileMatchKey && nameKey === profileMatchKey);
-        });
-
-        if (matched) {
-          await entriesRepository.updateFields(entry.ID, { [ENTRY_EVENTBRITE_ATTENDEE_ID]: matched.id });
-          updated++;
-        } else {
-          skipped++;
-        }
-      }
-    }
-
-    console.log(`[Backfill] Done — ${sessionsProcessed} sessions fetched from Eventbrite, ${updated} entries updated, ${skipped} skipped`);
-  } catch (error: any) {
-    console.error('[Backfill] Error:', error);
   }
 });
 

--- a/backend/routes/eventbrite.ts
+++ b/backend/routes/eventbrite.ts
@@ -6,10 +6,9 @@ import { profilesRepository } from '../services/repositories/profiles-repository
 import { recordsRepository } from '../services/repositories/records-repository';
 import { regularsRepository } from '../services/repositories/regulars-repository';
 import { validateArray, validateSession, validateEntry, validateProfile, validateGroup, safeParseLookupId } from '../services/data-layer';
-import { GROUP_LOOKUP, SESSION_LOOKUP, PROFILE_LOOKUP, ENTRY_CANCELLED, ENTRY_EVENTBRITE_ATTENDEE_ID } from '../services/field-names';
-import { getAttendees, getOrgAttendees, getOrgEvents, getEventConfigCheck, getCancelledAttendees, EventbriteConfigCheck } from '../services/eventbrite-client';
+import { GROUP_LOOKUP, SESSION_LOOKUP } from '../services/field-names';
+import { getAttendees, getOrgEvents, getEventConfigCheck, getCancelledAttendees, EventbriteConfigCheck } from '../services/eventbrite-client';
 import { syncAttendeesForSession } from '../services/eventbrite-sync';
-import { computeAndSaveProfileStats } from '../services/profile-stats';
 import { runSessionStatsRefresh } from '../services/session-stats';
 import { runProfileStatsRefresh } from '../services/profile-stats';
 import { runEntryStatsRefresh } from '../services/entry-stats';
@@ -127,38 +126,16 @@ async function runSyncAttendees(): Promise<SyncAttendeesResult> {
     console.log(`[Eventbrite Sync] Session ${session.ID} (${session.EventbriteEventID}): ${attendees.length} attendees`);
 
     const sessionEntries = entries.filter(e => safeParseLookupId(e[SESSION_LOOKUP]) === session.ID);
+    const cancelledAttendees = await getCancelledAttendees(session.EventbriteEventID!);
+    if (cancelledAttendees.length > 0)
+      console.log(`[Eventbrite Sync] Session ${session.ID}: ${cancelledAttendees.length} cancelled attendees to check`);
 
-    const result = await syncAttendeesForSession(session.ID, attendees, sessionEntries, profiles, allRecords, sessionDateMap);
+    const result = await syncAttendeesForSession(session.ID, attendees, sessionEntries, profiles, allRecords, sessionDateMap, cancelledAttendees);
     newProfiles += result.newProfiles;
     newEntries += result.newEntries;
     newRecords += result.newRecords;
     updatedRecords += result.updatedRecords;
-
-    // Cancellation — skip if no entries exist for this session
-    if (!sessionEntries.length) continue;
-    const cancelledAttendees = await getCancelledAttendees(session.EventbriteEventID!);
-    if (cancelledAttendees.length > 0) {
-      console.log(`[Eventbrite Sync] Session ${session.ID}: ${cancelledAttendees.length} cancelled attendees to check`);
-
-      const entryByAttendeeId = new Map<string, { id: number; profileId: number; alreadyCancelled: boolean }>();
-      for (const entry of sessionEntries) {
-        const pid = safeParseLookupId(entry[PROFILE_LOOKUP]);
-        if (pid === undefined) continue;
-        if (entry[ENTRY_EVENTBRITE_ATTENDEE_ID])
-          entryByAttendeeId.set(entry[ENTRY_EVENTBRITE_ATTENDEE_ID], { id: entry.ID, profileId: pid, alreadyCancelled: !!entry[ENTRY_CANCELLED] });
-      }
-
-      for (const attendee of cancelledAttendees) {
-        const entryInfo = entryByAttendeeId.get(attendee.id);
-        if (!entryInfo || entryInfo.alreadyCancelled) continue;
-
-        await entriesRepository.updateFields(entryInfo.id, { [ENTRY_CANCELLED]: new Date().toISOString() });
-        computeAndSaveProfileStats(entryInfo.profileId).catch(err =>
-          console.error('[Eventbrite Sync] computeAndSaveProfileStats failed for profile', entryInfo!.profileId, err)
-        );
-        cancelledEntries++;
-      }
-    }
+    cancelledEntries += result.cancelledEntries;
   }
 
   console.log(`[Eventbrite Sync] Done: ${liveSessions.length} sessions, ${newProfiles} new profiles, ${newEntries} new entries, ${cancelledEntries} cancelled, ${newRecords} new records, ${updatedRecords} updated records`);
@@ -350,98 +327,6 @@ router.get('/eventbrite/event-config-check', async (req: Request, res: Response)
   } catch (error: any) {
     console.error('Error checking event config:', error);
     res.status(500).json({ success: false, error: error.message || 'Failed to check event config' });
-  }
-});
-
-// Lightweight sync for recent Eventbrite registrations. Uses changed_since to fetch only
-// attendees modified in the given time window — most sessions return empty, keeping this fast.
-// #New tag is omitted: determining first-ever attendance requires a global entries snapshot.
-// The full daily sync (event-and-attendee-update) applies #New correctly.
-router.post('/eventbrite/quick-sync', async (req: Request, res: Response) => {
-  if (syncInProgress) {
-    res.status(409).json({ success: false, error: 'Sync already in progress' });
-    return;
-  }
-  syncInProgress = true;
-  try {
-    const sinceHours: Record<string, number> = { '24h': 24, '48h': 48, '7d': 168 };
-    const hours = sinceHours[String(req.query.since)] ?? 24;
-    const changedSince = new Date(Date.now() - hours * 60 * 60 * 1000);
-
-    const [rawSessions, rawProfiles] = await Promise.all([
-      sessionsRepository.getAll(),
-      profilesRepository.getAll(),
-    ]);
-
-    const sessions = validateArray(rawSessions, validateSession, 'Session');
-    const profiles = validateArray(rawProfiles, validateProfile, 'Profile');
-
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-    const liveSessions = sessions.filter(s => {
-      if (!s.EventbriteEventID || !s.Date) return false;
-      const d = new Date(s.Date);
-      d.setHours(0, 0, 0, 0);
-      return d >= today;
-    });
-
-    // Single org-wide call — skips all per-session Eventbrite calls
-    const recentAttendees = await getOrgAttendees(changedSince);
-    if (!recentAttendees.length) {
-      console.log(`[QuickSync] No changed attendees in window — skipping`);
-      res.json({ success: true, data: { added: 0, sessionsChecked: 0 } });
-      return;
-    }
-
-    // Group by Eventbrite event ID so we can look up per session below
-    const attendeesByEventId = new Map<string, typeof recentAttendees>();
-    for (const a of recentAttendees) {
-      if (!a.event_id) continue;
-      if (!attendeesByEventId.has(a.event_id)) attendeesByEventId.set(a.event_id, []);
-      attendeesByEventId.get(a.event_id)!.push(a);
-    }
-
-    const allRecords = recordsRepository.available ? await recordsRepository.getAll() : [];
-
-    // Fetch entries once; index per session for syncAttendeesForSession
-    const allEntriesRaw = await entriesRepository.getAll();
-    const allEntries = validateArray(allEntriesRaw, validateEntry, 'Entry');
-    const entriesBySession = new Map<number, typeof allEntries>();
-    for (const e of allEntries) {
-      const sId = safeParseLookupId(e[SESSION_LOOKUP]);
-      if (sId === undefined) continue;
-      if (!entriesBySession.has(sId)) entriesBySession.set(sId, []);
-      entriesBySession.get(sId)!.push(e);
-    }
-
-    let added = 0;
-
-    for (const session of liveSessions) {
-      const attendees = attendeesByEventId.get(session.EventbriteEventID!) ?? [];
-      if (!attendees.length) continue;
-
-      console.log(`[QuickSync] Session ${session.ID} (${session.EventbriteEventID}): ${attendees.length} new/changed attendees`);
-
-      const sessionEntries = entriesBySession.get(session.ID) ?? [];
-      // Pass empty sessionDateMap — quick sync doesn't track #New (entry-stats handles snapshot.booking)
-      const result = await syncAttendeesForSession(session.ID, attendees, sessionEntries, profiles, allRecords, new Map());
-      added += result.newEntries;
-    }
-
-    console.log(`[QuickSync] ${liveSessions.length} sessions checked, ${added} entries added`);
-
-    if (added > 0) {
-      await runProfileStatsRefresh();
-      await runEntryStatsRefresh();
-      await runSessionStatsRefresh();
-    }
-
-    res.json({ success: true, data: { added, sessionsChecked: liveSessions.length } });
-  } catch (error: any) {
-    console.error('Error in quick sync:', error);
-    res.status(500).json({ success: false, error: error.message || 'Quick sync failed' });
-  } finally {
-    syncInProgress = false;
   }
 });
 

--- a/backend/routes/eventbrite.ts
+++ b/backend/routes/eventbrite.ts
@@ -5,10 +5,10 @@ import { entriesRepository } from '../services/repositories/entries-repository';
 import { profilesRepository } from '../services/repositories/profiles-repository';
 import { recordsRepository } from '../services/repositories/records-repository';
 import { regularsRepository } from '../services/repositories/regulars-repository';
-import { validateArray, validateSession, validateEntry, validateProfile, validateGroup, safeParseLookupId } from '../services/data-layer';
-import { GROUP_LOOKUP, SESSION_LOOKUP, PROFILE_LOOKUP, ENTRY_CANCELLED } from '../services/field-names';
+import { validateArray, validateSession, validateEntry, validateProfile, validateGroup, safeParseLookupId, toMatchName } from '../services/data-layer';
+import { GROUP_LOOKUP, SESSION_LOOKUP, PROFILE_LOOKUP, ENTRY_CANCELLED, ENTRY_EVENTBRITE_ATTENDEE_ID } from '../services/field-names';
 import { getAttendees, getOrgAttendees, getOrgEvents, getEventConfigCheck, getCancelledAttendees, EventbriteConfigCheck } from '../services/eventbrite-client';
-import { isFirstSession, addSessionToProfileStats, findOrCreateProfile, findProfileByAttendee, upsertConsentRecords, bookingEmailFor, resolveAccompanyingAdult } from '../services/eventbrite-sync';
+import { syncAttendeesForSession, findProfileByAttendee } from '../services/eventbrite-sync';
 import { computeAndSaveProfileStats } from '../services/profile-stats';
 import { runSessionStatsRefresh } from '../services/session-stats';
 import { runProfileStatsRefresh } from '../services/profile-stats';
@@ -33,7 +33,6 @@ interface SyncAttendeesResult {
   newEntries: number;
   newRecords: number;
   updatedRecords: number;
-  duplicateWarnings: number;
   cancelledEntries: number;
 }
 
@@ -87,42 +86,31 @@ async function runSyncSessions(): Promise<SyncSessionsResult> {
 }
 
 async function runSyncAttendees(): Promise<SyncAttendeesResult> {
-  const [sessionsRaw, entriesRaw, profilesRaw, regularsRaw] = await Promise.all([
+  const [sessionsRaw, entriesRaw, profilesRaw] = await Promise.all([
     sessionsRepository.getAll(),
     entriesRepository.getAll(),
     profilesRepository.getAll(),
-    regularsRepository.getAll()
   ]);
 
   const sessions = validateArray(sessionsRaw, validateSession, 'Session');
   const entries = validateArray(entriesRaw, validateEntry, 'Entry');
   const profiles = validateArray(profilesRaw, validateProfile, 'Profile');
 
-  // Session date map for updating in-memory profile stats after entry creation
   const sessionDateMap = new Map<number, string>(
     sessions.map(s => [s.ID, (s.Date || '').substring(0, 10)])
   );
 
-  // Build set of groupId-profileId pairs for quick regular lookups
-  const regularSet = new Set<string>();
-  for (const r of regularsRaw) {
-    const gId = safeParseLookupId(r[GROUP_LOOKUP]);
-    const pId = safeParseLookupId(r[PROFILE_LOOKUP]);
-    if (gId !== undefined && pId !== undefined) regularSet.add(`${gId}-${pId}`);
-  }
-
-  // Find sessions with EventbriteEventID that are today or future
+  // Process sessions with Eventbrite IDs that are today or future, chronologically
   const today = new Date();
   today.setHours(0, 0, 0, 0);
-  const liveSessions = sessions.filter(s => {
-    if (!s.EventbriteEventID || !s.Date) return false;
-    const sessionDate = new Date(s.Date);
-    sessionDate.setHours(0, 0, 0, 0);
-    return sessionDate >= today;
-  });
-
-  // Process chronologically so earlier sessions are in the snapshot when later ones are checked
-  liveSessions.sort((a, b) => (a.Date || '').localeCompare(b.Date || ''));
+  const liveSessions = sessions
+    .filter(s => {
+      if (!s.EventbriteEventID || !s.Date) return false;
+      const d = new Date(s.Date);
+      d.setHours(0, 0, 0, 0);
+      return d >= today;
+    })
+    .sort((a, b) => (a.Date || '').localeCompare(b.Date || ''));
 
   console.log(`[Eventbrite Sync] ${liveSessions.length} live sessions with Eventbrite IDs`);
 
@@ -130,93 +118,59 @@ async function runSyncAttendees(): Promise<SyncAttendeesResult> {
   let newEntries = 0;
   let newRecords = 0;
   let updatedRecords = 0;
-  let duplicateWarnings = 0;
   let cancelledEntries = 0;
 
-  // Load existing records for upsert
   const allRecords = await recordsRepository.getAll();
 
   for (const session of liveSessions) {
     const attendees = await getAttendees(session.EventbriteEventID!);
     console.log(`[Eventbrite Sync] Session ${session.ID} (${session.EventbriteEventID}): ${attendees.length} attendees`);
 
-    // Get existing entry profile IDs for this session
     const sessionEntries = entries.filter(e => safeParseLookupId(e[SESSION_LOOKUP]) === session.ID);
-    const existingProfileIds = new Set(
-      sessionEntries.map(e => safeParseLookupId(e[PROFILE_LOOKUP])).filter(id => id !== undefined)
-    );
 
-    for (const attendee of attendees) {
-      const attendeeName = attendee.profile?.name;
-      const attendeeEmail = attendee.profile?.email;
-      if (!attendeeName) continue;
+    const result = await syncAttendeesForSession(session.ID, attendees, sessionEntries, profiles, allRecords, sessionDateMap);
+    newProfiles += result.newProfiles;
+    newEntries += result.newEntries;
+    newRecords += result.newRecords;
+    updatedRecords += result.updatedRecords;
 
-      const { profile, isNew, clash } = await findOrCreateProfile(attendeeName, attendeeEmail, profiles, 'Eventbrite Sync');
-      if (isNew) newProfiles++;
-      if (clash) duplicateWarnings++;
-
-      // Create entry if not already registered
-      const profileId = profile.ID;
-      if (!existingProfileIds.has(profileId)) {
-        const isChild = !!attendee.ticket_class_name?.toLowerCase().includes('child');
-        const entryFields: Record<string, any> = {
-          [SESSION_LOOKUP]: String(session.ID),
-          [PROFILE_LOOKUP]: String(profileId),
-          BookedBy: bookingEmailFor(attendee)
-        };
-        if (isChild && attendee.order_id) {
-          const adultProfile = resolveAccompanyingAdult(attendees, attendee.order_id, profiles);
-          if (adultProfile) entryFields.AccompanyingAdultLookupId = adultProfile.ID;
-        }
-        const newEntryId = await entriesRepository.create(entryFields);
-        const manual: Record<string, boolean> = { eventbrite: true };
-        if (clash) manual.duplicate = true;
-        await entriesRepository.updateStats(newEntryId, { manual });
-        existingProfileIds.add(profileId);
-        // Update in-memory profile stats so subsequent sessions in this batch see this entry
-        addSessionToProfileStats(profile, session.ID, sessionDateMap);
-        newEntries++;
-      }
-
-      // Upsert consent records from Eventbrite answers
-      const { created, updated } = await upsertConsentRecords(profileId, attendee, allRecords);
-      newRecords += created;
-      updatedRecords += updated;
-    }
-
-    // Cancellation step — skip if no entries exist for this session (nothing to cancel)
+    // Cancellation — skip if no entries exist for this session
     if (!sessionEntries.length) continue;
     const cancelledAttendees = await getCancelledAttendees(session.EventbriteEventID!);
     if (cancelledAttendees.length > 0) {
       console.log(`[Eventbrite Sync] Session ${session.ID}: ${cancelledAttendees.length} cancelled attendees to check`);
 
-      // Build map of profileId → entry for quick lookup
-      const entryByProfile = new Map<number, { id: number; alreadyCancelled: boolean }>();
+      // Primary: match by EventbriteAttendeeID; fallback: name match via findProfileByAttendee
+      const entryByAttendeeId = new Map<string, { id: number; profileId: number; alreadyCancelled: boolean }>();
+      const entryByProfileId = new Map<number, { id: number; profileId: number; alreadyCancelled: boolean }>();
       for (const entry of sessionEntries) {
         const pid = safeParseLookupId(entry[PROFILE_LOOKUP]);
-        if (pid !== undefined) {
-          entryByProfile.set(pid, { id: entry.ID, alreadyCancelled: !!entry[ENTRY_CANCELLED] });
-        }
+        if (pid === undefined) continue;
+        const info = { id: entry.ID, profileId: pid, alreadyCancelled: !!entry[ENTRY_CANCELLED] };
+        if (entry[ENTRY_EVENTBRITE_ATTENDEE_ID]) entryByAttendeeId.set(entry[ENTRY_EVENTBRITE_ATTENDEE_ID], info);
+        entryByProfileId.set(pid, info);
       }
 
       for (const attendee of cancelledAttendees) {
-        const profile = findProfileByAttendee(attendee, profiles);
-        if (!profile) continue;
-
-        const entryInfo = entryByProfile.get(profile.ID);
+        let entryInfo = entryByAttendeeId.get(attendee.id);
+        if (!entryInfo) {
+          // Fallback for pre-backfill entries without EventbriteAttendeeID
+          const profile = findProfileByAttendee(attendee, profiles);
+          if (profile) entryInfo = entryByProfileId.get(profile.ID);
+        }
         if (!entryInfo || entryInfo.alreadyCancelled) continue;
 
         await entriesRepository.updateFields(entryInfo.id, { [ENTRY_CANCELLED]: new Date().toISOString() });
-        computeAndSaveProfileStats(profile.ID).catch(err =>
-          console.error('[Eventbrite Sync] computeAndSaveProfileStats failed for profile', profile.ID, err)
+        computeAndSaveProfileStats(entryInfo.profileId).catch(err =>
+          console.error('[Eventbrite Sync] computeAndSaveProfileStats failed for profile', entryInfo!.profileId, err)
         );
         cancelledEntries++;
       }
     }
   }
 
-  console.log(`[Eventbrite Sync] Done: ${liveSessions.length} sessions, ${newProfiles} new profiles, ${newEntries} new entries, ${cancelledEntries} cancelled, ${newRecords} new records, ${updatedRecords} updated records, ${duplicateWarnings} duplicate warnings`);
-  return { sessionsProcessed: liveSessions.length, newProfiles, newEntries, newRecords, updatedRecords, duplicateWarnings, cancelledEntries };
+  console.log(`[Eventbrite Sync] Done: ${liveSessions.length} sessions, ${newProfiles} new profiles, ${newEntries} new entries, ${cancelledEntries} cancelled, ${newRecords} new records, ${updatedRecords} updated records`);
+  return { sessionsProcessed: liveSessions.length, newProfiles, newEntries, newRecords, updatedRecords, cancelledEntries };
 }
 
 const WARMUP_KEYS = ['groups', 'sessions', 'profiles', 'regulars'] as const;
@@ -266,7 +220,7 @@ async function handleNightlyUpdate(req: Request, res: Response): Promise<void> {
     const entryIdsStr = entryStatsResult.updatedIds.length ? ` (${entryStatsResult.updatedIds.join(', ')})` : '';
     const parts = [
       `${sessionResult.totalEvents} events, ${sessionResult.matchedEvents} matched, ${sessionResult.newSessions} new sessions / ${attendeeResult.sessionsProcessed} sessions`,
-      `${attendeeResult.newProfiles} new profiles, ${attendeeResult.newEntries} new entries, ${attendeeResult.cancelledEntries} cancelled, ${attendeeResult.newRecords} new consent records, ${attendeeResult.updatedRecords} updated consent records${attendeeResult.duplicateWarnings ? `, ${attendeeResult.duplicateWarnings} duplicate warning(s) — check session entries` : ''}`,
+      `${attendeeResult.newProfiles} new profiles, ${attendeeResult.newEntries} new entries, ${attendeeResult.cancelledEntries} cancelled, ${attendeeResult.newRecords} new consent records, ${attendeeResult.updatedRecords} updated consent records`,
       `Profile stats: ${profileStatsResult.updated}/${profileStatsResult.total} updated${profileStatsResult.errors.length ? `, ${profileStatsResult.errors.length} error(s)` : ''}${profileIdsStr}`,
       `Entry stats: ${entryStatsResult.updated}/${entryStatsResult.total} updated${entryStatsResult.errors.length ? `, ${entryStatsResult.errors.length} error(s)` : ''}${entryIdsStr}`,
       `Session stats: ${sessionStatsResult.updated}/${sessionStatsResult.total} updated${sessionStatsResult.errors.length ? `, ${sessionStatsResult.errors.length} error(s)` : ''}${sessionIdsStr}`,
@@ -422,21 +376,13 @@ router.post('/eventbrite/quick-sync', async (req: Request, res: Response) => {
     const hours = sinceHours[String(req.query.since)] ?? 24;
     const changedSince = new Date(Date.now() - hours * 60 * 60 * 1000);
 
-    const [rawSessions, rawProfiles, regularsRaw] = await Promise.all([
+    const [rawSessions, rawProfiles] = await Promise.all([
       sessionsRepository.getAll(),
       profilesRepository.getAll(),
-      regularsRepository.getAll()
     ]);
 
     const sessions = validateArray(rawSessions, validateSession, 'Session');
     const profiles = validateArray(rawProfiles, validateProfile, 'Profile');
-
-    const regularSet = new Set<string>();
-    for (const r of regularsRaw) {
-      const gId = safeParseLookupId(r[GROUP_LOOKUP]);
-      const pId = safeParseLookupId(r[PROFILE_LOOKUP]);
-      if (gId !== undefined && pId !== undefined) regularSet.add(`${gId}-${pId}`);
-    }
 
     const today = new Date();
     today.setHours(0, 0, 0, 0);
@@ -465,16 +411,15 @@ router.post('/eventbrite/quick-sync', async (req: Request, res: Response) => {
 
     const allRecords = recordsRepository.available ? await recordsRepository.getAll() : [];
 
-    // Fetch entries once; build per-session profile sets for duplicate checking
+    // Fetch entries once; index per session for syncAttendeesForSession
     const allEntriesRaw = await entriesRepository.getAll();
     const allEntries = validateArray(allEntriesRaw, validateEntry, 'Entry');
-    const sessionProfileIds = new Map<number, Set<number>>();
+    const entriesBySession = new Map<number, typeof allEntries>();
     for (const e of allEntries) {
       const sId = safeParseLookupId(e[SESSION_LOOKUP]);
-      const pId = safeParseLookupId(e[PROFILE_LOOKUP]);
-      if (sId === undefined || pId === undefined) continue;
-      if (!sessionProfileIds.has(sId)) sessionProfileIds.set(sId, new Set());
-      sessionProfileIds.get(sId)!.add(pId);
+      if (sId === undefined) continue;
+      if (!entriesBySession.has(sId)) entriesBySession.set(sId, []);
+      entriesBySession.get(sId)!.push(e);
     }
 
     let added = 0;
@@ -485,40 +430,10 @@ router.post('/eventbrite/quick-sync', async (req: Request, res: Response) => {
 
       console.log(`[QuickSync] Session ${session.ID} (${session.EventbriteEventID}): ${attendees.length} new/changed attendees`);
 
-      const existingProfileIds = sessionProfileIds.get(session.ID) ?? new Set<number>();
-      if (!sessionProfileIds.has(session.ID)) sessionProfileIds.set(session.ID, existingProfileIds);
-
-      const sessionGroupId = safeParseLookupId(session[GROUP_LOOKUP]);
-
-      for (const attendee of attendees) {
-        const attendeeName = attendee.profile?.name;
-        const attendeeEmail = attendee.profile?.email;
-        if (!attendeeName) continue;
-
-        const { profile, clash } = await findOrCreateProfile(attendeeName, attendeeEmail, profiles, 'QuickSync');
-
-        if (!existingProfileIds.has(profile.ID)) {
-          const isChild = !!attendee.ticket_class_name?.toLowerCase().includes('child');
-          const entryFields: Record<string, any> = {
-            [SESSION_LOOKUP]: String(session.ID),
-            [PROFILE_LOOKUP]: String(profile.ID),
-            BookedBy: bookingEmailFor(attendee)
-          };
-          if (isChild && attendee.order_id) {
-            const sessionAttendees = attendeesByEventId.get(session.EventbriteEventID!) ?? [];
-            const adultProfile = resolveAccompanyingAdult(sessionAttendees, attendee.order_id, profiles);
-            if (adultProfile) entryFields.AccompanyingAdultLookupId = adultProfile.ID;
-          }
-          const newEntryId = await entriesRepository.create(entryFields);
-          const manual: Record<string, boolean> = { eventbrite: true };
-          if (clash) manual.duplicate = true;
-          await entriesRepository.updateStats(newEntryId, { manual });
-          existingProfileIds.add(profile.ID);
-          added++;
-        }
-
-        await upsertConsentRecords(profile.ID, attendee, allRecords);
-      }
+      const sessionEntries = entriesBySession.get(session.ID) ?? [];
+      // Pass empty sessionDateMap — quick sync doesn't track #New (entry-stats handles snapshot.booking)
+      const result = await syncAttendeesForSession(session.ID, attendees, sessionEntries, profiles, allRecords, new Map());
+      added += result.newEntries;
     }
 
     console.log(`[QuickSync] ${liveSessions.length} sessions checked, ${added} entries added`);
@@ -535,6 +450,71 @@ router.post('/eventbrite/quick-sync', async (req: Request, res: Response) => {
     res.status(500).json({ success: false, error: error.message || 'Quick sync failed' });
   } finally {
     syncInProgress = false;
+  }
+});
+
+// One-time backfill: write EventbriteAttendeeID onto existing entries across all Eventbrite sessions.
+// Responds immediately and runs in the background — check server logs for progress and final count.
+// Safe to run multiple times — skips entries that already have the ID set.
+router.post('/eventbrite/backfill-attendee-ids', async (req: Request, res: Response) => {
+  try {
+    const [sessionsRaw, entriesRaw, profilesRaw] = await Promise.all([
+      sessionsRepository.getAll(),
+      entriesRepository.getAll(),
+      profilesRepository.getAll(),
+    ]);
+
+    const sessions = validateArray(sessionsRaw, validateSession, 'Session');
+    const entries = validateArray(entriesRaw, validateEntry, 'Entry');
+    const profiles = validateArray(profilesRaw, validateProfile, 'Profile');
+
+    const eventbriteSessions = sessions.filter(s => s.EventbriteEventID);
+    console.log(`[Backfill] Starting — ${eventbriteSessions.length} Eventbrite sessions to check`);
+
+    // Respond immediately; process in background so the request doesn't time out
+    res.json({ success: true, data: { message: `Backfill started for ${eventbriteSessions.length} sessions — check server logs for result` } });
+
+    let updated = 0;
+    let skipped = 0;
+    let sessionsProcessed = 0;
+
+    for (const session of eventbriteSessions) {
+      const sessionEntries = entries.filter(e =>
+        safeParseLookupId(e[SESSION_LOOKUP]) === session.ID &&
+        !e[ENTRY_EVENTBRITE_ATTENDEE_ID]
+      );
+
+      if (!sessionEntries.length) continue;
+
+      const attendees = await getAttendees(session.EventbriteEventID!);
+      sessionsProcessed++;
+
+      for (const entry of sessionEntries) {
+        const profileId = safeParseLookupId(entry[PROFILE_LOOKUP]);
+        if (profileId === undefined) { skipped++; continue; }
+        const profile = profiles.find(p => p.ID === profileId);
+        if (!profile) { skipped++; continue; }
+
+        const profileNameKey = toMatchName(profile.Title || '');
+        const profileMatchKey = toMatchName(profile.MatchName || '');
+        const matched = attendees.find(a => {
+          if (!a.profile?.name) return false;
+          const nameKey = toMatchName(a.profile.name);
+          return nameKey === profileNameKey || (profileMatchKey && nameKey === profileMatchKey);
+        });
+
+        if (matched) {
+          await entriesRepository.updateFields(entry.ID, { [ENTRY_EVENTBRITE_ATTENDEE_ID]: matched.id });
+          updated++;
+        } else {
+          skipped++;
+        }
+      }
+    }
+
+    console.log(`[Backfill] Done — ${sessionsProcessed} sessions fetched from Eventbrite, ${updated} entries updated, ${skipped} skipped`);
+  } catch (error: any) {
+    console.error('[Backfill] Error:', error);
   }
 });
 

--- a/backend/routes/profiles.ts
+++ b/backend/routes/profiles.ts
@@ -771,13 +771,17 @@ router.get('/profiles/:slug', async (req: Request, res: Response) => {
       })
       .sort((a, b) => b.date.localeCompare(a.date));
 
-    // Warnings from stored stats
+    // Badges and warnings from stored stats
     let profileWarnings: Array<{ text: string; url?: string }> = [];
+    let isMember = false;
+    let cardStatus: string | undefined;
     const storedStats = spProfile[PROFILE_STATS];
     if (storedStats) {
       try {
         const parsed = JSON.parse(storedStats);
         if (parsed.warnings?.length) profileWarnings = parsed.warnings;
+        isMember = parsed.isMember === true;
+        cardStatus = parsed.cardStatus ?? undefined;
       } catch { /* skip malformed */ }
     }
 
@@ -802,6 +806,8 @@ router.get('/profiles/:slug', async (req: Request, res: Response) => {
       matchName: spProfile.MatchName,
       user: spProfile.User,
       isGroup: profile.isGroup,
+      isMember,
+      cardStatus,
       hoursLastFY: Math.round(calculatedLastFY * 10) / 10,
       hoursThisFY: Math.round(calculatedThisFY * 10) / 10,
       hoursAll: Math.round(calculatedAll * 10) / 10,

--- a/backend/routes/profiles.ts
+++ b/backend/routes/profiles.ts
@@ -864,6 +864,7 @@ router.patch('/profiles/:slug', async (req: Request, res: Response) => {
     }
 
     await profilesRepository.updateFields(spProfile.ID, fields);
+    await computeAndSaveProfileStats(spProfile.ID);
     res.json({ success: true } as ApiResponse<void>);
   } catch (error: any) {
     console.error('Error updating profile:', error);

--- a/backend/routes/profiles.ts
+++ b/backend/routes/profiles.ts
@@ -31,6 +31,7 @@ import {
   PROFILE_LOOKUP, PROFILE_DISPLAY,
   ENTRY_CANCELLED,
   ENTRY_STATS,
+  ENTRY_EVENTBRITE_ATTENDEE_ID,
   PROFILE_STATS
 } from '../services/field-names';
 import { parseEntryStatsField } from '../services/data-layer';
@@ -765,6 +766,7 @@ router.get('/profiles/:slug', async (req: Request, res: Response) => {
           financialYear: `FY${sessionFY}`,
           cancelled: e[ENTRY_CANCELLED] || undefined,
           stats: parseEntryStatsField(e[ENTRY_STATS]),
+          eventbriteAttendeeId: e[ENTRY_EVENTBRITE_ATTENDEE_ID] || undefined,
         };
       })
       .sort((a, b) => b.date.localeCompare(a.date));

--- a/backend/routes/sessions.ts
+++ b/backend/routes/sessions.ts
@@ -31,7 +31,7 @@ import { parseSessionStats } from '../services/data-layer';
 import {
   GROUP_LOOKUP, GROUP_DISPLAY,
   SESSION_LOOKUP, SESSION_NOTES, SESSION_METADATA, SESSION_COVER_MEDIA, SESSION_STATS, SESSION_LIMITS,
-  PROFILE_LOOKUP, PROFILE_DISPLAY, PROFILE_STATS, ENTRY_CANCELLED, ENTRY_STATS
+  PROFILE_LOOKUP, PROFILE_DISPLAY, PROFILE_STATS, ENTRY_CANCELLED, ENTRY_STATS, ENTRY_EVENTBRITE_ATTENDEE_ID
 } from '../services/field-names';
 import type { SessionResponse, SessionDetailResponse, EntryResponse } from '../../types/api-responses';
 import type { ApiResponse } from '../../types/sharepoint';
@@ -487,7 +487,8 @@ router.get('/sessions/:group/:date', async (req: Request, res: Response) => {
         accompanyingAdultId: safeParseLookupId(e.AccompanyingAdultLookupId),
         cancelled: e[ENTRY_CANCELLED] || undefined,
         email: isOperational ? (profile ? parseEmails(profile.Email)[0] : undefined) : undefined,
-        stats: parseEntryStatsField(e[ENTRY_STATS])
+        stats: parseEntryStatsField(e[ENTRY_STATS]),
+        eventbriteAttendeeId: e[ENTRY_EVENTBRITE_ATTENDEE_ID] || undefined
       };
     });
 
@@ -499,7 +500,10 @@ router.get('/sessions/:group/:date', async (req: Request, res: Response) => {
     const childCount = activeEntries.filter(e => { const s = pes(e); return s ? s.snapshot?.isChild : /#Child\b/i.test(String(e.Notes || '')); }).length;
     const regularCount = activeEntries.filter(e => { const s = pes(e); return s ? s.snapshot?.booking === 'Regular' : /#Regular\b/i.test(String(e.Notes || '')); }).length;
     const cancelledRegularCount = sessionEntries.filter(e => { if (!e[ENTRY_CANCELLED]) return false; const s = pes(e); return s ? s.snapshot?.booking === 'Regular' : /#Regular\b/i.test(String(e.Notes || '')); }).length || undefined;
-    const eventbriteCount = activeEntries.filter(e => { const s = pes(e); return s ? s.manual?.eventbrite : /#Eventbrite\b/i.test(String(e.Notes || '')); }).length;
+    const eventbriteCount = activeEntries.filter(e => {
+      if (e[ENTRY_EVENTBRITE_ATTENDEE_ID]) return true;
+      const s = pes(e); return s ? s.manual?.eventbrite : /#Eventbrite\b/i.test(String(e.Notes || ''));
+    }).length;
 
     // Per-user personalised flags — from profile stats (all roles) with live entry fallback for admin/checkin
     // For self-service: also look up their own entry to return userEntryId (needed for cancel flow)

--- a/backend/services/data-layer.test.ts
+++ b/backend/services/data-layer.test.ts
@@ -1,6 +1,21 @@
 import { describe, it, expect } from 'vitest'
-import { calculateFinancialYear, calculateCurrentFY, calculateSessionStats } from './data-layer'
+import { calculateFinancialYear, calculateCurrentFY, calculateSessionStats, toMatchName } from './data-layer'
 import type { SharePointEntry } from '../../types/sharepoint'
+
+describe('toMatchName', () => {
+  it('returns empty string for undefined',        () => expect(toMatchName(undefined)).toBe(''))
+  it('returns empty string for empty string',     () => expect(toMatchName('')).toBe(''))
+  it('lowercases',                                () => expect(toMatchName('JOHN SMITH')).toBe('john smith'))
+  it('preserves hyphens',                         () => expect(toMatchName('Smith-Jones')).toBe('smith-jones'))
+  it('replaces apostrophes with space',           () => expect(toMatchName("O'Brien")).toBe('o brien'))
+  it('collapses multiple spaces',                 () => expect(toMatchName('John  Smith')).toBe('john smith'))
+  it('trims leading and trailing whitespace',     () => expect(toMatchName('  John Smith  ')).toBe('john smith'))
+  it('collapses mixed punctuation to one space',  () => expect(toMatchName('Dr. J. Smith')).toBe('dr j smith'))
+  it('preserves digits',                          () => expect(toMatchName('Team2')).toBe('team2'))
+  it('normalises accented characters via NFD',    () => expect(toMatchName('René')).toBe('rené'.normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase()))
+  it('René and Rene normalise to the same key',   () => expect(toMatchName('René')).toBe(toMatchName('Rene')))
+  it('Renée and Renee normalise to the same key', () => expect(toMatchName('Renée')).toBe(toMatchName('Renee')))
+})
 
 describe('calculateFinancialYear', () => {
   it('Apr 1 is in FY of that year',   () => expect(calculateFinancialYear(new Date('2025-04-01'))).toBe(2025))

--- a/backend/services/data-layer.ts
+++ b/backend/services/data-layer.ts
@@ -549,16 +549,19 @@ export function profileIdFromSlug(slug: string): number | undefined {
 }
 
 /**
- * Normalises a name for Eventbrite matching: lowercase and replace any
- * non-letter/non-digit character (hyphens, apostrophes, etc.) with a space,
- * then collapse runs of whitespace. Used both when storing MatchName and when
- * comparing against Eventbrite attendee names.
+ * Normalises a name for Eventbrite matching. Decomposes accented characters
+ * via NFD and strips diacritics so "René" matches "Rene". Hyphens are preserved
+ * so stored MatchNames like "smith-jones" continue to match. All other
+ * non-letter/non-digit/non-hyphen characters (apostrophes, spaces, dots, etc.)
+ * are collapsed to a single space.
  */
 export function toMatchName(name: string | undefined): string {
   if (!name) return '';
   return name
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g, ' ')
+    .replace(/[^a-z0-9-]+/g, ' ')
     .trim();
 }
 

--- a/backend/services/eventbrite-client.ts
+++ b/backend/services/eventbrite-client.ts
@@ -95,29 +95,6 @@ export async function getOrgEvents(): Promise<EventbriteEvent[]> {
   return all;
 }
 
-export async function getOrgAttendees(changedSince: Date): Promise<EventbriteAttendee[]> {
-  const orgId = process.env.EVENTBRITE_ORGANIZATION_ID;
-  if (!orgId) throw new Error('EVENTBRITE_ORGANIZATION_ID not configured');
-
-  const all: EventbriteAttendee[] = [];
-  let page = 1;
-  let hasMore = true;
-
-  const sinceParam = `&changed_since=${encodeURIComponent(changedSince.toISOString().replace(/\.\d{3}Z$/, 'Z'))}`;
-
-  while (hasMore) {
-    const data = await fetchEventbrite<{
-      attendees: EventbriteAttendee[];
-      pagination: { has_more_items: boolean };
-    }>(`/organizations/${orgId}/attendees/?status=attending&expand=answers,order&page=${page}${sinceParam}`);
-
-    all.push(...(data.attendees || []));
-    hasMore = data.pagination?.has_more_items || false;
-    page++;
-  }
-
-  return all;
-}
 
 export async function getAttendees(eventId: string, changedSince?: Date): Promise<EventbriteAttendee[]> {
   const all: EventbriteAttendee[] = [];

--- a/backend/services/eventbrite-sync.test.ts
+++ b/backend/services/eventbrite-sync.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { SharePointProfile } from '../../types/sharepoint'
+
+vi.mock('./repositories/entries-repository', () => ({
+  entriesRepository: { create: vi.fn(), updateFields: vi.fn(), getAll: vi.fn(), getBySessionIds: vi.fn() }
+}))
+
+vi.mock('./repositories/profiles-repository', () => ({
+  profilesRepository: {
+    create: vi.fn().mockResolvedValue(999),
+    updateFields: vi.fn().mockResolvedValue(undefined)
+  }
+}))
+
+vi.mock('./repositories/records-repository', () => ({
+  recordsRepository: { available: false, getAll: vi.fn(), create: vi.fn(), update: vi.fn() }
+}))
+
+import { findOrCreateProfile } from './eventbrite-sync'
+import { profilesRepository } from './repositories/profiles-repository'
+
+function profile(overrides: Partial<SharePointProfile> & { ID: number }): SharePointProfile {
+  return { Title: 'Test User', Email: undefined, MatchName: undefined, Created: '', Modified: '', ...overrides }
+}
+
+beforeEach(() => {
+  vi.mocked(profilesRepository.create).mockResolvedValue(999)
+  vi.mocked(profilesRepository.updateFields).mockResolvedValue(undefined)
+})
+
+describe('findOrCreateProfile — name + email match', () => {
+  it('returns existing profile when name and email match', async () => {
+    const profiles = [profile({ ID: 1, Title: 'Jane Smith', Email: 'jane@example.com', MatchName: 'jane smith' })]
+    const result = await findOrCreateProfile('Jane Smith', 'jane@example.com', profiles, 'Test')
+    expect(result.profile.ID).toBe(1)
+    expect(result.isNew).toBe(false)
+    expect(profilesRepository.create).not.toHaveBeenCalled()
+  })
+
+  it('matches via MatchName field', async () => {
+    const profiles = [profile({ ID: 2, Title: 'Jane Smith', Email: 'jane@example.com', MatchName: 'jane smith' })]
+    const result = await findOrCreateProfile('Jane  Smith', 'jane@example.com', profiles, 'Test')
+    expect(result.profile.ID).toBe(2)
+    expect(result.isNew).toBe(false)
+  })
+
+  it('matches case-insensitively', async () => {
+    const profiles = [profile({ ID: 3, Title: 'JANE SMITH', Email: 'jane@example.com', MatchName: 'jane smith' })]
+    const result = await findOrCreateProfile('jane smith', 'jane@example.com', profiles, 'Test')
+    expect(result.profile.ID).toBe(3)
+    expect(result.isNew).toBe(false)
+  })
+})
+
+describe('findOrCreateProfile — name-only match', () => {
+  it('returns existing profile when names match and neither has email', async () => {
+    const profiles = [profile({ ID: 4, Title: 'John Doe', MatchName: 'john doe' })]
+    const result = await findOrCreateProfile('John Doe', undefined, profiles, 'Test')
+    expect(result.profile.ID).toBe(4)
+    expect(result.isNew).toBe(false)
+  })
+
+  it('returns existing profile when names match and only profile has email', async () => {
+    const profiles = [profile({ ID: 5, Title: 'John Doe', Email: 'john@example.com', MatchName: 'john doe' })]
+    const result = await findOrCreateProfile('John Doe', undefined, profiles, 'Test')
+    expect(result.profile.ID).toBe(5)
+    expect(result.isNew).toBe(false)
+  })
+
+  it('backfills email onto profile when attendee has one and profile does not', async () => {
+    const p = profile({ ID: 6, Title: 'John Doe', MatchName: 'john doe' })
+    const profiles = [p]
+    const result = await findOrCreateProfile('John Doe', 'john@example.com', profiles, 'Test')
+    expect(result.profile.ID).toBe(6)
+    expect(result.isNew).toBe(false)
+    expect(profilesRepository.updateFields).toHaveBeenCalledWith(6, { Email: 'john@example.com' })
+  })
+})
+
+describe('findOrCreateProfile — email clash creates new profile', () => {
+  it('creates new profile when name matches but emails differ', async () => {
+    const profiles = [profile({ ID: 7, Title: 'Alex Jones', Email: 'alex1@example.com', MatchName: 'alex jones' })]
+    const result = await findOrCreateProfile('Alex Jones', 'alex2@example.com', profiles, 'Test')
+    expect(result.isNew).toBe(true)
+    expect(result.clash).toBe(true)
+    expect(profilesRepository.create).toHaveBeenCalled()
+  })
+
+  it('pushes new profile into the profiles array so subsequent lookups see it', async () => {
+    const profiles: SharePointProfile[] = [profile({ ID: 8, Title: 'Alex Jones', Email: 'alex1@example.com', MatchName: 'alex jones' })]
+    await findOrCreateProfile('Alex Jones', 'alex2@example.com', profiles, 'Test')
+    expect(profiles).toHaveLength(2)
+    expect(profiles[1].ID).toBe(999)
+  })
+})
+
+describe('findOrCreateProfile — no match creates new profile', () => {
+  it('creates new profile when name is not found', async () => {
+    const profiles = [profile({ ID: 9, Title: 'Someone Else', MatchName: 'someone else' })]
+    const result = await findOrCreateProfile('New Person', 'new@example.com', profiles, 'Test')
+    expect(result.isNew).toBe(true)
+    expect(result.clash).toBeFalsy()
+    expect(profilesRepository.create).toHaveBeenCalledWith(expect.objectContaining({
+      Title: 'New Person',
+      Email: 'new@example.com',
+      MatchName: 'new person'
+    }))
+  })
+
+  it('pushes new profile into the profiles array', async () => {
+    const profiles: SharePointProfile[] = []
+    await findOrCreateProfile('Brand New', undefined, profiles, 'Test')
+    expect(profiles).toHaveLength(1)
+    expect(profiles[0].Title).toBe('Brand New')
+  })
+})

--- a/backend/services/eventbrite-sync.ts
+++ b/backend/services/eventbrite-sync.ts
@@ -285,11 +285,15 @@ export async function syncAttendeesForSession(
 
   // Index existing entries by EventbriteAttendeeID and by profile ID for fast lookup
   const entryByAttendeeId = new Map<string, SharePointEntry>();
+  const entryByProfileId = new Map<number, SharePointEntry>();
   const existingProfileIds = new Set<number>();
   for (const entry of sessionEntries) {
     if (entry.EventbriteAttendeeID) entryByAttendeeId.set(entry.EventbriteAttendeeID, entry);
     const pid = safeParseLookupId(entry[PROFILE_LOOKUP]);
-    if (pid !== undefined) existingProfileIds.add(pid);
+    if (pid !== undefined) {
+      entryByProfileId.set(pid, entry);
+      existingProfileIds.add(pid);
+    }
   }
 
   for (const attendee of attendees) {
@@ -327,6 +331,12 @@ export async function syncAttendeesForSession(
       existingProfileIds.add(profile.ID);
       addSessionToProfileStats(profile, sessionId, sessionDateMap);
       newEntries++;
+    } else {
+      // Profile already has an entry — stamp the AttendeeID onto it if not already set
+      const existingEntry = entryByProfileId.get(profile.ID);
+      if (existingEntry && !existingEntry.EventbriteAttendeeID) {
+        await entriesRepository.updateFields(existingEntry.ID, { [ENTRY_EVENTBRITE_ATTENDEE_ID]: attendee.id });
+      }
     }
 
     const { created, updated } = await upsertConsentRecords(profile.ID, attendee, records);

--- a/backend/services/eventbrite-sync.ts
+++ b/backend/services/eventbrite-sync.ts
@@ -9,7 +9,8 @@ import { recordsRepository } from './repositories/records-repository';
 import { toMatchName, safeParseLookupId, parseEmails } from './data-layer';
 import type { EventbriteAttendee } from './eventbrite-client';
 import type { SharePointProfile, SharePointEntry } from '../../types/sharepoint';
-import { SESSION_LOOKUP, PROFILE_LOOKUP, ENTRY_EVENTBRITE_ATTENDEE_ID } from './field-names';
+import { SESSION_LOOKUP, PROFILE_LOOKUP, ENTRY_EVENTBRITE_ATTENDEE_ID, ENTRY_CANCELLED } from './field-names';
+import { computeAndSaveProfileStats } from './profile-stats';
 
 /**
  * Returns the booking email for an attendee — the order contact email (whoever
@@ -227,6 +228,7 @@ export interface SyncAttendeesForSessionResult {
   newEntries: number;
   newRecords: number;
   updatedRecords: number;
+  cancelledEntries: number;
 }
 
 /**
@@ -247,12 +249,14 @@ export async function syncAttendeesForSession(
   sessionEntries: SharePointEntry[],
   profiles: SharePointProfile[],
   records: any[],
-  sessionDateMap: Map<number, string>
+  sessionDateMap: Map<number, string>,
+  cancelledAttendees: EventbriteAttendee[] = []
 ): Promise<SyncAttendeesForSessionResult> {
   let newProfiles = 0;
   let newEntries = 0;
   let newRecords = 0;
   let updatedRecords = 0;
+  let cancelledEntries = 0;
 
   // Index existing entries by EventbriteAttendeeID and by profile ID for fast lookup
   const entryByAttendeeId = new Map<string, SharePointEntry>();
@@ -307,6 +311,7 @@ export async function syncAttendeesForSession(
       const existingEntry = entryByProfileId.get(profile.ID);
       if (existingEntry && !existingEntry.EventbriteAttendeeID) {
         await entriesRepository.updateFields(existingEntry.ID, { [ENTRY_EVENTBRITE_ATTENDEE_ID]: attendee.id });
+        existingEntry.EventbriteAttendeeID = attendee.id;
       }
     }
 
@@ -315,5 +320,23 @@ export async function syncAttendeesForSession(
     updatedRecords += updated;
   }
 
-  return { newProfiles, newEntries, newRecords, updatedRecords };
+  // Cancellations — index entries by AttendeeID, set Cancelled timestamp if not already set
+  const entryByAttendeeIdForCancel = new Map<string, { id: number; profileId: number; alreadyCancelled: boolean }>();
+  for (const entry of sessionEntries) {
+    const pid = safeParseLookupId(entry[PROFILE_LOOKUP]);
+    if (pid === undefined) continue;
+    if (entry.EventbriteAttendeeID)
+      entryByAttendeeIdForCancel.set(entry.EventbriteAttendeeID, { id: entry.ID, profileId: pid, alreadyCancelled: !!entry[ENTRY_CANCELLED] });
+  }
+  for (const attendee of cancelledAttendees) {
+    const entryInfo = entryByAttendeeIdForCancel.get(attendee.id);
+    if (!entryInfo || entryInfo.alreadyCancelled) continue;
+    await entriesRepository.updateFields(entryInfo.id, { [ENTRY_CANCELLED]: new Date().toISOString() });
+    computeAndSaveProfileStats(entryInfo.profileId).catch(err =>
+      console.error('[Sync] computeAndSaveProfileStats failed for profile', entryInfo!.profileId, err)
+    );
+    cancelledEntries++;
+  }
+
+  return { newProfiles, newEntries, newRecords, updatedRecords, cancelledEntries };
 }

--- a/backend/services/eventbrite-sync.ts
+++ b/backend/services/eventbrite-sync.ts
@@ -108,41 +108,12 @@ export function addSessionToProfileStats(
 }
 
 /**
- * Finds an existing profile by name match (normalised). If the name matches
- * but both sides have different emails, a new profile is created and
- * clash=true is returned so the caller can tag the entry with #Duplicate
- * for admin review. Email is never matched alone — name is always required.
+ * Finds or creates a profile for an Eventbrite attendee.
+ * If name matches but emails differ, creates a new profile rather than risk
+ * exposing data to the wrong person. Email is never matched alone.
  * Mutates `profiles` by pushing any newly-created profile so subsequent
  * lookups within the same batch stay consistent.
  */
-/**
- * Find a profile matching an Eventbrite attendee by name + email — find-only, no create.
- * Uses the same matching priority as findOrCreateProfile (name+email first, name-only second).
- */
-export function findProfileByAttendee(
-  attendee: EventbriteAttendee,
-  profiles: SharePointProfile[]
-): SharePointProfile | undefined {
-  const attendeeName = attendee.profile?.name;
-  if (!attendeeName) return undefined;
-  const nameKey = toMatchName(attendeeName);
-  const email = bookingEmailFor(attendee)?.toLowerCase();
-
-  if (email) {
-    const byNameAndEmail = profiles.find(p => {
-      const nameMatches = (p.MatchName && toMatchName(p.MatchName) === nameKey) ||
-                          (p.Title && toMatchName(p.Title) === nameKey);
-      return nameMatches && parseEmails(p.Email).some(e => e.toLowerCase() === email);
-    });
-    if (byNameAndEmail) return byNameAndEmail;
-  }
-
-  return profiles.find(p =>
-    (p.MatchName && toMatchName(p.MatchName) === nameKey) ||
-    (p.Title && toMatchName(p.Title) === nameKey)
-  );
-}
-
 export async function findOrCreateProfile(
   attendeeName: string,
   attendeeEmail: string | undefined,

--- a/backend/services/eventbrite-sync.ts
+++ b/backend/services/eventbrite-sync.ts
@@ -3,12 +3,13 @@
  * (routes/eventbrite.ts) and the per-session refresh (routes/entries.ts).
  */
 
+import { entriesRepository } from './repositories/entries-repository';
 import { profilesRepository } from './repositories/profiles-repository';
 import { recordsRepository } from './repositories/records-repository';
 import { toMatchName, safeParseLookupId, parseEmails } from './data-layer';
 import type { EventbriteAttendee } from './eventbrite-client';
 import type { SharePointProfile, SharePointEntry } from '../../types/sharepoint';
-import { SESSION_LOOKUP, PROFILE_LOOKUP } from './field-names';
+import { SESSION_LOOKUP, PROFILE_LOOKUP, ENTRY_EVENTBRITE_ATTENDEE_ID } from './field-names';
 
 /**
  * Returns the booking email for an attendee — the order contact email (whoever
@@ -248,4 +249,90 @@ export async function upsertConsentRecords(
   }
 
   return { created, updated };
+}
+
+export interface SyncAttendeesForSessionResult {
+  newProfiles: number;
+  newEntries: number;
+  newRecords: number;
+  updatedRecords: number;
+}
+
+/**
+ * Syncs Eventbrite attendees for a single session. Used by both the nightly bulk
+ * sync and the per-session refresh so the logic lives in one place.
+ *
+ * Matching priority for existing entries:
+ *   1. EventbriteAttendeeID match (deterministic, post-backfill)
+ *   2. Profile ID match (fallback for pre-backfill entries)
+ *
+ * No Notes tags are written — the presence of EventbriteAttendeeID is the source
+ * of truth for the Eventbrite icon; child/new/etc. are handled by live fields and
+ * entry-stats snapshot computation.
+ */
+export async function syncAttendeesForSession(
+  sessionId: number,
+  attendees: EventbriteAttendee[],
+  sessionEntries: SharePointEntry[],
+  profiles: SharePointProfile[],
+  records: any[],
+  sessionDateMap: Map<number, string>
+): Promise<SyncAttendeesForSessionResult> {
+  let newProfiles = 0;
+  let newEntries = 0;
+  let newRecords = 0;
+  let updatedRecords = 0;
+
+  // Index existing entries by EventbriteAttendeeID and by profile ID for fast lookup
+  const entryByAttendeeId = new Map<string, SharePointEntry>();
+  const existingProfileIds = new Set<number>();
+  for (const entry of sessionEntries) {
+    if (entry.EventbriteAttendeeID) entryByAttendeeId.set(entry.EventbriteAttendeeID, entry);
+    const pid = safeParseLookupId(entry[PROFILE_LOOKUP]);
+    if (pid !== undefined) existingProfileIds.add(pid);
+  }
+
+  for (const attendee of attendees) {
+    const attendeeName = attendee.profile?.name;
+    const attendeeEmail = attendee.profile?.email;
+    if (!attendeeName) continue;
+
+    // If we already have an entry for this exact attendee ID, only update consent
+    if (entryByAttendeeId.has(attendee.id)) {
+      const profileId = safeParseLookupId(entryByAttendeeId.get(attendee.id)![PROFILE_LOOKUP]);
+      if (profileId !== undefined) {
+        const { created, updated } = await upsertConsentRecords(profileId, attendee, records);
+        newRecords += created;
+        updatedRecords += updated;
+      }
+      continue;
+    }
+
+    const { profile, isNew } = await findOrCreateProfile(attendeeName, attendeeEmail, profiles, `Sync:${sessionId}`);
+    if (isNew) newProfiles++;
+
+    if (!existingProfileIds.has(profile.ID)) {
+      const isChild = !!attendee.ticket_class_name?.toLowerCase().includes('child');
+      const entryFields: Record<string, any> = {
+        [SESSION_LOOKUP]: String(sessionId),
+        [PROFILE_LOOKUP]: String(profile.ID),
+        [ENTRY_EVENTBRITE_ATTENDEE_ID]: attendee.id,
+        BookedBy: bookingEmailFor(attendee)
+      };
+      if (isChild && attendee.order_id) {
+        const adultProfile = resolveAccompanyingAdult(attendees, attendee.order_id, profiles);
+        if (adultProfile) entryFields.AccompanyingAdultLookupId = String(adultProfile.ID);
+      }
+      await entriesRepository.create(entryFields);
+      existingProfileIds.add(profile.ID);
+      addSessionToProfileStats(profile, sessionId, sessionDateMap);
+      newEntries++;
+    }
+
+    const { created, updated } = await upsertConsentRecords(profile.ID, attendee, records);
+    newRecords += created;
+    updatedRecords += updated;
+  }
+
+  return { newProfiles, newEntries, newRecords, updatedRecords };
 }

--- a/backend/services/field-names.ts
+++ b/backend/services/field-names.ts
@@ -25,5 +25,6 @@ export const SESSION_COVER_MEDIA = 'CoverMediaLookupId'; // Lookup to Media libr
 export const SESSION_STATS       = 'Stats';  // Pre-computed JSON stats stored on Session items (avoid full entries scan on listing views)
 export const SESSION_LIMITS      = 'Limits'; // Per-session capacity limits JSON: {"new": 4, "total": 16}
 export const PROFILE_STATS       = 'Stats';  // Same field name on Profiles list
-export const ENTRY_CANCELLED     = 'Cancelled'; // Date/time when entry was cancelled; null = active booking
-export const ENTRY_STATS         = 'Stats';     // Snapshot JSON stored on Entry items (frozen once session date passes)
+export const ENTRY_CANCELLED             = 'Cancelled';         // Date/time when entry was cancelled; null = active booking
+export const ENTRY_STATS                 = 'Stats';             // Snapshot JSON stored on Entry items (frozen once session date passes)
+export const ENTRY_EVENTBRITE_ATTENDEE_ID = 'EventbriteAttendeeID'; // Eventbrite attendee ID — source of truth for the Eventbrite icon

--- a/backend/services/profile-stats.ts
+++ b/backend/services/profile-stats.ts
@@ -108,6 +108,8 @@ export async function computeAndSaveProfileStats(profileId: number): Promise<voi
         return toMatchName(p.Title) === thisTitleKey || (thisMatchKey && toMatchName(p.MatchName) === thisMatchKey);
       })
     : false;
+  const hasMatchNameError = !!(thisProfile?.Title && thisProfile?.MatchName &&
+    toMatchName(thisProfile.Title) !== thisProfile.MatchName);
   const hasChildNoAdult = profileEntries.some(e =>
     !e[ENTRY_CANCELLED] && e.Notes?.toLowerCase().includes('#child') && !e.AccompanyingAdultLookupId
   );
@@ -120,6 +122,7 @@ export async function computeAndSaveProfileStats(profileId: number): Promise<voi
   const hasPhotoConsent = profileRecordsRaw.some(r => r.Type === 'Photo Consent' && r.Status === 'Accepted');
   const warnings: Array<{ text: string; url?: string }> = [];
   if (hasDuplicate) warnings.push({ text: 'Possible Duplicate', url: `/profiles?fy=all&search=${encodeURIComponent(thisProfile?.Title || '')}` });
+  if (hasMatchNameError) warnings.push({ text: 'Match Name Error' });
   if (hasChildNoAdult) warnings.push({ text: 'Child No Adult', url: `/entries?q=%23child&fy=all&accompanyingAdult=empty&profileId=${profileId}&profileName=${encodeURIComponent(thisProfile?.Title || '')}` });
   if (hasFutureBooking && (!hasPrivacyConsent || !hasPhotoConsent)) warnings.push({ text: 'No Consent' });
 
@@ -299,6 +302,7 @@ export async function runProfileStatsRefresh(): Promise<ProfileStatsRefreshResul
       try {
         const warnings: Array<{ text: string; url?: string }> = [];
         if (possibleDuplicateIds.has(spProfile.ID)) warnings.push({ text: 'Possible Duplicate', url: `/profiles?fy=all&search=${encodeURIComponent(spProfile.Title || '')}` });
+        if (spProfile.Title && spProfile.MatchName && toMatchName(spProfile.Title) !== spProfile.MatchName) warnings.push({ text: 'Match Name Error' });
         if (childNoAdultIds.has(spProfile.ID)) warnings.push({ text: 'Child No Adult', url: `/entries?q=%23child&fy=all&accompanyingAdult=empty&profileId=${spProfile.ID}&profileName=${encodeURIComponent(spProfile.Title || '')}` });
         if (futureBookingIds.has(spProfile.ID) && (!consentedPrivacyIds.has(spProfile.ID) || !consentedPhotoIds.has(spProfile.ID))) warnings.push({ text: 'No Consent' });
 

--- a/backend/services/repositories/entries-repository.ts
+++ b/backend/services/repositories/entries-repository.ts
@@ -6,7 +6,7 @@
 
 import { SharePointEntry } from '../../../types/sharepoint';
 import { sharePointClient, CACHE_TTL } from '../sharepoint-client';
-import { SESSION_LOOKUP, SESSION_DISPLAY, PROFILE_LOOKUP, PROFILE_DISPLAY, ACCOMPANYING_ADULT_LOOKUP, ACCOMPANYING_ADULT_DISPLAY, ENTRY_CANCELLED, ENTRY_STATS } from '../field-names';
+import { SESSION_LOOKUP, SESSION_DISPLAY, PROFILE_LOOKUP, PROFILE_DISPLAY, ACCOMPANYING_ADULT_LOOKUP, ACCOMPANYING_ADULT_DISPLAY, ENTRY_CANCELLED, ENTRY_STATS, ENTRY_EVENTBRITE_ATTENDEE_ID } from '../field-names';
 import type { EntryStats } from '../../../types/entry-stats';
 import { serializeEntryStats } from '../entry-stats';
 
@@ -18,7 +18,7 @@ class EntriesRepository {
   }
 
   private get selectFields(): string {
-    return `ID,Title,${SESSION_DISPLAY},${SESSION_LOOKUP},${PROFILE_DISPLAY},${PROFILE_LOOKUP},Count,Checked,Hours,Notes,BookedBy,${ACCOMPANYING_ADULT_DISPLAY},${ACCOMPANYING_ADULT_LOOKUP},${ENTRY_CANCELLED},${ENTRY_STATS},Created,Modified`;
+    return `ID,Title,${SESSION_DISPLAY},${SESSION_LOOKUP},${PROFILE_DISPLAY},${PROFILE_LOOKUP},Count,Checked,Hours,Notes,BookedBy,${ACCOMPANYING_ADULT_DISPLAY},${ACCOMPANYING_ADULT_LOOKUP},${ENTRY_CANCELLED},${ENTRY_STATS},${ENTRY_EVENTBRITE_ATTENDEE_ID},Created,Modified`;
   }
 
   async getAll(): Promise<SharePointEntry[]> {

--- a/docs/api.md
+++ b/docs/api.md
@@ -138,7 +138,6 @@ All write endpoints also accept `X-Api-Key` authentication for the scheduled Azu
 | Endpoint | Method | Access | Description |
 |---|---|---|---|
 | `/api/eventbrite/nightly-update` | POST | Admin / API key | Full nightly run: sync, stats refresh, backup, cache warmup |
-| `/api/eventbrite/quick-sync` | POST | Check In+ | Quick sync without full stats refresh |
 | `/api/eventbrite/sync-sessions` | POST | Admin / API key | Sync Eventbrite events → sessions |
 | `/api/eventbrite/sync-attendees` | POST | Admin / API key | Sync Eventbrite attendees → profiles/entries |
 | `/api/eventbrite/unmatched-events` | GET | Trusted | List Eventbrite events with no matching group |

--- a/docs/features/eventbrite.md
+++ b/docs/features/eventbrite.md
@@ -8,15 +8,20 @@ Eventbrite IDs are stored at the same level as the DTV object they identify.
 |------------|------------------|-------------------|
 | Group | `EventbriteSeriesID` | Recurring series |
 | Session | `EventbriteEventID` | Specific event instance |
-| Entry | _not currently stored_ | Attendee / ticket holder |
+| Entry | `EventbriteAttendeeID` | Attendee / ticket holder |
 
-We do not store `EventbriteOrderID` on Entries. Orders belong to Eventbrite’s booking/payment layer, while DTV Entries represent one Profile booked onto one Session.
+We do not store `EventbriteOrderID` on Entries. Orders belong to Eventbrite's booking/payment layer, while DTV Entries represent one Profile booked onto one Session.
 
 ## Volunteer Matching
 
-In the current implementation, Eventbrite attendees are matched to Profiles via `Profile.MatchName`, a lowercase normalised name field.
+Eventbrite attendees are matched to Profiles via a priority chain:
 
-No direct Eventbrite attendee ID is stored on the Entry yet, so re-sync and deduplication still rely on matching attendee details back to Profiles and Sessions.
+1. **`EventbriteAttendeeID` match** (deterministic) — if an existing entry already carries the attendee ID, that entry is updated in-place.
+2. **Name + email match** — `Profile.MatchName` / `Profile.Title` normalised to lowercase, combined with booking email.
+3. **Name-only match** — used when emails are compatible (absent on one or both sides).
+4. **No match** — a new Profile is created.
+
+`Entry.EventbriteAttendeeID` is the source of truth for the Eventbrite icon on entry cards. The legacy `#Eventbrite` Notes tag and `stats.manual.eventbrite` field remain on pre-migration entries as fallbacks but are no longer written by the sync.
 
 ## Nightly Sync
 
@@ -27,14 +32,28 @@ Triggered by Azure Logic App via:
 This runs two steps in sequence:
 
 1. **sync-sessions** — finds Eventbrite events by `EventbriteSeriesID` and creates missing Sessions.
-2. **sync-entries** — fetches attendees for Eventbrite-linked Sessions, matches them to Profiles, and creates missing Entries.
+2. **sync-entries** — fetches attendees for Eventbrite-linked Sessions (today or future), matches them to Profiles, and creates missing Entries. Uses the shared `syncAttendeesForSession()` function.
 
 Both steps are also available individually for manual runs from the Admin page.
 
-## Future Work
+## Quick Sync
 
-- Add `Entry.EventbriteAttendeeID` to store the Eventbrite attendee ID directly on each Entry.
-- Use `Session.EventbriteEventID + Entry.EventbriteAttendeeID` as the hard link back to Eventbrite.
-- Replace the `#eventbrite` tag in `Entry.Notes` with a derived label based on `EventbriteAttendeeID` being present.
-- Do not add `Entry.EventbriteOrderID` unless a proven reporting need appears.
-- Current eventbrite sync does the checks for possible duplicates. Going forward that will be a dervived warning in the stats json.
+`POST /api/eventbrite/quick-sync?since=24h|48h|7d`
+
+Fetches org-wide attendees changed in the given window using `getOrgAttendees(changedSince)` — much faster than a full scan. Uses the same `syncAttendeesForSession()` function per session.
+
+## Per-Session Refresh
+
+`POST /sessions/:group/:date/refresh`
+
+Manual trigger from the session detail page. Syncs regulars and Eventbrite attendees for a single session using the same `syncAttendeesForSession()` function.
+
+## Historic Backfill
+
+`POST /api/eventbrite/backfill-attendee-ids`
+
+One-time endpoint to populate `EventbriteAttendeeID` on existing Entries that predate this field. Matches by profile name against Eventbrite attendees for each session. Safe to run multiple times — skips entries that already have the field set.
+
+## Duplicate Detection
+
+Duplicate detection is handled entirely by the profile stats warnings system (`profile-stats.ts`). Profiles sharing the same `Title` or `MatchName` key gain a `"Possible Duplicate"` warning in `Profile.Stats.warnings`. This warning surfaces as a badge on entry cards. The sync no longer tags entries with `#Duplicate` or `stats.manual.duplicate`.

--- a/docs/features/eventbrite.md
+++ b/docs/features/eventbrite.md
@@ -41,15 +41,9 @@ Triggered by Azure Logic App via:
 This runs two steps in sequence:
 
 1. **sync-sessions** — finds Eventbrite events by `EventbriteSeriesID` and creates missing Sessions.
-2. **sync-entries** — fetches attendees for Eventbrite-linked Sessions (today or future), matches them to Profiles, and creates missing Entries. Uses the shared `syncAttendeesForSession()` function. Also processes cancellations: sets `Cancelled` on any Entry whose `EventbriteAttendeeID` matches a cancelled attendee, but only if `Cancelled` is not already set (preserving any earlier manual cancellation date).
+2. **sync-entries** — fetches attendees for Eventbrite-linked Sessions (today or future), matches them to Profiles, and creates missing Entries. Uses the shared `syncAttendeesForSession()` function. Also processes cancellations: sets `Cancelled` to the sync run timestamp on any Entry whose `EventbriteAttendeeID` matches a cancelled attendee, but only if `Cancelled` is not already set (preserving any earlier manual cancellation date). The Eventbrite API does not expose a cancellation date on the attendee object, so the sync timestamp is used.
 
 Both steps are also available individually for manual runs from the Admin page.
-
-## Quick Sync
-
-`POST /api/eventbrite/quick-sync?since=24h|48h|7d`
-
-Fetches org-wide attendees changed in the given window using `getOrgAttendees(changedSince)` — much faster than a full scan. Uses the same `syncAttendeesForSession()` function per session.
 
 ## Per-Session Refresh
 

--- a/docs/features/eventbrite.md
+++ b/docs/features/eventbrite.md
@@ -1,5 +1,13 @@
 # Eventbrite Integration
 
+## Design Principles
+
+**Add, never delete.** The sync only creates new Sessions, Profiles, Entries, and consent Records. It never removes data. Cancellations set a `Cancelled` date on an Entry; the Entry itself is kept.
+
+**Targeted patches only.** When updating existing data, the sync writes only the specific field that changed — `EventbriteAttendeeID` (only if not already set), `Cancelled` (only if null), consent record status (only if changed). It never overwrites existing field values.
+
+**Err on the side of a duplicate profile.** When matching an Eventbrite attendee to a Profile, the sync requires name plus compatible email to be confident. If the name matches but emails differ, a new Profile is created rather than risk exposing one person's data to another. Duplicate profiles surface as a warning badge via the profile stats system.
+
 ## ID Storage
 
 Eventbrite IDs are stored at the same level as the DTV object they identify.
@@ -14,14 +22,15 @@ We do not store `EventbriteOrderID` on Entries. Orders belong to Eventbrite's bo
 
 ## Volunteer Matching
 
-Eventbrite attendees are matched to Profiles via a priority chain:
+Attendees are matched to existing Entries and Profiles via a priority chain:
 
-1. **`EventbriteAttendeeID` match** (deterministic) — if an existing entry already carries the attendee ID, that entry is updated in-place.
-2. **Name + email match** — `Profile.MatchName` / `Profile.Title` normalised to lowercase, combined with booking email.
-3. **Name-only match** — used when emails are compatible (absent on one or both sides).
-4. **No match** — a new Profile is created.
+1. **`EventbriteAttendeeID` match** (deterministic) — if an Entry already carries the attendee ID, only consent records are updated. No entry data is changed.
+2. **Profile ID match** — if no AttendeeID match but the Profile is already booked on this session, `EventbriteAttendeeID` is stamped onto the existing Entry (only if not already set). Consent records are updated.
+3. **Name + email match** — `Profile.MatchName` / `Profile.Title` normalised to lowercase, combined with booking email. High confidence — a new Entry is created with `EventbriteAttendeeID`.
+4. **Name-only match** — used when emails are compatible (absent on one or both sides). A new Entry is created.
+5. **No match, or name match with conflicting emails** — a new Profile and Entry are created. Conflicting emails mean a different person; creating a duplicate is safer than a wrong match.
 
-`Entry.EventbriteAttendeeID` is the source of truth for the Eventbrite icon on entry cards. The legacy `#Eventbrite` Notes tag and `stats.manual.eventbrite` field remain on pre-migration entries as fallbacks but are no longer written by the sync.
+`Entry.EventbriteAttendeeID` is the source of truth for the Eventbrite icon on entry cards. The legacy `#Eventbrite` Notes tag and `stats.manual.eventbrite` field remain on pre-migration entries but are no longer used or written by the sync.
 
 ## Nightly Sync
 
@@ -32,7 +41,7 @@ Triggered by Azure Logic App via:
 This runs two steps in sequence:
 
 1. **sync-sessions** — finds Eventbrite events by `EventbriteSeriesID` and creates missing Sessions.
-2. **sync-entries** — fetches attendees for Eventbrite-linked Sessions (today or future), matches them to Profiles, and creates missing Entries. Uses the shared `syncAttendeesForSession()` function.
+2. **sync-entries** — fetches attendees for Eventbrite-linked Sessions (today or future), matches them to Profiles, and creates missing Entries. Uses the shared `syncAttendeesForSession()` function. Also processes cancellations: sets `Cancelled` on any Entry whose `EventbriteAttendeeID` matches a cancelled attendee, but only if `Cancelled` is not already set (preserving any earlier manual cancellation date).
 
 Both steps are also available individually for manual runs from the Admin page.
 
@@ -50,9 +59,7 @@ Manual trigger from the session detail page. Syncs regulars and Eventbrite atten
 
 ## Historic Backfill
 
-`POST /api/eventbrite/backfill-attendee-ids`
-
-One-time endpoint to populate `EventbriteAttendeeID` on existing Entries that predate this field. Matches by profile name against Eventbrite attendees for each session. Safe to run multiple times — skips entries that already have the field set.
+A one-time backfill was run to populate `EventbriteAttendeeID` on existing Entries that predate the field. It matched by profile name against Eventbrite attendees for each session, updating 680 entries across 227 sessions. The endpoint has been removed.
 
 ## Duplicate Detection
 

--- a/docs/sharepoint-schema.md
+++ b/docs/sharepoint-schema.md
@@ -87,9 +87,10 @@ Fall back to zeros if the field is empty (e.g. before first refresh run).
 | **Count** | Count | Number | No | 1 | For group registrations |
 | **Checked** | Checked | Yes/No | No | No | Check-in status for the volunteer |
 | **Hours** | Hours | Number | No | - | Hours worked at this session |
-| **Notes** | Notes | Single line of text | No | - | Manual operational tags: #Child (also sets AccompanyingAdult), #CSR, #Late, #DigLead (role taken), #FirstAider (role taken), #Eventbrite; legacy snapshot tags (#New, #Regular, #NoPhoto etc.) remain for pre-migration entries |
+| **Notes** | Notes | Single line of text | No | - | Manual operational tags: #Child (also sets AccompanyingAdult), #CSR, #Late, #DigLead (role taken), #FirstAider (role taken); legacy tags (#Eventbrite, #New, #Regular, #NoPhoto etc.) remain on pre-migration entries |
 | **Stats** | Stats | Multiple lines of text | No | - | Snapshot JSON (`EntryStats`); frozen once session date passes and field is non-empty — see schema below |
 | **BookedBy** | BookedBy | Single line of text | No | - | Order contact email from Eventbrite (whoever made the booking); historic audit trail |
+| **EventbriteAttendeeID** | EventbriteAttendeeID | Single line of text | No | - | Eventbrite attendee ID; presence means this entry originated via Eventbrite and is the source of truth for the Eventbrite icon |
 | **AccompanyingAdult** | AccompanyingAdult | Lookup (Profiles) | No | - | For child entries: the adult responsible on the day; derived from same Eventbrite order |
 | **Modified** | Modified | Date and Time | Auto | - | Last modified timestamp (read-only) |
 | **Created** | Created | Date and Time | Auto | - | Creation timestamp (read-only) |

--- a/docs/testing/full-regression.md
+++ b/docs/testing/full-regression.md
@@ -158,7 +158,7 @@ Run with `npm run dev` at http://localhost:3000. Log in via Microsoft Entra ID.
 ### H13. Refresh session (bulk)
 - [ ] Session detail → "Refresh" button
 - [ ] `POST /api/sessions/:group/:date/refresh`
-- [ ] Adds missing regulars, syncs Eventbrite attendees, tags #NoPhoto
+- [ ] Adds missing regulars, syncs Eventbrite attendees (with `EventbriteAttendeeID`), tags #NoPhoto
 - [ ] Shows summary: "Added: X regulars, Y from Eventbrite, Z new profiles, W #NoPhoto"
 
 ### H14. Create volunteer
@@ -283,14 +283,20 @@ Run with `npm run dev` at http://localhost:3000. Log in via Microsoft Entra ID.
 - [ ] Admin → "Fetch New Attendees"
 - [ ] `POST /api/eventbrite/sync-attendees`
 - [ ] Shows "X sessions, Y new profiles, Z new entries, W consent records"
-- [ ] Creates profiles, entries, upserts consent records
-- [ ] Two attendees with same name but different emails → two separate profiles created; entry for the new profile has `#Duplicate` (red warning badge) on session detail
+- [ ] Creates profiles, entries, upserts consent records; new entries have `EventbriteAttendeeID` set in SharePoint
+- [ ] Newly synced entry shows Eventbrite icon on session detail (driven by `EventbriteAttendeeID`, not Notes tag)
+- [ ] Two attendees with same name but different emails → two separate profiles created; profile-level "Possible Duplicate" warning badge appears on entry cards (no `#Duplicate` Notes tag)
 - [ ] Attendee name AND email both match an existing profile → same profile reused (email checked against all profile emails, not just the first)
 - [ ] Attendee name matches existing profile, email is one of the profile's secondary emails → profile reused, no duplicate
 - [ ] Attendee name matches existing profile with no stored email → email is backfilled on the existing profile, no duplicate created
 - [ ] Attendee email matches an existing profile's email but name differs → name match used, not email; behaves by name logic
-- [ ] If any duplicates flagged, sync summary includes "X duplicate warning(s) — check session entries"
 - [ ] Triggering sync while one is already running returns 409 "Sync already in progress" (second request rejected immediately)
+
+### H25b. Eventbrite backfill
+- [ ] `POST /api/eventbrite/backfill-attendee-ids` (admin/api-key auth)
+- [ ] Returns `{ updated: N, skipped: M }` — entries updated with `EventbriteAttendeeID`
+- [ ] After backfill, existing Eventbrite entries show the Eventbrite icon (no manual stats or Notes tag needed)
+- [ ] Running a second time: all entries already have ID set → returns `{ updated: 0, skipped: ... }`
 
 ### H26. Nightly update (scheduled)
 - [ ] `POST /api/eventbrite/nightly-update` with `X-Api-Key` header

--- a/frontend/src/components/RecentEntryList.vue
+++ b/frontend/src/components/RecentEntryList.vue
@@ -26,8 +26,8 @@
     <EntryEditModal
       v-if="editingEntry"
       :entry="editingEntry"
-      :is-cancelled="!!editingEntry.cancelled"
       :is-admin="true"
+      :profile-click="editingEntry.profile.slug ? () => router.push(profilePath(editingEntry!.profile.slug!)) : undefined"
       :session-click="() => router.push(sessionPath(editingEntry!.session.groupKey, editingEntry!.session.date))"
       :session-adults="sessionAdults"
       :working="editWorking"
@@ -45,7 +45,7 @@ import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import type { RecentSignupResponse, EntryListItemResponse } from '../../../types/api-responses'
 import type { EntryItem } from '../types/entry'
-import { sessionPath } from '../router/index'
+import { sessionPath, profilePath } from '../router/index'
 import EntryListItem from './entries/EntryListItem.vue'
 import EntryEditModal from '../pages/modals/EntryEditModal.vue'
 import { fetchSessionAdults } from '../utils/fetchSessionAdults'
@@ -74,11 +74,15 @@ function mapToEntryItem(e: RecentSignupResponse): EntryItem {
     notes: e.notes,
     accompanyingAdultId: e.accompanyingAdultId,
     cancelled: e.cancelled,
+    stats: e.stats,
+    eventbriteAttendeeId: e.eventbriteAttendeeId,
     profile: {
       name: e.volunteerName,
       slug: e.volunteerSlug,
-      isMember: false,
-      isGroup: false,
+      isMember: e.isMember ?? false,
+      cardStatus: e.cardStatus,
+      isGroup: e.isGroup ?? false,
+      hasProfileWarning: e.hasProfileWarning,
     },
     session: {
       groupKey: e.groupKey,

--- a/frontend/src/components/entries/EntryListItem.vue
+++ b/frontend/src/components/entries/EntryListItem.vue
@@ -37,7 +37,7 @@ const props = defineProps<{
   selected?: boolean
 }>()
 
-const icons = computed(() => iconsForEntry({ isGroup: props.entry.isGroup, isChild: !!props.entry.accompanyingAdultId, stats: props.entry.stats }))
+const icons = computed(() => iconsForEntry({ isGroup: props.entry.isGroup, isChild: !!props.entry.accompanyingAdultId, stats: props.entry.stats, eventbriteAttendeeId: props.entry.eventbriteAttendeeId }))
 
 function formatDate(date: string): string {
   return new Date(date).toLocaleDateString('en-GB', { day: 'numeric', month: 'short' })

--- a/frontend/src/components/profiles/ProfileEntryList.vue
+++ b/frontend/src/components/profiles/ProfileEntryList.vue
@@ -27,7 +27,7 @@
         :title-to="allowEdit ? undefined : sessionPath(e.session.groupKey, e.session.date)"
         :checked-in="e.checkedIn"
         :hours="e.hours"
-        :icons="iconsForEntry({ ...e.profile, isChild: !!e.accompanyingAdultId, stats: e.stats }).filter(i => i.type !== 'badge')"
+        :icons="iconsForEntry({ ...e.profile, isChild: !!e.accompanyingAdultId, stats: e.stats, eventbriteAttendeeId: e.eventbriteAttendeeId }).filter(i => i.type !== 'badge')"
         :allow-edit="allowEdit ?? false"
         :working="workingId === e.id"
         @update="(c, h) => emit('update', e, c, h)"

--- a/frontend/src/components/sessions/SessionEntryList.vue
+++ b/frontend/src/components/sessions/SessionEntryList.vue
@@ -22,7 +22,7 @@
         :title-to="allowEdit ? undefined : (e.profile.slug ? profilePath(e.profile.slug) : undefined)"
         :checked-in="e.checkedIn"
         :hours="e.hours"
-        :icons="iconsForEntry({ ...e.profile, isChild: !!e.accompanyingAdultId, stats: e.stats })"
+        :icons="iconsForEntry({ ...e.profile, isChild: !!e.accompanyingAdultId, stats: e.stats, eventbriteAttendeeId: e.eventbriteAttendeeId })"
         :allow-edit="allowEdit"
         :working="workingId === e.id"
         :cancelled="!!e.cancelled"

--- a/frontend/src/pages/EntriesPage.vue
+++ b/frontend/src/pages/EntriesPage.vue
@@ -83,11 +83,15 @@ function mapToEntryItem(e: EntryListItemResponse): EntryItem {
     notes: e.notes,
     accompanyingAdultId: e.accompanyingAdultId,
     cancelled: e.cancelled,
+    stats: e.stats,
+    eventbriteAttendeeId: e.eventbriteAttendeeId,
     profile: {
       name: e.volunteerName ?? 'Unknown',
       slug: e.volunteerSlug,
-      isMember: false,
+      isMember: e.isMember ?? false,
+      cardStatus: e.cardStatus,
       isGroup: e.isGroup,
+      hasProfileWarning: e.hasProfileWarning,
     },
     session: {
       groupKey: e.groupKey,

--- a/frontend/src/pages/ProfileDetailPage.vue
+++ b/frontend/src/pages/ProfileDetailPage.vue
@@ -475,9 +475,10 @@ function mapProfileEntry(e: ProfileEntryResponse): EntryItem {
     profile: {
       name: store.profile?.name ?? 'Unknown',
       slug: store.profile?.slug,
-      isMember: false,
-      cardStatus: undefined,
+      isMember: store.profile?.isMember ?? false,
+      cardStatus: store.profile?.cardStatus,
       isGroup: store.profile?.isGroup ?? false,
+      hasProfileWarning: !!(store.profile?.warnings?.length),
     },
     session: {
       groupKey: e.groupKey ?? '',
@@ -558,11 +559,15 @@ function mapChildEntryToItem(e: EntryListItemResponse): EntryItem {
     notes: e.notes,
     accompanyingAdultId: e.accompanyingAdultId,
     cancelled: e.cancelled,
+    stats: e.stats,
+    eventbriteAttendeeId: e.eventbriteAttendeeId,
     profile: {
       name: e.volunteerName ?? 'Unknown',
       slug: e.volunteerSlug,
-      isMember: false,
+      isMember: e.isMember ?? false,
+      cardStatus: e.cardStatus,
       isGroup: e.isGroup,
+      hasProfileWarning: e.hasProfileWarning,
     },
     session: {
       groupKey: e.groupKey,

--- a/frontend/src/pages/ProfileDetailPage.vue
+++ b/frontend/src/pages/ProfileDetailPage.vue
@@ -472,6 +472,7 @@ function mapProfileEntry(e: ProfileEntryResponse): EntryItem {
     accompanyingAdultId: e.accompanyingAdultId,
     cancelled: e.cancelled,
     stats: e.stats,
+    eventbriteAttendeeId: e.eventbriteAttendeeId,
     profile: {
       name: store.profile?.name ?? 'Unknown',
       slug: store.profile?.slug,

--- a/frontend/src/pages/ProfileDetailPage.vue
+++ b/frontend/src/pages/ProfileDetailPage.vue
@@ -300,11 +300,10 @@ async function onEditProfile(data: EditProfilePayload) {
       body: JSON.stringify(data),
     })
     if (!res.ok) throw new Error(`Save failed (${res.status})`)
-    store.profile.name = data.name
-    store.profile.emails = data.emails
-    store.profile.matchName = data.matchName
-    store.profile.user = data.user
-    store.profile.isGroup = data.isGroup
+    const oldSlug = store.profile.slug
+    await store.fetch(oldSlug)
+    if (store.profile && store.profile.slug !== oldSlug)
+      router.replace(profilePath(store.profile.slug))
     actionsRef.value?.onEditSuccess()
   } catch (e) {
     console.error('[ProfileDetailPage] onEditProfile failed', e)

--- a/frontend/src/pages/SessionDetailPage.vue
+++ b/frontend/src/pages/SessionDetailPage.vue
@@ -338,6 +338,7 @@ function mapEntry(e: EntryResponse): EntryItem {
     accompanyingAdultId: e.accompanyingAdultId,
     cancelled: e.cancelled,
     stats: e.stats,
+    eventbriteAttendeeId: e.eventbriteAttendeeId,
     profile: {
       name: e.volunteerName ?? 'Unknown',
       slug: e.volunteerSlug,

--- a/frontend/src/pages/modals/EntryEditModal.vue
+++ b/frontend/src/pages/modals/EntryEditModal.vue
@@ -76,6 +76,10 @@
         <input type="checkbox" class="eem-checkbox" v-model="form.cancelled" />
       </FormRow>
 
+      <FormRow v-if="isAdmin || entry.eventbriteAttendeeId" title="Eventbrite Attendee ID" :full-width="true">
+        <input class="eem-input eem-input--wide" :value="entry.eventbriteAttendeeId ?? ''" :disabled="true" />
+      </FormRow>
+
       <!-- Notes hidden during #189 testing — restore once tags migration complete and notes UX tidied -->
       <!-- <FormRow title="Notes" :full-width="true">
         <textarea class="eem-textarea" v-model="form.notes" rows="2" />
@@ -214,6 +218,12 @@ function deleteEntry() {
   padding: 0.3rem 0.5rem;
   font-family: inherit;
   font-size: 0.95rem;
+}
+
+.eem-input--wide {
+  width: 100%;
+  box-sizing: border-box;
+  color: var(--color-text-muted);
 }
 
 .eem-checkbox {

--- a/frontend/src/pages/modals/EntryEditModal.vue
+++ b/frontend/src/pages/modals/EntryEditModal.vue
@@ -139,6 +139,7 @@ const entryIcons = computed(() => iconsForEntry({
   hasProfileWarning: props.entry.profile.hasProfileWarning,
   isChild: form.accompanyingAdultId !== null,
   stats: { ...props.entry.stats, manual: form.statsManual },
+  eventbriteAttendeeId: props.entry.eventbriteAttendeeId,
 }))
 
 watch(() => props.entry, (e) => {

--- a/frontend/src/types/entry.ts
+++ b/frontend/src/types/entry.ts
@@ -25,6 +25,7 @@ export interface EntryItem {
   accompanyingAdultId?: number
   cancelled?: string // ISO datetime if booking was cancelled
   stats?: EntryStats
+  eventbriteAttendeeId?: string
   profile: EntryProfileSummary
   session: EntrySessionSummary
 }

--- a/frontend/src/utils/tagIcons.test.ts
+++ b/frontend/src/utils/tagIcons.test.ts
@@ -37,3 +37,25 @@ describe('iconsForEntry — Profile Warning', () => {
     expect(icons.some(i => i.alt === 'Profile Warning')).toBe(false)
   })
 })
+
+describe('iconsForEntry — Eventbrite', () => {
+  it('shows Eventbrite icon when eventbriteAttendeeId is set', () => {
+    const icons = iconsForEntry({ eventbriteAttendeeId: '12345' })
+    expect(icons.some(i => i.alt === 'Eventbrite')).toBe(true)
+  })
+
+  it('omits Eventbrite icon when only manual.eventbrite is set (not source of truth)', () => {
+    const icons = iconsForEntry({ stats: { manual: { eventbrite: true } } })
+    expect(icons.some(i => i.alt === 'Eventbrite')).toBe(false)
+  })
+
+  it('omits Eventbrite icon when eventbriteAttendeeId is absent', () => {
+    const icons = iconsForEntry({})
+    expect(icons.some(i => i.alt === 'Eventbrite')).toBe(false)
+  })
+
+  it('shows Eventbrite icon even when stats is absent', () => {
+    const icons = iconsForEntry({ eventbriteAttendeeId: '99' })
+    expect(icons.some(i => i.alt === 'Eventbrite')).toBe(true)
+  })
+})

--- a/frontend/src/utils/tagIcons.ts
+++ b/frontend/src/utils/tagIcons.ts
@@ -25,7 +25,7 @@ export const TAG_ICONS: TagIcon[] = [
   { icon: 'badges/firstaider.svg', alt: 'First Aider',      type: 'tag', color: 'green', manualKey: 'firstAider', snapshotKey: 'isFirstAider', activeLabel: 'On Duty', availableLabel: 'Available' },
   { icon: 'badges/csr.svg',        alt: 'CSR',              type: 'tag', manualKey: 'csr' },
   { icon: 'badges/late.svg',       alt: 'Late',             type: 'tag', manualKey: 'late' },
-  { icon: 'brands/eventbrite.svg', alt: 'Eventbrite',       type: 'tag', manualKey: 'eventbrite' },
+  { icon: 'brands/eventbrite.svg', alt: 'Eventbrite',       type: 'tag' },
   { icon: 'badges/regular.svg',    alt: 'Regular',          type: 'tag' },
   { icon: 'badges/new.svg',        alt: 'New',              type: 'tag' },
   { icon: 'badges/nophoto.svg',    alt: 'No Photo',         type: 'tag', color: 'red' },

--- a/frontend/src/utils/tagIcons.ts
+++ b/frontend/src/utils/tagIcons.ts
@@ -45,6 +45,7 @@ interface EntryIconSource {
   stats?: EntryStats
   isChild?: boolean
   hasProfileWarning?: boolean
+  eventbriteAttendeeId?: string
 }
 
 /** Builds the full icon list for an entry: profile badges + stats snapshot + stats manual */
@@ -60,6 +61,9 @@ export function iconsForEntry(e: EntryIconSource): TagIcon[] {
 
   // Entry-level tag: child (live from accompanyingAdultId, not frozen snapshot)
   if (e.isChild) icons.push({ icon: 'badges/child.svg', alt: 'Child', type: 'tag' })
+
+  if (e.eventbriteAttendeeId)
+    icons.push({ icon: 'brands/eventbrite.svg', alt: 'Eventbrite', type: 'tag' })
 
   if (e.stats) {
     const { snapshot, manual } = e.stats
@@ -87,7 +91,6 @@ export function iconsForEntry(e: EntryIconSource): TagIcon[] {
     if (manual?.digLead)    icons.push({ icon: 'badges/diglead.svg',    alt: 'Dig Lead',   type: 'tag' })
     if (manual?.csr)        icons.push({ icon: 'badges/csr.svg',        alt: 'CSR',        type: 'tag' })
     if (manual?.late)       icons.push({ icon: 'badges/late.svg',        alt: 'Late',       type: 'tag' })
-    if (manual?.eventbrite) icons.push({ icon: 'brands/eventbrite.svg', alt: 'Eventbrite', type: 'tag' })
   }
 
   return icons

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -20,5 +20,6 @@ export default defineConfig({
   test: {
     environment: 'happy-dom',
     globals: true,
+    include: ['src/**/*.test.ts'],
   },
 })

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "start": "node app.js",
     "dev": "cross-env NODE_ENV=development nodemon app.js",
     "test": "vitest",
+    "test:all": "vitest run && cd frontend && npx vitest run",
     "test:live": "node tests/run-tests.js",
     "frontend:build": "cd frontend && npm run build"
   },

--- a/types/api-responses.ts
+++ b/types/api-responses.ts
@@ -92,6 +92,7 @@ export interface ProfileEntryResponse {
   financialYear: string;
   cancelled?: string;
   stats?: EntryStats;
+  eventbriteAttendeeId?: string;
 }
 
 export interface ProfileGroupHours {
@@ -165,9 +166,10 @@ export interface EntryResponse {
   checkedIn: boolean;
   notes?: string;
   accompanyingAdultId?: number;
-  cancelled?: string; // ISO datetime if booking was cancelled
-  email?: string;     // only present for operational users (admin/check-in)
-  stats?: EntryStats; // snapshot; undefined if not yet computed (pre-migration entries)
+  cancelled?: string;          // ISO datetime if booking was cancelled
+  email?: string;              // only present for operational users (admin/check-in)
+  stats?: EntryStats;          // snapshot; undefined if not yet computed (pre-migration entries)
+  eventbriteAttendeeId?: string; // present when entry originated from Eventbrite
 }
 
 export interface SessionDetailResponse {
@@ -276,6 +278,7 @@ export interface EntryListItemResponse {
   accompanyingAdultId?: number;
   cancelled?: string;
   stats?: import('./entry-stats').EntryStats;
+  eventbriteAttendeeId?: string;
 }
 
 export interface TagHoursItem {

--- a/types/api-responses.ts
+++ b/types/api-responses.ts
@@ -122,6 +122,8 @@ export interface ProfileDetailResponse {
   matchName?: string;
   user?: string;
   isGroup: boolean;
+  isMember?: boolean;
+  cardStatus?: string;
   hoursLastFY: number;
   hoursThisFY: number;
   hoursAll: number;
@@ -257,8 +259,14 @@ export interface RecentSignupResponse {
   checkedIn: boolean;
   hours: number;
   count: number;
+  isGroup?: boolean;
+  isMember?: boolean;
+  cardStatus?: string;
+  hasProfileWarning?: boolean;
   accompanyingAdultId?: number;
-  cancelled?: string; // ISO datetime if booking was cancelled (appears in recent list ordered by Cancelled date)
+  cancelled?: string;
+  stats?: import('./entry-stats').EntryStats;
+  eventbriteAttendeeId?: string;
 }
 
 export interface EntryListItemResponse {
@@ -274,6 +282,9 @@ export interface EntryListItemResponse {
   hours: number;
   count: number;
   isGroup: boolean;
+  isMember?: boolean;
+  cardStatus?: string;
+  hasProfileWarning?: boolean;
   hasAccompanyingAdult: boolean;
   accompanyingAdultId?: number;
   cancelled?: string;

--- a/types/sharepoint.ts
+++ b/types/sharepoint.ts
@@ -73,8 +73,9 @@ export interface SharePointEntry extends SharePointBaseItem {
   BookedBy?: string;
   AccompanyingAdultLookupId?: number;
   AccompanyingAdult?: string;
-  Cancelled?: string; // ISO datetime when booking was cancelled; absent/null = active
-  Stats?: string;     // Snapshot JSON (EntryStats); frozen once session date passes
+  Cancelled?: string;              // ISO datetime when booking was cancelled; absent/null = active
+  Stats?: string;                  // Snapshot JSON (EntryStats); frozen once session date passes
+  EventbriteAttendeeID?: string;   // Eventbrite attendee ID; presence means this entry came via Eventbrite
   /** Allow bracket access for dynamic field names (SessionLookupId, ProfileLookupId, etc.) */
   [key: string]: any;
 }

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,6 +1,0 @@
-import { defineWorkspace } from 'vitest/config'
-
-export default defineWorkspace([
-  './vitest.config.ts',
-  './frontend/vite.config.ts',
-])


### PR DESCRIPTION
Adds EventbriteAttendeeID to the Entry SharePoint field, replaces the manual.eventbrite / #Eventbrite Notes tag as the sole driver of the Eventbrite icon. Extracts syncAttendeesForSession() shared across bulk sync, quick-sync, and session refresh. Adds backfill endpoint to populate the field on existing entries by name-matching against Eventbrite attendees. Cancellation now matches by AttendeeID with name-match fallback for pre-backfill entries.