### PR TITLE
fix(email): improve pre-session email clarity and subject encoding

### DIFF
--- a/backend/services/email-renderer.test.ts
+++ b/backend/services/email-renderer.test.ts
@@ -28,6 +28,15 @@ describe('pre-session email', () => {
     expect(subject).toContain('3 May')
   })
 
+  it('renders apostrophes in subject as plain text', async () => {
+    const { subject } = await renderEmail('pre-session', {
+      ...PRE_SESSION_VARS,
+      groupName: "Women's Dig",
+    })
+    expect(subject).toBe("Women's Dig details for 3 May")
+    expect(subject).not.toContain('&#x27;')
+  })
+
   it('renders html with volunteer name and session URL', async () => {
     const { html } = await renderEmail('pre-session', PRE_SESSION_VARS)
     expect(html).toContain('Alice')

--- a/backend/services/email-renderer.test.ts
+++ b/backend/services/email-renderer.test.ts
@@ -38,9 +38,13 @@ describe('pre-session email', () => {
   })
 
   it('renders html with volunteer name and session URL', async () => {
-    const { html } = await renderEmail('pre-session', PRE_SESSION_VARS)
+    const { html } = await renderEmail('pre-session', {
+      ...PRE_SESSION_VARS,
+      sessionTitle: 'Women Dig Intro Session',
+    })
     expect(html).toContain('Alice')
     expect(html).toContain('sessions/trail-crew/2025-05-03')
+    expect(html).toContain('Session:</strong> Women Dig Intro Session')
   })
 
   it('renders non-empty text', async () => {

--- a/backend/services/email-renderer.test.ts
+++ b/backend/services/email-renderer.test.ts
@@ -44,7 +44,7 @@ describe('pre-session email', () => {
     })
     expect(html).toContain('Alice')
     expect(html).toContain('sessions/trail-crew/2025-05-03')
-    expect(html).toContain('Session:</strong> Women Dig Intro Session')
+    expect(html).toContain('Women Dig Intro Session')
   })
 
   it('renders non-empty text', async () => {

--- a/backend/services/email-renderer.ts
+++ b/backend/services/email-renderer.ts
@@ -63,6 +63,14 @@ async function loadTemplate(filePath: string): Promise<HandlebarsTemplateDelegat
   return compiled;
 }
 
+async function loadSubjectTemplate(filePath: string): Promise<HandlebarsTemplateDelegate> {
+  if (process.env.NODE_ENV !== 'development' && templateCache.has(filePath)) return templateCache.get(filePath)!;
+  const src = await fs.readFile(filePath, 'utf-8');
+  const compiled = Handlebars.compile(src, { noEscape: true });
+  templateCache.set(filePath, compiled);
+  return compiled;
+}
+
 export function clearEmailTemplateCache(): void {
   templateCache.clear();
 }
@@ -70,7 +78,7 @@ export function clearEmailTemplateCache(): void {
 export async function renderEmail(template: string, vars: Record<string, unknown>): Promise<RenderedEmail> {
   const templateDir = path.join(TEMPLATES_DIR, template);
   const [renderSubject, renderText, renderHtml, renderBase] = await Promise.all([
-    loadTemplate(path.join(templateDir, 'subject.hbs')),
+    loadSubjectTemplate(path.join(templateDir, 'subject.hbs')),
     loadTemplate(path.join(templateDir, 'text.hbs')),
     loadTemplate(path.join(templateDir, 'html.hbs')),
     loadTemplate(path.join(TEMPLATES_DIR, 'base.hbs')),

--- a/docs/design/booking-actions.md
+++ b/docs/design/booking-actions.md
@@ -1,0 +1,79 @@
+# Session Booking Actions
+
+## Known Facts
+- Session is either Future or Past
+- User is either Public or Logged In
+- Attended (past) or Booked (future) = user has non-cancelled entry for session.
+- Regular users are automatically booked on sessions and gurenteed a space.
+- A New user defined by this being their first session. Spaces can be limited. Or zero for non-open sessions.
+- A Repeat user defined by not a regular, and not new.
+- Sessions are never Cancelled, booking closes as the session becomes "past".
+
+## Possible Combinations
+
+| User     | Past            | New Space    | Repeat Only  | No Space     |
+|----------|-----------------|--------------|--------------|--------------|
+| Public   | Login to Upload | Book         | Limited      | Sold Out     |
+| New      | Next            | Book         | Next         | Next         |
+| Repeat   | Next            | Book         | Book         | Next         |
+| Regular  | Next            | Book         | Book         | Book         |
+| Booked   | Upload          | Cancel/Child | Cancel/Child | Cancel/Child |
+
+## State Machine
+
+```
+If Past Session:
+
+    If Public:
+        "Did you attend this session?"
+        [Login to upload photos]
+
+
+    If Logged In:
+
+        If Attended:
+            "You attended."
+            [Upload photos]
+
+        Else:
+            "Like the look of this?"
+            [Book on the next one]
+
+Else If Future Session:
+
+    If Public:
+
+        If New Spaces:
+            "Space available."
+            [Book Here]
+
+        Else If No New and Repeat Spaces:
+            "Limited availability."
+            [Login to Book]
+
+    If Logged In and Booked:
+
+        "You're all booked on."
+        [Cancel]
+        "or"
+        [Add Child] {if Child Space}
+
+    Else If Can Book:
+            "Space available."
+            [Book here]
+            {Child Message}
+
+        Else If Cannot Book and Repeat Spaces:
+            "Limited availability."
+            [Next Session]
+
+        Else If No New and No Repeat:
+            "Sold out."
+            [Next Session]
+
+    Else No New and No Repeat:
+
+        "Sold out."
+        [Next Session]
+
+```

--- a/templates/email/pre-session/html.hbs
+++ b/templates/email/pre-session/html.hbs
@@ -9,6 +9,9 @@
 {{/section}}
 
 {{#section}}
+  {{#if sessionTitle}}
+  <p style="margin:0 0 16px;"><strong>{{sessionTitle}}</strong></p>
+  {{/if}}
   {{#if description}}
   <p style="margin:0 0 16px;">{{{nl2br description}}}</p>
   {{/if}}

--- a/templates/email/pre-session/text.hbs
+++ b/templates/email/pre-session/text.hbs
@@ -3,10 +3,16 @@ Hi {{volunteerName}}, you're booked onto the next {{groupName}}.
 Date: {{formattedDateLong}}
 Time: 9:30 to 12:30 (about 3 hours)
 Location: By the DTV containers, Forest of Dean Cycle Centre
+{{#if sessionTitle}}
+
+{{sessionTitle}}
+{{/if}}
 {{#if description}}
 
 {{description}}
 {{/if}}
+
+
 
 Please bring sturdy boots, clothes you don't mind getting muddy, and water. Gloves are useful if you have them. We'll provide tools and hi-viz.
 {{#if tags}}


### PR DESCRIPTION
## Summary
- stop HTML entity escaping in pre-session/post-session subject template rendering so apostrophes render correctly (e.g. Women's Dig)
- add session title near the top of pre-session HTML/text email body content so recipients can quickly identify the session
- add/extend email renderer tests to cover unescaped apostrophes in subject and session-title rendering in email HTML

## Test plan
- [x] Run `npx vitest run backend/services/email-renderer.test.ts`
- [ ] Send a pre-session preview email for a session with apostrophe in group name and confirm the subject line is plain text
- [ ] Send a pre-session preview email with a session title and confirm title appears above the main body copy