### PR TITLE
fix(session): use stored stats for self-service session detail

### DIFF
--- a/backend/routes/sessions.ts
+++ b/backend/routes/sessions.ts
@@ -462,9 +462,7 @@ router.get('/sessions/:group/:date', async (req: Request, res: Response) => {
     const profiles = validateArray(rawProfiles, validateProfile, 'Profile');
     const profileMap = new Map(profiles.map(p => [p.ID, p]));
 
-    // Active entries: exclude cancelled for stats. All entries returned to operational users (with cancelled flag).
-    const activeEntries = sessionEntries.filter(e => !e[ENTRY_CANCELLED]);
-
+    // All session entries returned to operational users (with cancelled flag).
     const entryResponses: EntryResponse[] = sessionEntries.map(e => {
       const volunteerId = safeParseLookupId(e[PROFILE_LOOKUP]);
       const profile = volunteerId !== undefined ? profileMap.get(volunteerId) : undefined;
@@ -493,19 +491,6 @@ router.get('/sessions/:group/:date', async (req: Request, res: Response) => {
         eventbriteAttendeeId: e[ENTRY_EVENTBRITE_ATTENDEE_ID] || undefined
       };
     });
-
-    // Stats use only active (non-cancelled) entries
-    const totalHours = activeEntries.reduce((sum, e) => sum + parseHours(e.Hours), 0);
-    const newCount = activeEntries.filter(e => {
-      const pid = safeParseLookupId(e[PROFILE_LOOKUP]);
-      if (pid === undefined) return false;
-      const ps = JSON.parse(profileMap.get(pid)?.[PROFILE_STATS] || '{}');
-      return Array.isArray(ps.sessionIds) && ps.sessionIds[0] === spSession.ID && !e.Labels?.includes('Regular');
-    }).length;
-    const childCount = activeEntries.filter(e => !!e.AccompanyingAdultLookupId).length;
-    const regularCount = activeEntries.filter(e => e.Labels?.includes('Regular')).length;
-    const cancelledRegularCount = sessionEntries.filter(e => e[ENTRY_CANCELLED] && e.Labels?.includes('Regular')).length || undefined;
-    const eventbriteCount = activeEntries.filter(e => !!e[ENTRY_EVENTBRITE_ATTENDEE_ID]).length;
 
     // Per-user personalised flags — from profile stats (all roles) with live entry fallback for admin/checkin
     // For self-service: also look up their own entry to return userEntryId (needed for cancel flow)
@@ -570,15 +555,9 @@ router.get('/sessions/:group/:date', async (req: Request, res: Response) => {
       limits: sessionLimits,
       storedLimits: rawLimits,
       regularsCount,
-      stats: {
-        count: isSelfService ? storedStats.count : activeEntries.length,
-        hours: Math.round(totalHours * 10) / 10,
-        new: newCount || undefined,
-        child: childCount || undefined,
-        regular: regularCount || undefined,
-        cancelledRegular: cancelledRegularCount,
-        eventbrite: eventbriteCount || undefined,
-      },
+      // Session stats are persisted on the session item and refreshed after writes.
+      // Keep this endpoint consistent across public, trusted, and self-service callers.
+      stats: storedStats,
       financialYear: `FY${calculateFinancialYear(new Date(spSession.Date))}`,
       isBookable: spSession.Date >= today,
       eventbriteEventId: spSession.EventbriteEventID,

--- a/backend/services/repositories/sessions-repository.ts
+++ b/backend/services/repositories/sessions-repository.ts
@@ -142,11 +142,12 @@ class SessionsRepository {
     sharePointClient.clearCacheByPrefix('session_slug_');
   }
 
-  // Updates only the Stats field — clears sessions cache only (not full flush).
-  // Bulk refresh callers (session-stats.ts) call clearCacheKey('sessions') once after the loop instead.
+  // Updates only the Stats field — keep list/item caches coherent without a full flush.
+  // Bulk refresh callers (session-stats.ts) still clear the sessions list once after the loop.
   async updateStats(sessionId: number, stats: Record<string, any>): Promise<void> {
     await sharePointClient.updateListItem(this.listGuid, sessionId, { [SESSION_STATS]: JSON.stringify(stats) });
     sharePointClient.clearCacheKey('sessions');
+    sharePointClient.clearCacheKey(`session_item_${sessionId}`);
     sharePointClient.clearCacheByPrefix('sessions_FY');
     // Slug entries are not affected by stats-only updates — no slug clear needed here
   }

--- a/docs/testing/full-regression.md
+++ b/docs/testing/full-regression.md
@@ -79,6 +79,7 @@ Run with `npm run dev` at http://localhost:3000. Log in via Microsoft Entra ID.
 - [ ] Self-Service: registering for a session that already has their entry returns 409 (duplicate prevention)
 - [ ] Self-Service: cannot register another volunteer — `POST /api/sessions/.../entries` with a different profileId returns 403
 - [ ] Self-Service: can cancel own future booking via `PATCH /api/entries/:id` with `{ cancelled: true }`; another volunteer’s entry returns 403; `DELETE /api/entries/:id` returns 403 (admins only)
+- [ ] Self-Service: session detail stats match stored `session.stats` values (same regular/new/child/eventbrite totals as trusted view); regulars denominator uses cancellation-adjusted value (`regularsCount - cancelledRegular`)
 - [ ] Self-Service: Upload button visible on own entry detail; can upload photos
 - [ ] **Public API security — media PII**: `GET /api/media?sessionId=X` response does **not** contain `name` or `webUrl` fields (these embed uploader's name in the filename)
 - [ ] **Public API security — media PII**: authenticated `GET /api/media?sessionId=X` response **does** include `name` and `webUrl`

--- a/frontend/src/utils/sessionStats.test.ts
+++ b/frontend/src/utils/sessionStats.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { sessionDisplayStats } from './sessionStats'
+
+describe('sessionDisplayStats', () => {
+  it('reduces effective regulars by cancelled regular count', () => {
+    const display = sessionDisplayStats(
+      { count: 12, hours: 36, regular: 6, cancelledRegular: 2 },
+      10,
+      { total: 20 },
+    )
+
+    expect(display.regular).toBe(6)
+    expect(display.effectiveRegularsCount).toBe(8)
+  })
+
+  it('never returns a negative effective regulars count', () => {
+    const display = sessionDisplayStats(
+      { count: 3, hours: 9, regular: 1, cancelledRegular: 5 },
+      2,
+      { total: 10 },
+    )
+
+    expect(display.effectiveRegularsCount).toBe(0)
+  })
+})

--- a/frontend/src/utils/sessionStats.ts
+++ b/frontend/src/utils/sessionStats.ts
@@ -33,7 +33,7 @@ export function sessionDisplayStats(
     eventbrite: stats.eventbrite ?? 0,
     repeatCount: Math.max(0, stats.count - (stats.new ?? 0) - (stats.regular ?? 0)),
     effectiveRegularsCount: regularsCount !== undefined
-      ? regularsCount - (stats.cancelledRegular ?? 0)
+      ? Math.max(0, regularsCount - (stats.cancelledRegular ?? 0))
       : undefined,
     spacesLeft: limits?.total !== undefined ? limits.total - stats.count : null,
     totalLimit: limits?.total,


### PR DESCRIPTION
Use the persisted session stats payload for authenticated detail responses so self-service shows the same regular/cancellation totals as trusted views, and add coverage for cancellation-adjusted regular display math.