### PR TITLE
Require profile User for Microsoft login and simplify access labels

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ Feature-complete volunteer tracking application with:
 All pages are Vue 3 SPA routes defined in [frontend/src/router/index.ts](frontend/src/router/index.ts).
 
 - Dashboard with FY stats, next session card, personalised calendar ([HomePage.vue](frontend/src/pages/HomePage.vue))
-- Admin page with Eventbrite sync buttons, exports, backup export, site shortcuts ([AdminPage.vue](frontend/src/pages/AdminPage.vue))
+- Tools page (`/tools`, UI label **Tools**; `/admin` redirects) with Eventbrite sync buttons, exports, backup export, site shortcuts ([AdminPage.vue](frontend/src/pages/AdminPage.vue))
 - Groups listing with FY filter ([GroupListPage.vue](frontend/src/pages/GroupListPage.vue))
 - Group detail with FY stats, FY bar chart, regulars, sessions, edit/create/delete ([GroupDetailPage.vue](frontend/src/pages/GroupDetailPage.vue))
 - Sessions listing with FY filter, calendar view, text search, cascading filters, bulk tagging, CSV download ([SessionListPage.vue](frontend/src/pages/SessionListPage.vue))

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ Feature-complete volunteer tracking application with:
 - Data layer handling SharePoint quirks, enrichment, and FY stats ([services/data-layer.ts](services/data-layer.ts))
 - Repository pattern for each SharePoint list ([services/repositories/](services/repositories/))
 - Auth middleware with session auth + API key bypass ([middleware/require-auth.ts](middleware/require-auth.ts))
-- Role-based authorization: Admin, Check In, Read Only, Self-Service, and Public ([middleware/require-admin.ts](middleware/require-admin.ts))
+- Role-based authorization: Admin, Check In, Self-Service, and Public ([middleware/require-admin.ts](middleware/require-admin.ts)); **Admin extends Check In** (same field-day APIs plus admin-only routes)
 - Server-side caching with tier-informed per-entity TTLs and targeted per-repository invalidation
 - Hosted on Azure App Service with Azure Logic App for scheduled Eventbrite sync
 
@@ -149,7 +149,7 @@ All data computation is server-side in the stats pipeline (ProfileStats → Sess
 - **`RoleContext`** interface — plain snapshot for passing auth context into components as a prop.
 - **Pages**: `const profile = useViewer()` → use `profile.isAdmin` in template; pass `:profile="profile.context"` to child components.
 - **Components**: accept `profile?: RoleContext` as a prop — never call `useViewer()` inside a component.
-- **`isOperational`** = Admin or Check-In.
+- **`hasCheckInAccess`** = Admin or Check-In (check-in tier: session/volunteer operations UI). Prefer this over vague “operational” wording.
 
 ### Vue Frontend: Page and Store Pattern
 
@@ -218,9 +218,10 @@ The Profiles list also has a `Stats` JSON field storing `hoursByFY`, `sessionsBy
 
 ### Permissions / Authorization
 
-- Five access levels: **Admin** (full), **Check In** (field-day ops), **Read Only** (view only), **Self-Service** (own data via magic link), **Public** (unauthenticated)
-- **"Trusted"** = Admin + Check In + Read Only. Self-Service is explicitly not trusted.
-- Admin: `ADMIN_USERS` env var. Check In: Profile `User` field. Self-Service: Profile `Email` field (comma-separated). Everyone else via Microsoft = Read Only.
+- Four app permission levels (+ Microsoft auth rules): **Admin** (`ADMIN_USERS` + Profile `User` — full system), **Check In** (Profile `User` only — field-day ops), **Self-Service** (Profile `Email` / magic link — own data), **Public** (unauthenticated).
+- Capability stack (additive): **Public** ⊆ **Check In tier** ⊆ **Admin tier** (`admin = public + check-in + admin-only`). UI should be additive (admin sees check-in surface plus extra controls), not unrelated “modes”.
+- **"Trusted"** (Microsoft-linked) = Admin ∪ Check In. Self-Service is not trusted for other volunteers’ PII.
+- **Microsoft sign-in**: requires a Profiles list **`User`** value matching the signed-in work email. If not linked, sign-in is **rejected** (session cleared, `/login?reason=dtv-not-authorised`) — not the same as choosing public browsing. **Admin** still needs **`ADMIN_USERS`** in addition to **`User`**.
 - Backend: `requireAuth` gates all API routes; `requireAdmin` enforces role rules; handlers enforce ownership for self-service.
 - Frontend: CSS classes control visibility — `.admin-only`, `.checkin-only`, `.trusted-only`, `.auth-only`, `.unauth-only`, `.selfservice-only`.
 - All login redirects go to `/login` — never `/auth/login`.

--- a/app.js
+++ b/app.js
@@ -74,7 +74,7 @@ if (!isDev) {
 }
 
 // Stable media proxy — serves SharePoint images via stable app-domain URLs.
-// Trusted users (admin/check-in/read-only) always served; self-service and public only see isPublic === true items.
+// Trusted Microsoft users (admin/check-in) always served; self-service and public only see isPublic === true items.
 // Public items cached 12h in memory and 24h in browser. Retries once on 401/403 with fresh folder metadata.
 app.get('/media/:group/:date/:id', async (req, res) => {
     const groupKey = req.params.group.toLowerCase();

--- a/backend/middleware/public-api-get-paths.ts
+++ b/backend/middleware/public-api-get-paths.ts
@@ -1,0 +1,28 @@
+import type { Request } from 'express';
+
+/**
+ * Full-path prefixes for API GETs allowed without a session (PII-safe).
+ * Used by `require-auth.ts` (global) and `require-admin.ts` (mounted under `/api`).
+ * `req.path` alone is not enough inside the API router — combine with `req.baseUrl`.
+ */
+export const PUBLIC_API_GET_PATH_PREFIXES: readonly string[] = [
+  '/api/stats',
+  '/api/sessions',
+  '/api/groups',
+  '/api/tags',
+  '/api/media',
+  '/api/email/sandbox',
+];
+
+function fullApiPath(req: Pick<Request, 'path' | 'baseUrl'>): string {
+  const base = req.baseUrl ?? '';
+  const path = req.path ?? '';
+  if (!base) return path;
+  return path === '/' ? base : base + path;
+}
+
+export function isPublicApiGet(req: Pick<Request, 'method' | 'path' | 'baseUrl'>): boolean {
+  if (req.method !== 'GET') return false;
+  const full = fullApiPath(req);
+  return PUBLIC_API_GET_PATH_PREFIXES.some(p => full.startsWith(p));
+}

--- a/backend/middleware/require-admin.ts
+++ b/backend/middleware/require-admin.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 /// <reference path="../types/express-session.d.ts" />
+import { isPublicApiGet } from './public-api-get-paths';
 
 const CHECKIN_ALLOWED_PATTERNS = [
   { method: 'PATCH', pattern: /^\/entries\/\d+$/ },           // check-in + set hours
@@ -51,6 +52,18 @@ export function requireAdmin(req: Request, res: Response, next: NextFunction): v
   // API key auth (scheduled sync) bypasses role checks
   if (!req.session.user && req.headers['x-api-key']) {
     next();
+    return;
+  }
+
+  // Anonymous (or post-logout) public reads — same paths as require-auth; must not require a role
+  if (isPublicApiGet(req)) {
+    next();
+    return;
+  }
+
+  // From here on, authenticated role is required for this request path
+  if (!req.session.user) {
+    res.status(403).json({ success: false, error: 'Not permitted' });
     return;
   }
 

--- a/backend/middleware/require-admin.ts
+++ b/backend/middleware/require-admin.ts
@@ -84,22 +84,25 @@ export function requireAdmin(req: Request, res: Response, next: NextFunction): v
     return;
   }
 
-  // Block admin-only GET endpoints
-  if (req.method === 'GET') {
-    if (ADMIN_ONLY_GET_PATTERNS.some(p => p.test(req.path))) {
-      res.status(403).json({ success: false, error: 'Admin access required' });
+  // Check-in only — must match role exactly (stale sessions may still carry removed roles such as
+  // `readonly`; those must never fall through into this allowlist).
+  if (role === 'checkin') {
+    if (req.method === 'GET') {
+      if (ADMIN_ONLY_GET_PATTERNS.some(p => p.test(req.path))) {
+        res.status(403).json({ success: false, error: 'Admin access required' });
+        return;
+      }
+      next();
       return;
     }
-    next();
+    if (CHECKIN_ALLOWED_PATTERNS.some(p => p.method === req.method && p.pattern.test(req.path))) {
+      next();
+      return;
+    }
+    res.status(403).json({ success: false, error: 'Admin access required' });
     return;
   }
 
-  // Allow specific write operations for Check In Only
-  if (CHECKIN_ALLOWED_PATTERNS.some(p => p.method === req.method && p.pattern.test(req.path))) {
-    next();
-    return;
-  }
-
-  // Block all other write operations
-  res.status(403).json({ success: false, error: 'Admin access required' });
+  // Unknown or legacy role (e.g. pre-deploy `readonly`) — deny; do not treat as check-in.
+  res.status(403).json({ success: false, error: 'Not permitted' });
 }

--- a/backend/middleware/require-admin.ts
+++ b/backend/middleware/require-admin.ts
@@ -60,16 +60,6 @@ export function requireAdmin(req: Request, res: Response, next: NextFunction): v
     return;
   }
 
-  // Read Only users: allow GETs (except exports), block all writes
-  if (role === 'readonly') {
-    if (req.method === 'GET' && !ADMIN_ONLY_GET_PATTERNS.some(p => p.test(req.path))) {
-      next();
-      return;
-    }
-    res.status(403).json({ success: false, error: 'Read only access' });
-    return;
-  }
-
   // Self-service users: public-equivalent GET access + own profile + narrow write allowlist
   if (role === 'selfservice') {
     if (req.method === 'GET') {

--- a/backend/middleware/require-auth.ts
+++ b/backend/middleware/require-auth.ts
@@ -1,11 +1,9 @@
 import { Request, Response, NextFunction } from 'express';
 /// <reference path="../types/express-session.d.ts" />
-
-// GET paths accessible without authentication (no PII returned)
-const PUBLIC_GET_PATHS = ['/api/stats', '/api/sessions', '/api/groups', '/api/tags', '/api/media', '/api/email/sandbox'];
+import { isPublicApiGet } from './public-api-get-paths';
 
 export function requireAuth(req: Request, res: Response, next: NextFunction): void {
-  if (req.method === 'GET' && PUBLIC_GET_PATHS.some(p => req.path.startsWith(p))) {
+  if (isPublicApiGet(req)) {
     next();
     return;
   }

--- a/backend/routes/auth/dtv.ts
+++ b/backend/routes/auth/dtv.ts
@@ -54,39 +54,51 @@ router.get('/callback', async (req: Request, res: Response) => {
       headers: { Authorization: `Bearer ${tokenResponse.accessToken}` },
     });
 
-    const profile = graphResponse.data;
-    const email = profile.mail || profile.userPrincipalName;
+    const graphProfile = graphResponse.data;
+    const email = graphProfile.mail || graphProfile.userPrincipalName;
 
     const adminUsers = (process.env.ADMIN_USERS || '').split(',').map((e: string) => e.trim().toLowerCase()).filter(Boolean);
     const profiles = await profilesRepository.getAll();
     const matchedProfile = profiles.find(p => p.User?.toLowerCase() === email.toLowerCase());
+    const savedReturnTo = req.session.returnTo;
 
-    let role: 'admin' | 'checkin' | 'readonly' = 'readonly';
-    if (adminUsers.includes(email.toLowerCase())) {
-      role = 'admin';
-    } else if (matchedProfile) {
-      role = 'checkin';
+    if (!matchedProfile) {
+      req.session.destroy((destroyErr) => {
+        if (destroyErr) console.error('Session destroy:', destroyErr.message);
+        const q = 'reason=dtv-not-authorised';
+        const path =
+          savedReturnTo && savedReturnTo.startsWith('/')
+            ? `/login?${q}&returnTo=${encodeURIComponent(savedReturnTo)}`
+            : `/login?${q}`;
+        res.redirect(path);
+      });
+      return;
     }
+
+    const role: 'admin' | 'checkin' = adminUsers.includes(email.toLowerCase()) ? 'admin' : 'checkin';
 
     let profileStats: NonNullable<typeof req.session.user>['profileStats'] | undefined;
-    if (matchedProfile?.[PROFILE_STATS]) {
-      try { profileStats = JSON.parse(matchedProfile[PROFILE_STATS]); } catch {}
+    if (matchedProfile[PROFILE_STATS]) {
+      try { profileStats = JSON.parse(matchedProfile[PROFILE_STATS]); } catch { /* ignore */ }
     }
 
+    delete req.session.returnTo;
+
     req.session.user = {
-      id: profile.id,
-      displayName: profile.displayName,
+      id: String(matchedProfile.ID),
+      displayName: matchedProfile.Title || email,
       email,
       role,
-      profileSlug: matchedProfile ? profileSlug(matchedProfile.Title, matchedProfile.ID) : undefined,
-      profileId: matchedProfile?.ID,
+      profileSlug: profileSlug(matchedProfile.Title, matchedProfile.ID),
+      profileId: matchedProfile.ID,
       freshAuthAt: new Date().toISOString(),
       profileStats,
     };
 
-    const returnTo = req.session.returnTo || '/';
-    delete req.session.returnTo;
-    const returnToWithNotice = returnTo.includes('?') ? `${returnTo}&flashKey=signed-in` : `${returnTo}?flashKey=signed-in`;
+    const returnToPath = savedReturnTo && savedReturnTo.startsWith('/') ? savedReturnTo : '/';
+    const returnToWithNotice = returnToPath.includes('?')
+      ? `${returnToPath}&flashKey=signed-in`
+      : `${returnToPath}?flashKey=signed-in`;
     res.redirect(returnToWithNotice);
   } catch (error: any) {
     console.error('Error in auth callback:', error.message);

--- a/backend/routes/entries.ts
+++ b/backend/routes/entries.ts
@@ -43,6 +43,7 @@ import { sharePointClient } from '../services/sharepoint-client';
 import { mediaDriveId, exifDate, mediaFilename } from '../services/media-upload';
 
 import type { EntryDetailResponse, EntryListItemResponse, RecentSignupResponse, EntryUploadContextResponse } from '../../types/api-responses';
+import { trackerAccessForProfileUser } from '../services/tracker-access';
 import type { ApiResponse } from '../../types/sharepoint';
 
 const router: Router = express.Router();
@@ -229,6 +230,9 @@ router.get('/entries', async (req: Request, res: Response) => {
 
     const entries = validateArray(rawEntries, validateEntry, 'Entry');
 
+    const showTrackerAccess =
+      req.session.user?.role === 'admin' || req.session.user?.role === 'checkin';
+
     const results: EntryListItemResponse[] = entries
       .flatMap(e => {
         const sessionId = safeParseLookupId(e[SESSION_LOOKUP]);
@@ -291,6 +295,7 @@ router.get('/entries', async (req: Request, res: Response) => {
           cancelled: e.Cancelled || undefined,
           labels: e.Labels,
           eventbriteAttendeeId: e[ENTRY_EVENTBRITE_ATTENDEE_ID] || undefined,
+          ...(showTrackerAccess ? { trackerAccess: trackerAccessForProfileUser(profile?.User) } : {}),
         }];
       })
       .sort((a, b) => b.date.localeCompare(a.date));

--- a/backend/routes/media.ts
+++ b/backend/routes/media.ts
@@ -44,7 +44,7 @@ router.get('/media/counts', async (req: Request, res: Response) => {
 });
 
 // List media in a session folder. Returns stable proxy URLs (not raw SharePoint pre-auth URLs).
-// Trusted users (admin/check-in/read-only) see all items with raw SharePoint URLs for direct CDN access.
+// Trusted Microsoft users (admin/check-in) see all items with raw SharePoint URLs for direct CDN access.
 // Self-service and unauthenticated users only see isPublic === true items via stable proxy URLs.
 router.get('/media', async (req: Request, res: Response) => {
   const groupKey = (req.query.groupKey as string || '').replace(/[^a-zA-Z0-9-]/g, '');
@@ -76,7 +76,7 @@ router.get('/media', async (req: Request, res: Response) => {
   }
 });
 
-// Download the original file. Trusted DTV users only (admin/check-in/read-only).
+// Download the original file. Trusted Microsoft users only (admin/check-in).
 // Fetches the file server-side and serves it with Content-Disposition: attachment.
 router.get('/media/:itemId/download', async (req: Request, res: Response) => {
   const role = req.session?.user?.role;

--- a/backend/routes/profiles.ts
+++ b/backend/routes/profiles.ts
@@ -35,6 +35,7 @@ import {
   PROFILE_STATS
 } from '../services/field-names';
 import type { ProfileResponse, ProfileDetailResponse, ProfileEntryResponse, ProfileGroupHours, ConsentRecordResponse } from '../../types/api-responses';
+import { trackerAccessForProfileUser } from '../services/tracker-access';
 import type { ApiResponse } from '../../types/sharepoint';
 
 const router: Router = express.Router();
@@ -145,6 +146,9 @@ router.get('/profiles', async (req: Request, res: Response) => {
       } catch { /* skip malformed */ }
     }
 
+    const showTrackerAccess =
+      req.session.user?.role === 'admin' || req.session.user?.role === 'checkin';
+
     const data: ProfileResponse[] = validProfiles.map(spProfile => {
       const profile = convertProfile(spProfile);
       const ps = profileStats.get(spProfile.ID);
@@ -154,6 +158,7 @@ router.get('/profiles', async (req: Request, res: Response) => {
         name: profile.name,
         email: profile.email,
         user: profile.user,
+        ...(showTrackerAccess ? { trackerAccess: trackerAccessForProfileUser(spProfile.User) } : {}),
         isGroup: profile.isGroup,
         isMember: memberIds.has(spProfile.ID),
         cardStatus: cardStatusMap.get(spProfile.ID),
@@ -799,6 +804,7 @@ router.get('/profiles/:slug', async (req: Request, res: Response) => {
     }));
 
     const isSelfService = req.session.user?.role === 'selfservice';
+    const trustedMicrosoft = req.session.user?.role === 'admin' || req.session.user?.role === 'checkin';
 
     const data: ProfileDetailResponse = {
       id: profile.id,
@@ -807,6 +813,7 @@ router.get('/profiles/:slug', async (req: Request, res: Response) => {
       emails: profile.emails,
       matchName: spProfile.MatchName,
       user: spProfile.User,
+      ...(trustedMicrosoft ? { trackerAccess: trackerAccessForProfileUser(spProfile.User) } : {}),
       isGroup: profile.isGroup,
       isMember,
       cardStatus,

--- a/backend/routes/sessions.ts
+++ b/backend/routes/sessions.ts
@@ -36,6 +36,7 @@ import {
 import type { SessionResponse, SessionDetailResponse, EntryResponse } from '../../types/api-responses';
 import type { ApiResponse } from '../../types/sharepoint';
 import { sharePointClient } from '../services/sharepoint-client';
+import { trackerAccessForProfileUser } from '../services/tracker-access';
 import { taxonomyClient } from '../services/taxonomy-client';
 import { runSessionStatsRefresh } from '../services/session-stats';
 
@@ -451,7 +452,7 @@ router.get('/sessions/:group/:date', async (req: Request, res: Response) => {
     const selfProfileId = req.session.user?.profileId;
     const selfProfileStats = req.session.user?.profileStats;
     const isSelfService = role === 'selfservice';
-    const isOperational = role === 'admin' || role === 'checkin';
+    const hasCheckInTier = role === 'admin' || role === 'checkin';
 
     const [rawEntries, rawProfiles] = await Promise.all([
       isSelfService ? Promise.resolve([]) : entriesRepository.getBySessionIds([spSession.ID]),
@@ -462,7 +463,7 @@ router.get('/sessions/:group/:date', async (req: Request, res: Response) => {
     const profiles = validateArray(rawProfiles, validateProfile, 'Profile');
     const profileMap = new Map(profiles.map(p => [p.ID, p]));
 
-    // All session entries returned to operational users (with cancelled flag).
+    // All session entries returned to check-in tier users (with cancelled flag).
     const entryResponses: EntryResponse[] = sessionEntries.map(e => {
       const volunteerId = safeParseLookupId(e[PROFILE_LOOKUP]);
       const profile = volunteerId !== undefined ? profileMap.get(volunteerId) : undefined;
@@ -483,7 +484,8 @@ router.get('/sessions/:group/:date', async (req: Request, res: Response) => {
         notes: e.Notes,
         accompanyingAdultId: safeParseLookupId(e.AccompanyingAdultLookupId),
         cancelled: e[ENTRY_CANCELLED] || undefined,
-        email: isOperational ? (profile ? parseEmails(profile.Email)[0] : undefined) : undefined,
+        email: hasCheckInTier ? (profile ? parseEmails(profile.Email)[0] : undefined) : undefined,
+        ...(hasCheckInTier ? { trackerAccess: trackerAccessForProfileUser(profile?.User) } : {}),
         labels: e.Labels,
         isNew: isNew || undefined,
         noPhoto: pStats.noPhoto === true || undefined,

--- a/backend/routes/stats.ts
+++ b/backend/routes/stats.ts
@@ -2,6 +2,7 @@ import express, { Request, Response, Router } from 'express';
 import { sharePointClient, CACHE_TTL } from '../services/sharepoint-client';
 import { taxonomyClient } from '../services/taxonomy-client';
 import { clearMediaCache } from '../services/media-cache';
+import { clearCoverCache } from '../services/cover-cache';
 import { sessionsRepository } from '../services/repositories/sessions-repository';
 import { profilesRepository } from '../services/repositories/profiles-repository';
 import { calculateCurrentFY, calculateFinancialYear, safeParseLookupId } from '../services/data-layer';
@@ -213,6 +214,7 @@ router.post('/cache/clear', (req: Request, res: Response) => {
     sharePointClient.clearColumnCache();
     taxonomyClient.clearTreeCache();
     clearMediaCache();
+    clearCoverCache();
     res.json({ success: true, message: 'Cache cleared successfully' });
   } catch (error: any) {
     console.error('Error clearing cache:', error);

--- a/backend/services/tracker-access.ts
+++ b/backend/services/tracker-access.ts
@@ -1,0 +1,19 @@
+/** Microsoft Tracker tier implied by Profile `User` + `ADMIN_USERS`. Trusted API responses only. */
+
+import type { TrackerAccess } from '../../types/api-responses';
+
+export function adminUsersSet(): Set<string> {
+  return new Set(
+    (process.env.ADMIN_USERS || '')
+      .split(',')
+      .map((e) => e.trim().toLowerCase())
+      .filter(Boolean)
+  );
+}
+
+export function trackerAccessForProfileUser(userField: string | undefined | null): TrackerAccess {
+  const u = userField?.trim().toLowerCase();
+  if (!u) return 'none';
+  if (adminUsersSet().has(u)) return 'admin';
+  return 'checkin';
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -7,8 +7,8 @@ All endpoints are prefixed with `/api`. Auth routes (`/auth/...`) are listed at 
 | Level | Who |
 |---|---|
 | **Public** | No login required |
-| **Trusted** | Any Microsoft login — Read Only, Check In, or Admin |
-| **Check In+** | Check In or Admin |
+| **Trusted** | Microsoft session with Profile **`User`** link — Check In or Admin |
+| **Check In+** | Check In or Admin (check-in tier APIs) |
 | **Admin** | Admin only |
 | **Admin / API key** | Admin session or `X-Api-Key` header (scheduled sync) |
 | **SS (own)** | Self-service login restricted to own data; handler enforces ownership |

--- a/docs/api.md
+++ b/docs/api.md
@@ -180,7 +180,7 @@ All pages are Vue 3 SPA routes served at `/`.
 | Page | URL | Description |
 |---|---|---|
 | Dashboard | `/` | FY stats, next session, personalised calendar |
-| Admin | `/admin` | Eventbrite sync buttons, exports, site links |
+| Tools (admin UI) | `/tools` (`/admin` → redirect) | Eventbrite sync buttons, exports, site links |
 | Groups | `/groups` | Groups listing with FY filter |
 | Group Detail | `/groups/:key` | Stats, regulars, sessions, edit/delete |
 | Sessions | `/sessions` | Sessions listing with FY filter, search, term filters |

--- a/docs/app-dev-guidelines.md
+++ b/docs/app-dev-guidelines.md
@@ -86,7 +86,7 @@ Good examples:
 - `canToggleCheckin`
 - `canSetHours`
 
-
+**Auth in the SPA:** pages use **`useViewer()`** and pass **`RoleContext`** (`profile`) into presentational components — do not call `useViewer()` inside leaf components. Use **`hasCheckInAccess`** for the check-in toolset (Admin ∪ Check In); **`isTrusted`** matches Microsoft trusted callers. Prefer **additive layouts**: admins see the same check-in surfaces plus extra controls unless a feature is genuinely admin-only.
 
 This keeps components focused on what they may do, not on wider app policy.
 

--- a/docs/features/auth.md
+++ b/docs/features/auth.md
@@ -2,12 +2,18 @@
 
 ## Microsoft Authentication (Entra ID OAuth)
 
-Trusted users (Admin, Check In, Read Only) sign in via Microsoft OAuth. Role is assigned at login:
-- **Admin**: email in `ADMIN_USERS` env var
-- **Check In**: Microsoft login matched to a Profile with a `User` field set
-- **Read Only**: any other Microsoft login
+Microsoft sign-in is only granted when the signed-in email matches the **Profiles** list **`User`** field (case-insensitive). There is **no** “implicit read-only” Microsoft role.
 
-Routes: [routes/auth/dtv.ts](../../routes/auth/dtv.ts). Session stored server-side; `dtv-auth` cookie identifies the session.
+Role after a successful profile link:
+
+- **Admin**: **`User`** match **and** email listed in **`ADMIN_USERS`**
+- **Check In**: **`User`** match and **not** in **`ADMIN_USERS`**
+
+If OAuth succeeds but **no profile** has **`User`** equal to the Microsoft email, the app **destroys the session** and redirects to **`/login?reason=dtv-not-authorised`**. That is a **failed Microsoft sign-in** (access refused), not an intentional “public” session.
+
+Operators can set **`User`** in SharePoint when the in-app profile editor is insufficient. **Admin** accounts need both **`User`** and **`ADMIN_USERS`**.
+
+Routes: [backend/routes/auth/dtv.ts](../../backend/routes/auth/dtv.ts). Session stored server-side; `dtv-auth` cookie identifies the session.
 
 ## Self-Service Login (Magic Link + Verification Code)
 
@@ -15,24 +21,23 @@ Volunteers sign in by email — no Microsoft account required. Access is control
 
 Two methods, both sending via Microsoft Graph Mail (`MAIL_SENDER` env var required):
 
-- **Magic link** ([routes/auth/magic.ts](../../routes/auth/magic.ts)): 15-minute JWT link emailed to the volunteer; clicking sets the session directly
-- **Verification code** ([routes/auth/verify.ts](../../routes/auth/verify.ts)): 4-digit code valid for 15 minutes; volunteer enters it on the login page
+- **Magic link** ([backend/routes/auth/magic.ts](../../backend/routes/auth/magic.ts)): 15-minute JWT link emailed to the volunteer; clicking sets the session directly
+- **Verification code** ([backend/routes/auth/verify.ts](../../backend/routes/auth/verify.ts)): 4-digit code valid for 15 minutes; volunteer enters it on the login page
 
 Session token: 128-bit random, SHA-256 hash stored in SharePoint Logins list. TTL controlled by `AUTH_BASIC_TTL_HOURS` (default 72h). Global send rate limit: `EMAIL_RATE_LIMIT_PER_HOUR` (default 60).
 
 ## Role-Based Permissions
 
-Five roles in ascending trust order:
+App levels (see also capability stack in [AGENTS.md](../../AGENTS.md)):
 
 | Role | How assigned | Access |
 |------|-------------|--------|
 | **Public** | Unauthenticated | Limited non-privacy view |
 | **Self-Service** | Profile email match (magic link) | Own profile, own entries, future session sign-up, own photo upload |
-| **Read Only** | Microsoft login (no special config) | View all data, no edits |
-| **Check In** | Microsoft login + Profile.User field set | Field-day ops: check-in, hours, entries, edit sessions/profiles |
-| **Admin** | `ADMIN_USERS` env var | Full access |
+| **Check In** | Microsoft + Profile **`User`** match (not admin list) | Field-day ops: check-in, hours, entries, edit sessions/profiles |
+| **Admin** | Microsoft + **`User`** match **and** **`ADMIN_USERS`** | Full access (includes everything Check In can do) |
 
-**Trusted** = Admin + Check In + Read Only. Self-Service is explicitly not trusted — stricter than Read Only.
+**Trusted (Microsoft)** = Admin ∪ Check In. Self-Service is explicitly not trusted for other volunteers’ data.
 
 Backend enforcement: `requireAuth` middleware + `requireAdmin` middleware + handler-level ownership checks. Full reference: [docs/permissions.md](../permissions.md).
 

--- a/docs/features/frontend.md
+++ b/docs/features/frontend.md
@@ -14,7 +14,7 @@ Authenticated users with a linked profile see:
 - Registered / Attended pills on session cards
 - Next / Last buttons jump to own sessions, falling back to any session if none
 
-Public and Read Only users see the standard global session calendar.
+Public users see the standard global session calendar (same component; trusted Microsoft users see additional affordances elsewhere).
 
 ## Taxonomy Word Cloud
 

--- a/docs/features/frontend.md
+++ b/docs/features/frontend.md
@@ -2,6 +2,10 @@
 
 All pages are Vue 3 SPA routes. See [docs/app-dev-guidelines.md](../app-dev-guidelines.md) for component architecture and patterns.
 
+## App header
+
+The burger menu includes **About** (`AboutModal`): app name, then **Logged in** (tier from `loginTierLabel()` in `accessLabels.ts`), then build time, GitHub commit, contact, and licence.
+
 ## FY Filtering and Bar Charts
 
 All list pages (sessions, volunteers, groups) support financial year filtering: This FY / Last FY / All / Rolling FY. FY runs April 1 – March 31. Group detail and profile detail pages include a FY bar chart showing hours per year.

--- a/docs/features/frontend.md
+++ b/docs/features/frontend.md
@@ -34,9 +34,9 @@ Term picker on session detail (Admin/Check In). Hierarchical picker backed by Sh
 - Volunteers listing: export selected or all visible profiles
 - Records export from admin page
 
-## Admin Page
+## Tools page (`/tools`)
 
-Buttons for: Eventbrite sync (sessions + attendees + nightly), stats refresh, backup export. Unmatched Eventbrite events list. SharePoint section: full server cache clear (use after manual SharePoint list edits), shortcuts (Site Contents, Term Store, backup). Icon legend.
+`AdminPage.vue` — page title and burger menu use the **Tools** label. Full admins are still **Tracker Admin** in role copy elsewhere (welcome, badges, privacy). Old URL `/admin` redirects here. Buttons: Eventbrite sync (sessions + attendees + nightly), stats refresh, backup export; unmatched Eventbrite events list; SharePoint section (clear all server caches, Site Contents, Term Store, backup); icon legend.
 
 ## PWA
 

--- a/docs/features/frontend.md
+++ b/docs/features/frontend.md
@@ -36,7 +36,7 @@ Term picker on session detail (Admin/Check In). Hierarchical picker backed by Sh
 
 ## Admin Page
 
-Buttons for: Eventbrite sync (sessions + attendees + nightly), stats refresh, cache clear, backup export. Unmatched Eventbrite events list. Site shortcuts (SharePoint Site Contents, Term Store, Backups). Icon legend.
+Buttons for: Eventbrite sync (sessions + attendees + nightly), stats refresh, backup export. Unmatched Eventbrite events list. SharePoint section: full server cache clear (use after manual SharePoint list edits), shortcuts (Site Contents, Term Store, backup). Icon legend.
 
 ## PWA
 

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -11,7 +11,7 @@ There are **four** app permission levels. **Admin** extends **Check In** (same f
 | **Self-Service** | Yes (magic link / verification code on email) | View own profile, register for sessions, upload own photos. Cannot view other volunteers' data. Matched via Profile **`Email`**. |
 | **Public** | No | Limited access to non-privacy data (sessions, groups, stats) |
 
-> **"Trusted" (Microsoft)** = **Admin ∪ Check In** — both require a **Profile `User`** link to the Microsoft work account. There is **no** Microsoft “read-only” fallback: if Entra succeeds but no profile **`User`** matches, sign-in is **rejected** (`/login?reason=dtv-not-authorised`) and no session is opened (this is **not** the same as browsing as Public). **Self-Service** is not trusted for other volunteers’ PII.
+> **"Trusted" (Microsoft)** = **Admin ∪ Check In** — both require a **Profile `User`** link to the volunteer’s Microsoft sign-in email. There is **no** Microsoft “read-only” fallback: if Entra succeeds but no profile **`User`** matches, sign-in is **rejected** (`/login?reason=dtv-not-authorised`) and no session is opened (this is **not** the same as browsing as Public). **Self-Service** is not trusted for other volunteers’ PII.
 
 ## Configuration
 
@@ -173,6 +173,7 @@ Check In can make a session photo non-public via `PATCH /media/:itemId`; permane
 2. **Auth middleware** (`middleware/require-auth.ts`): Whitelist of public GET paths (`/api/stats`, `/api/sessions`, `/api/groups`, `/api/tags`, `/api/media`). All other paths require a session. Page requests redirect to `/login`; API requests return 401. API key auth bypasses this for `/api/eventbrite/` paths.
 
 3. **Role enforcement** (`middleware/require-admin.ts`): After `requireAuth` on API routes:
+   - **Public GETs** (same path set as `require-auth.ts`, resolved with `baseUrl` + `path` inside the `/api` mount): **always** allowed without a session user so anonymous and post-logout home/session list loads are not blocked.
    - **Admin**: passes through.
    - **Self-Service**: GETs restricted to `SELFSERVICE_ALLOWED_GET_PATTERNS` plus own profile slug; writes allowed only per `SELFSERVICE_ALLOWED_PATTERNS`.
    - **Check In** (`role === 'checkin'` only): GETs allowed except `ADMIN_ONLY_GET_PATTERNS` (exports, `/entries` list); writes allowed only for `CHECKIN_ALLOWED_PATTERNS`. Any other stored role (including legacy values) gets **403** — check-in patterns are never implied for unknown roles.

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -2,35 +2,30 @@
 
 ## Roles
 
-There are five access levels:
+There are **four** app permission levels. **Admin** extends **Check In** (same field-day capabilities plus admin-only endpoints and UI).
 
 | Role | Auth required | Description |
 |------|--------------|-------------|
-| **Admin** | Yes (Microsoft) | Full access to all features |
-| **Check In** | Yes (Microsoft) | Field-day operations: view all data, check in volunteers, set hours, add entries, edit sessions/profiles, manage regulars, upload photos |
-| **Read Only** | Yes (Microsoft) | View all volunteer data (profiles, entries, hours) — no editing |
-| **Self-Service** | Yes (Google or Facebook) | Volunteer login: view own profile, register for sessions, upload own photos. Cannot view other volunteers' data. |
-| **Public** | No | Limited read-only access to non-privacy data only (sessions, groups, stats) |
+| **Admin** | Yes (Microsoft) | Profile **`User`** must match sign-in email **and** email must be in **`ADMIN_USERS`**. Full access (includes all Check In capabilities). |
+| **Check In** | Yes (Microsoft) | Profile **`User`** matches sign-in email; not in **`ADMIN_USERS`**. Field-day operations: check-in, hours, entries, sessions/profiles edits, regulars, uploads, consent collection, etc. |
+| **Self-Service** | Yes (magic link / verification code on email) | View own profile, register for sessions, upload own photos. Cannot view other volunteers' data. Matched via Profile **`Email`**. |
+| **Public** | No | Limited access to non-privacy data (sessions, groups, stats) |
 
-> **"Trusted" users** = Admin + Check In + Read Only. These are the three Microsoft-authenticated roles. Self-Service (Google/Facebook) is **not** trusted and has tighter restrictions than Read Only.
+> **"Trusted" (Microsoft)** = **Admin ∪ Check In** — both require a **Profile `User`** link to the Microsoft work account. There is **no** Microsoft “read-only” fallback: if Entra succeeds but no profile **`User`** matches, sign-in is **rejected** (`/login?reason=dtv-not-authorised`) and no session is opened (this is **not** the same as browsing as Public). **Self-Service** is not trusted for other volunteers’ PII.
 
 ## Configuration
 
-**Admin** users are set via the `ADMIN_USERS` environment variable — comma-separated email addresses, case-insensitive:
+**Microsoft (Check In / Admin):** A volunteer **Profiles** row must have **`User`** set to the person’s DTV Microsoft email. **Admin** additionally requires that email in **`ADMIN_USERS`** (comma-separated, case-insensitive):
 
 ```
 ADMIN_USERS=first.last@dtv.org.uk,another.email@dtv.org.uk
 ```
 
-**Check In** users are determined by matching the login email against the `User` field on Profiles. If a profile's `User` value matches the authenticated user's email, they get Check In access.
+**Self-Service:** `Profile.Email` (comma-separated) contains the volunteer address used for magic link / code. Editable by Check In and Admin.
 
-**Read Only** is the default for any other authenticated DTV user (logged in via Microsoft but not in `ADMIN_USERS` and no matched Profile).
+**Public:** no session.
 
-**Self-Service** users log in via Google or Facebook OAuth. Access is granted if the OAuth account email matches the `Email` field on a volunteer Profile (case-insensitive). To grant access: set `Profile.Email` to the volunteer's email. To revoke: clear it. The `Email` field is editable only by Check In and Admin users. Facebook login via the installed PWA uses `window.open()` + session polling to work around Android's intent system routing the OAuth callback to the native Facebook app.
-
-**Public** is any unauthenticated visitor — no login required, but volunteer names, profiles, entries, and parking info are hidden.
-
-Role is determined at login and stored in the session. All login/redirect flows use `/login.html` (the unified sign-in page).
+Capability stack (additive UI / testing): **Public** ⊆ **Check In tier** ⊆ **Admin tier**. Role is stored in `req.session.user.role`. The SPA sign-in route is **`/login`**.
 
 ### Future: Entra ID App Roles
 
@@ -46,11 +41,11 @@ To migrate to Entra ID roles, configure App Roles in the Azure app registration 
 |------|--------|
 | Dashboard, Groups list, Group detail, Sessions list | Full view (no volunteer names/emails) |
 | Session detail | Session info, stats, tags, public photos; entries and free parking hidden |
-| Volunteers list | Redirected to `/login.html` |
-| Profile detail | Redirected to `/login.html` |
-| Add entry, Entry detail, Admin | Redirected to `/login.html` |
+| Volunteers list | Redirected to `/login` |
+| Profile detail | Redirected to `/login` |
+| Add entry, Entry detail, Admin | Redirected to `/login` |
 
-### Self-Service (volunteer Google/Facebook login)
+### Self-Service (magic link / email code)
 
 | Page | Access |
 |------|--------|
@@ -66,21 +61,25 @@ To migrate to Entra ID roles, configure App Roles in the Azure app registration 
 | Add entry | Can register for future sessions (own profile only) |
 | Admin | Redirected |
 
-### Trusted (Read Only, Check In, Admin)
+### Trusted Microsoft (Check In, Admin)
 
-| Page | Public sees | Read Only additionally sees | Check In additionally sees | Admin additionally sees |
-|------|------------|----------------------------|--------------------------|------------------------|
-| **Dashboard** | Stats, word cloud | — | — | — |
-| **Groups list** | Full view, regulars count | — | — | — |
-| **Group detail** | Group info, stats, sessions, regulars list | — | — | Edit button, Create Session button |
-| **Sessions list** | Full view | CSV download, checkboxes (Advanced) | — | Add Tags button |
-| **Session detail** | Session info, stats, tags, photos; Privacy Protection card | Entries list, Free Parking card | Check-in checkboxes, Set Hours, Add Entry, Refresh, Edit (title + description only); photo edit (caption, public, cover — not delete) | Delete session; delete photos; edit modal: Group, Date, Eventbrite ID |
-| **Add entry** | Redirected (auth required) | View only (API blocks writes) | Full access (search, select, create entry, add new profile) | — |
-| **Entry detail** | Redirected (auth required) | View only (controls disabled) | Checked In toggle, Hours field, Count, Upload button | Notes, tag buttons, Delete Entry |
-| **Volunteers list** | Redirected (auth required) | View, search, filter, sort, CSV download | — | Bulk Records |
-| **Profile detail** | Redirected (auth required) | View stats/entries/groups, duplicates/linked profiles | Edit profile (name/email/match name), Regulars checkboxes, Inline hours editing (own profile only), Collect Consent button | Username field in edit modal, Add Record, record pill editing, Inline hours editing (all profiles), Transfer, Delete Profile |
-| **Consent page** | Redirected (auth required) | **Blocked** — page loads but API returns 403 | Full access — collect privacy and photo consent | Full access |
-| **Admin** | Redirected (auth required) | Icon Legend only | — | Eventbrite sync, Exports, Site link |
+Check In and Admin share the **same** base visibility on these pages; **Admin** adds the items in the last column only.
+
+| Page | Public sees | Check In additionally | Admin additionally |
+|------|------------|----------------------|-------------------|
+| **Dashboard** | Stats, word cloud | — | — |
+| **Groups list** | Full view, regulars count | — | — |
+| **Group detail** | Group info, stats, sessions, regulars list | — | Edit button, Create Session button |
+| **Sessions list** | Full view | CSV download, checkboxes (Advanced) | Add Tags button |
+| **Session detail** | Session info, stats, tags, photos; Privacy Protection card | Entries list, Free Parking card; check-in, Set Hours, Add Entry, Refresh, Edit (title + description); photo edit (caption, public, cover — not delete) | Delete session; delete photos; edit modal: Group, Date, Eventbrite ID |
+| **Add entry** | Redirected (auth required) | Full access | — |
+| **Entry detail** | Redirected (auth required) | Checked In toggle, Hours, Count, Upload | Notes, tag buttons, Delete Entry |
+| **Volunteers list** | Redirected (auth required) | View, search, filter, sort, CSV download | Bulk Records |
+| **Profile detail** | Redirected (auth required) | Edit profile (name/email/match name), Regulars checkboxes, inline hours (own profile only), Collect Consent | **`User`** field in edit modal, Add Record, record pill editing, inline hours (all profiles), Transfer, Delete Profile |
+| **Consent page** | Redirected (auth required) | Full access | Full access |
+| **Admin** | Redirected (auth required) | — | Eventbrite sync, Exports, Site link |
+
+**trackerAccess:** For trusted callers, profile and entry payloads may include **`trackerAccess`** (`none` | `checkin` | `admin`) so dig leads can see who else has Microsoft Tracker access. Omitted for self-service/public.
 
 ---
 
@@ -116,11 +115,11 @@ Self-service users **cannot** access:
 - `/api/sessions/export`, `/api/records/export` — GDPR exports
 - Any write endpoint not in the allowlist above
 
-### Trusted — Everyone (Read Only, Check In, Admin)
+### Trusted Microsoft — Check In + Admin
 
 | Method | Endpoint | Purpose |
 |--------|----------|---------|
-| GET | All endpoints (except exports) | View all data including volunteer PII |
+| GET | All endpoints (except admin-only exports/listings) | View all data including volunteer PII |
 
 ### Check In + Admin
 
@@ -169,16 +168,15 @@ Check In can make a session photo non-public via `PATCH /media/:itemId`; permane
 
 ### Backend
 
-1. **Role assignment** (`routes/auth.ts`): At Microsoft login, the user's email is checked against `ADMIN_USERS` (→ `admin`), then against Profile `User` fields (→ `checkin`), otherwise → `readonly`. At Google/Facebook login, the email is matched against Profile `Email` fields (→ `selfservice`); no match → redirect to `/login.html?reason=not-approved`. Role is stored in `req.session.user.role`. Unauthenticated visitors have no role (Public).
+1. **Role assignment** ([`routes/auth/dtv.ts`](../routes/auth/dtv.ts)): Microsoft callback requires a Profile **`User`** match; else session is destroyed and redirect **`/login?reason=dtv-not-authorised`**. If matched: `ADMIN_USERS` → **`admin`**, else **`checkin`**. Magic link / verify flows set **`selfservice`** when Profile **`Email`** matches; no match → `reason=not-approved`. Role is `req.session.user.role`. Public = no session.
 
-2. **Auth middleware** (`middleware/require-auth.ts`): Whitelist of public GET paths (`/api/stats`, `/api/sessions`, `/api/groups`, `/api/tags`, `/api/media`). All other paths require a session. Page requests redirect to `/login.html`; API requests return 401. API key auth bypasses this for `/api/eventbrite/` paths.
+2. **Auth middleware** (`middleware/require-auth.ts`): Whitelist of public GET paths (`/api/stats`, `/api/sessions`, `/api/groups`, `/api/tags`, `/api/media`). All other paths require a session. Page requests redirect to `/login`; API requests return 401. API key auth bypasses this for `/api/eventbrite/` paths.
 
-3. **Role enforcement** (`middleware/require-admin.ts`): A single middleware applied after `requireAuth` on all API routes.
+3. **Role enforcement** (`middleware/require-admin.ts`): After `requireAuth` on API routes:
    - **Admin**: passes through.
-   - **Read Only**: all GETs allowed (except export endpoints); all writes blocked (403 "Read only access").
-   - **Self-Service**: GETs allowed only for patterns in `SELFSERVICE_ALLOWED_GET_PATTERNS` plus own profile slug (regex `/^\/profiles\/[^/]+-\d+$/`); writes allowed only for patterns in `SELFSERVICE_ALLOWED_PATTERNS`.
-   - **Check In** (default for authenticated non-Admin/Read Only/Self-Service): GETs allowed; writes allowed for patterns in `CHECKIN_ALLOWED_PATTERNS`; everything else 403.
-   - Export GETs (`/sessions/export`, `/records/export`) are in `ADMIN_ONLY_GET_PATTERNS` — blocked for Check In and all lower roles.
+   - **Self-Service**: GETs restricted to `SELFSERVICE_ALLOWED_GET_PATTERNS` plus own profile slug; writes allowed only per `SELFSERVICE_ALLOWED_PATTERNS`.
+   - **Check In**: GETs allowed except `ADMIN_ONLY_GET_PATTERNS` (exports, `/entries` list); writes allowed for `CHECKIN_ALLOWED_PATTERNS`.
+   - Export GETs (`/sessions/export`, `/records/export`) and **`GET /entries`** — **Admin only**.
 
 4. **Handler-level enforcement**: Route handlers perform a second ownership check for self-service users. `GET /api/profiles/:slug` checks `req.session.user.profileIds` and returns 403 if the profile ID doesn't match. Similar checks in entries and upload-context handlers.
 
@@ -186,29 +184,19 @@ Check In can make a session photo non-public via `PATCH /media/:itemId`; permane
 
 ### Frontend
 
-1. **`common.js`**: After fetching `/auth/me`, sets `document.body.dataset.role` to the user's role (`admin`, `checkin`, `readonly`, or `selfservice`). Also stores `window.currentUser` and dispatches a `authReady` custom event for pages that need to react to auth state. For Public (unauthenticated), `data-role` is never set.
+1. **`useViewer()`** ([`frontend/src/composables/useViewer.ts`](../frontend/src/composables/useViewer.ts)): Fetches **`/auth/me`**. **`hasCheckInAccess`** = Admin or Check In (check-in tier). **`isTrusted`** = same. **`RoleContext`** is passed into presentational components (e.g. session cards).
 
-2. **`styles.css`**: CSS rules handle visibility per role:
-   - `body:not([data-role="admin"]) .admin-only { display: none !important; }` — hides admin elements for all non-admins (including Public)
-   - `body:not([data-role="admin"]) .admin-clickable { pointer-events: none; }` — disables clicks (record pills)
-   - `body:not([data-role]) .checkin-only { display: none !important; }` — hides check-in action buttons for Public
-   - `body[data-role="readonly"] .checkin-only { display: none !important; }` — hides check-in action buttons for Read Only
-   - `body[data-role="selfservice"] .checkin-only { display: none !important; }` — hides check-in UI for self-service users
-   - `body[data-role="readonly"] ...` — disables inline controls (checkboxes, inputs) with `pointer-events: none; opacity: 0.6`
-   - `.auth-only { display: none !important; }` / `body[data-role] .auth-only { display: revert !important; }` — hides auth-gated content from Public
-   - `body[data-role] .unauth-only { display: none !important; }` — shows Public-only content (e.g. Privacy Protection card) only to unauthenticated visitors
-   - `.selfservice-only { display: none !important; }` / `body[data-role="selfservice"] .selfservice-only { display: revert !important; }` — shows self-service-only UI
-   - `.trusted-only { display: none !important; }` / `body[data-role="admin"] .trusted-only`, `body[data-role="checkin"] .trusted-only`, `body[data-role="readonly"] .trusted-only { display: revert !important; }` — shows content only for the three trusted (Microsoft-auth) roles; hidden from Self-Service and Public
+2. **CSS classes** (see [`frontend/src/main.css`](../frontend/src/main.css) / layouts): **`admin-only`**, **`checkin-only`**, **`trusted-only`**, **`selfservice-only`**, etc., gate visibility.
 
-3. **HTML class reference**:
+3. **Class reference**:
    - `admin-only` — Admin only
-   - `checkin-only` — Check In and Admin only (hidden for Read Only, Self-Service, Public)
-   - `trusted-only` — All three Microsoft-auth roles (Admin + Check In + Read Only); hidden from Self-Service and Public
-   - `auth-only` — Any authenticated user (all roles including Self-Service)
-   - `unauth-only` — Public (unauthenticated) only
+   - `checkin-only` — Check In and Admin
+   - `trusted-only` — Microsoft trusted (Admin + Check In)
+   - `auth-only` — Any authenticated user
+   - `unauth-only` — Public only
    - `selfservice-only` — Self-Service only
 
-4. **JavaScript guards**: Some UI elements can't be controlled by CSS alone (e.g. checkbox rendering per card). These use `window.currentUser.role` directly. For example, sessions.js gates checkbox rendering: `const isTrusted = role === 'admin' || role === 'checkin' || role === 'readonly';`.
+4. Prefer **additive** layouts: admins should see the same check-in surfaces plus extra controls, not unrelated replacement UIs per role.
 
 ### Public (No Authentication)
 
@@ -216,10 +204,10 @@ The following endpoints and pages require no authentication and are served befor
 
 | Method | Path | Purpose |
 |--------|------|---------|
-| GET | `/login.html` | Unified sign-in page (Google, Facebook, Microsoft options) |
-| GET | `/upload.html` | Volunteer photo upload page — uses `?entryId=` query param; redirects to `/login.html` if not authenticated |
+| GET | `/login` | Unified sign-in (self-service email + Microsoft) |
+| GET | `/upload` | Volunteer photo upload — uses `?entryId=` |
 
-The upload page calls `GET /api/entries/:id/upload-context` (requires login → 401 redirects to `/login.html`) and `POST /api/entries/:id/photos` (requires login + ownership for self-service users). Self-service users can only upload to their own entries; check-in and admin users can upload to any entry.
+The upload flow calls `GET /api/entries/:id/upload-context` and `POST /api/entries/:id/photos` (ownership enforced for self-service). Check-in and admin can upload to any entry.
 
 ### API Key Auth
 

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -175,7 +175,7 @@ Check In can make a session photo non-public via `PATCH /media/:itemId`; permane
 3. **Role enforcement** (`middleware/require-admin.ts`): After `requireAuth` on API routes:
    - **Admin**: passes through.
    - **Self-Service**: GETs restricted to `SELFSERVICE_ALLOWED_GET_PATTERNS` plus own profile slug; writes allowed only per `SELFSERVICE_ALLOWED_PATTERNS`.
-   - **Check In**: GETs allowed except `ADMIN_ONLY_GET_PATTERNS` (exports, `/entries` list); writes allowed for `CHECKIN_ALLOWED_PATTERNS`.
+   - **Check In** (`role === 'checkin'` only): GETs allowed except `ADMIN_ONLY_GET_PATTERNS` (exports, `/entries` list); writes allowed only for `CHECKIN_ALLOWED_PATTERNS`. Any other stored role (including legacy values) gets **403** — check-in patterns are never implied for unknown roles.
    - Export GETs (`/sessions/export`, `/records/export`) and **`GET /entries`** — **Admin only**.
 
 4. **Handler-level enforcement**: Route handlers perform a second ownership check for self-service users. `GET /api/profiles/:slug` checks `req.session.user.profileIds` and returns 403 if the profile ID doesn't match. Similar checks in entries and upload-context handlers.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,5 +1,11 @@
 # Development Progress
 
+## Session: 2026-05-10 (Microsoft requires Profile `User`; remove read-only role)
+
+- Microsoft sign-in only when a volunteer profile’s **`User`** field matches the Entra email (`ADMIN_USERS` → admin, else check-in). No session + **`/login?reason=dtv-not-authorised`** when there is no match.
+- Frontend: **`hasCheckInAccess`** / **`isTrusted`** replace the old read-only / **`isOperational`** split; API adds optional **`trackerAccess`** on profile and entry payloads for trusted callers.
+- Docs: **`docs/permissions.md`**, **`docs/testing/full-regression.md`**, **`docs/app-dev-guidelines.md`**, **`AGENTS.md`** / **`docs/features/auth.md`** aligned with four permission levels and SPA paths.
+
 ## Session: 2026-05-05 (Self-service booking cancel — permissions)
 
 - Self-service may no longer `DELETE /api/entries/:id` (middleware block; hard delete remains admin-only in handler).
@@ -159,9 +165,9 @@ Accepts `profile?: RoleContext` prop — same pattern as `SessionCard`. Page pas
 Introduced `useProfile()` as the single UI-facing auth composable, replacing `useRole.ts`. All pages and components now import from `useProfile` only — `useAuth` and `useRole` are blocked by ESLint.
 
 **Key decisions:**
-- `useProfile()` returns `reactive({...})` so boolean helpers (`isAdmin`, `isCheckIn`, `isOperational`, etc.) auto-unwrap in both templates and script — no `.value` needed
+- `useViewer()` / profile context: boolean helpers (`isAdmin`, `hasCheckInAccess`, `isTrusted`, etc.) are exposed for templates and script
 - `RoleContext` interface: plain snapshot object for passing auth context as a component prop (explicit contract, easy to mock in sandbox)
-- `isOperational` = Admin or Check-In (the primary UI branch — stats/management vs. public availability)
+- `hasCheckInAccess` = Admin or Check-In (check-in tier; additive UI with admin)
 - ESLint v9 flat config (`eslint.config.js`) with `no-restricted-imports` rule; exempts `useProfile.ts` and `router/index.ts`; `"type": "module"` added to `frontend/package.json`
 
 **New files:**
@@ -185,7 +191,7 @@ Introduced `useProfile()` as the single UI-facing auth composable, replacing `us
 SessionCard now shows operational stats (registrations, new, child, regular, Eventbrite counts) for Admin/Check-In users, and availability message for everyone else. `groupDescription` now surfaces on all cards.
 
 **Changes:**
-- `SessionCard.vue` — `profile?: RoleContext` prop replaces old `user` prop; footer shows stats list or availability based on `isOperational`; layout: Group / Long Date / Description / [Stats or Availability] + View button
+- `SessionCard.vue` — `profile?: RoleContext` prop; footer shows stats list or availability based on `hasCheckInAccess` / trusted context; layout: Group / Long Date / Description / [Stats or Availability] + View button
 - `SessionListResults.vue` — passes `:profile="profile.context"` to each SessionCard
 - `SessionConcertina.vue` — `profile?: RoleContext` prop, passes down to SessionCard
 - `HomePage.vue` — passes `:profile="profile.context"` to SessionConcertina
@@ -1884,7 +1890,7 @@ Applied the visual identity from the new DTV website (deantrailvolunteers.org.uk
 **Inline hours editing:**
 - Admin users see editable hours inputs on all profiles
 - Check In users see inputs only on their own profile (`/auth/me` profileSlug match)
-- Read Only users always see plain text hours
+- Microsoft sign-in requires Profile `User` match; no read-only Microsoft tier
 - `onchange` fires `PATCH /api/entries/:id` with `{ hours }`, reverts on failure
 - Auth check via `apiFetch('/auth/me')` at page load, awaited before rendering
 

--- a/docs/testing/full-regression.md
+++ b/docs/testing/full-regression.md
@@ -316,7 +316,7 @@ Run with `npm run dev` at http://localhost:3000. Log in via Microsoft Entra ID.
 - [ ] NoPhoto badge shown for a volunteer without Accepted Photo Consent (live from `profile.stats.noPhoto`)
 
 ### H27. Clear cache
-- [ ] Admin page → SharePoint section → "Clear all server caches" (confirm) → success message; `POST /api/cache/clear`
+- [ ] Tools page (`/tools`) → SharePoint section → "Clear all server caches" → success message; `POST /api/cache/clear` (legacy `/admin` redirects here)
 - [ ] Forces fresh data on next request (list cache, column schema, taxonomy, media bytes, cover image bytes)
 
 ### H28. Upload button (entry detail — check-in/admin)
@@ -383,7 +383,7 @@ Run with `npm run dev` at http://localhost:3000. Log in via Microsoft Entra ID.
 - [ ] `GET /api/email/sandbox/pre-session?format=json` returns fixture data
 
 ### H31. Backup export
-- [ ] Admin page → "Export Backup" button → `POST /api/backup/export-all`
+- [ ] Tools page (`/tools`) → "Export Backup" button → `POST /api/backup/export-all`
 - [ ] Returns summary with file counts and timestamp; displayed in admin page
 - [ ] Files written to `Backups/` folder in Shared Documents on the Tracker site
 - [ ] Unchanged files are skipped (SHA-256 diff check) — re-running immediately results in 0 updated files

--- a/docs/testing/full-regression.md
+++ b/docs/testing/full-regression.md
@@ -316,9 +316,8 @@ Run with `npm run dev` at http://localhost:3000. Log in via Microsoft Entra ID.
 - [ ] NoPhoto badge shown for a volunteer without Accepted Photo Consent (live from `profile.stats.noPhoto`)
 
 ### H27. Clear cache
-- [ ] Dashboard → Refresh button
-- [ ] `POST /api/cache/clear`
-- [ ] Forces fresh data on next request
+- [ ] Admin page → SharePoint section → "Clear all server caches" (confirm) → success message; `POST /api/cache/clear`
+- [ ] Forces fresh data on next request (list cache, column schema, taxonomy, media bytes, cover image bytes)
 
 ### H28. Upload button (entry detail — check-in/admin)
 - [ ] Entry detail → "Upload" button visible for Admin and Check In; hidden for Self-Service (`checkin-only` class)

--- a/docs/testing/full-regression.md
+++ b/docs/testing/full-regression.md
@@ -14,23 +14,26 @@ Run with `npm run dev` at http://localhost:3000. Log in via Microsoft Entra ID.
 ### H1. Authentication & Permissions
 
 - [ ] Unauthenticated visit to `/` (homepage) loads without redirect — stats, sessions, groups nav cards visible; volunteers nav card hidden; admin button hidden; header shows "Log in" button
-- [ ] Unauthenticated visit to `/sessions.html` loads without redirect
-- [ ] Unauthenticated visit to `/groups.html` loads without redirect; regulars count shows 0
-- [ ] Unauthenticated visit to `/groups/:key/detail.html` loads without redirect; regulars section hidden
-- [ ] Unauthenticated visit to `/sessions/:group/:date/details.html` loads; entries section and free parking card hidden
-- [ ] Unauthenticated visit to `/volunteers.html` redirects to `/login.html`
-- [ ] Unauthenticated visit to `/profiles/:slug/details.html` redirects to `/login.html`
+- [ ] Unauthenticated visit to `/sessions` loads without redirect
+- [ ] Unauthenticated visit to `/groups` loads without redirect; regulars count shows 0
+- [ ] Unauthenticated visit to `/groups/:key` loads without redirect; regulars section hidden
+- [ ] Unauthenticated visit to `/sessions/:group/:date` loads; entries section and free parking card hidden
+- [ ] Unauthenticated visit to `/profiles` redirects to `/login` (trusted route)
+- [ ] Unauthenticated visit to `/profiles/:slug` redirects to `/login`
 - [ ] Unauthenticated `GET /api/entries/recent` returns 401
 - [ ] Unauthenticated visit to `/` does not trigger a `GET /api/entries/recent` request (check Network tab — recent sign-ups section should not be fetched)
-- [ ] Unauthenticated API 401 response (from `apiFetch` in common.js) redirects to `/login.html?returnTo=...` not `/auth/login`
-- [ ] `/login.html` shows Volunteer Sign In (magic link) and DTV Teams Account (Microsoft) cards; Volunteer card only shown when `MAIL_SENDER` is configured
+- [ ] Unauthenticated API 401 from the SPA fetch layer redirects to `/login?returnTo=...` (not `/auth/login`)
+- [ ] `/login` shows self-service (magic link / code) and Microsoft cards; email card only when mail sending is configured
 - [ ] Enter email, click "Send sign-in link" → both cards hide, sent-confirmation section appears with 15:00 countdown
 - [ ] Countdown ticks down to 00:00 then stops
 - [ ] Click "Didn't receive the link? Back to Login" → cards restored, countdown stopped, form re-enabled
 - [ ] Click magic link in email → signed in, redirected to destination (or `/` if no returnTo)
-- [ ] Click expired magic link (wait >15min) → redirected to `/login.html?reason=invalid-state`
-- [ ] Email not in Profiles → redirected to `/login.html?reason=not-approved` with warning banner
+- [ ] Click expired magic link → redirected to `/login?reason=invalid-state` (or equivalent)
+- [ ] Email not in Profiles → redirected to `/login?reason=not-approved` with warning banner
+- [ ] **Microsoft without Profile `User`:** Entra completes but no volunteer row has `User` = signed-in email → session cleared → `/login?reason=dtv-not-authorised` with explanation (not browsing as Public with a session)
+- [ ] After `dtv-not-authorised`, user can still use self-service login or fix `User` in SharePoint and retry Microsoft
 - [ ] Successful Microsoft login redirects back to `/` (or originally requested page via `returnTo`)
+- [ ] **trackerAccess (spot check):** as Check In or Admin, open volunteers list or profile detail for someone with Profile `User` set — response includes `trackerAccess` `checkin` or `admin`; entry list on session detail passes through per-row `trackerAccess` where applicable (badge icons for dig leads)
 - [ ] Click Logout — session cleared, redirected to Microsoft logout
 - [ ] API key auth: `POST /api/eventbrite/nightly-update` with valid `X-Api-Key` succeeds without session
 - [ ] Invalid/missing API key returns 401
@@ -46,22 +49,15 @@ Run with `npm run dev` at http://localhost:3000. Log in via Microsoft Entra ID.
 - [ ] Check In: Add Entry link visible on session detail, can add entry for existing volunteer
 - [ ] Check In: can create new profile from add-entry page ("+ Add New" button)
 - [ ] Check In: edit profile button visible, can update name/email
-- [ ] Check In: Upload button on entry detail visible and functional (navigates to `/upload.html?entryId=:id`)
+- [ ] Check In: Upload button on entry detail visible and functional (navigates to `/upload?entryId=:id`)
 - [ ] Check In: Add Record, Transfer, Delete still hidden on profile page
 - [ ] Check In: `POST /api/profiles/:slug/records` returns 403
 - [ ] Check In: `POST /api/groups` returns 403
-- [ ] **Read Only user** (no matching profile `User` field, not in `ADMIN_USERS`): all action buttons hidden
-- [ ] Read Only: session detail — edit, refresh, set hours, add entry buttons all hidden
-- [ ] Read Only: session detail — check-in checkboxes visible but disabled (greyed out, not clickable)
-- [ ] Read Only: entry detail — checked in and hours controls visible but disabled
-- [ ] Read Only: profile detail — edit button hidden, regular checkboxes disabled
-- [ ] Read Only: any POST/PATCH/DELETE API call returns 403 "Read only access"
-- [ ] Read Only: `GET /api/sessions/export` returns 403 (GDPR — trusted only)
 - [ ] Check In Only: `DELETE /api/sessions/:group/:date` returns 403
 - [ ] Check In Only: `GET /api/sessions/export` returns 403 (GDPR)
 - [ ] Check In Only: admin page shows only Icon Legend section
 - [ ] `/auth/me` returns `role: "admin"` or `role: "checkin"` based on env var
-- [ ] **Self-Service user** (profile has matching `Email` field, Google/Facebook login): no admin/check-in/edit controls visible
+- [ ] **Self-Service user** (profile has matching `Email`, magic link / code): no admin/check-in/edit controls visible
 - [ ] Self-Service: sessions page loads; CSV download button and session checkboxes **not shown** (trusted-only)
 - [ ] Self-Service: Advanced section on sessions page still functional (tag filter, group filter work)
 - [ ] Self-Service: groups page shows zero regulars count; group detail page shows **no regulars list**
@@ -83,8 +79,6 @@ Run with `npm run dev` at http://localhost:3000. Log in via Microsoft Entra ID.
 - [ ] Self-Service: Upload button visible on own entry detail; can upload photos
 - [ ] **Public API security — media PII**: `GET /api/media?sessionId=X` response does **not** contain `name` or `webUrl` fields (these embed uploader's name in the filename)
 - [ ] **Public API security — media PII**: authenticated `GET /api/media?sessionId=X` response **does** include `name` and `webUrl`
-- [ ] **PWA standalone Facebook login** (Android, installed PWA from home screen): tapping "Continue with Facebook" opens a Chrome Custom Tab (not the native Facebook app); after completing Facebook login the PWA navigates to the dashboard without stalling
-
 ### H2. Create group
 - [ ] Groups page → "+" button → modal with Key (required), Display Name, Description
 - [ ] Missing key shows validation error
@@ -192,7 +186,6 @@ Run with `npm run dev` at http://localhost:3000. Log in via Microsoft Entra ID.
 - [ ] Admin: hours input shown on all profiles, change value → `PATCH /api/entries/:id` → persists on reload
 - [ ] Check In: hours input shown only on own profile (profileSlug match)
 - [ ] Check In: hours displayed as plain text on other profiles
-- [ ] Read Only: hours always displayed as plain text
 - [ ] Invalid value (negative) → reverts to original
 - [ ] Clicking the entry card still navigates to entry detail
 
@@ -216,19 +209,16 @@ Run with `npm run dev` at http://localhost:3000. Log in via Microsoft Entra ID.
 
 ### H22b. Collect consent (Check In / Admin / Self-Service)
 - [ ] Profile detail → Records → "Collect Consent" button visible (Check In or Admin)
-- [ ] "Collect Consent" button **hidden** for Read Only users
-- [ ] Click → `/profiles/:slug/consent.html` — shows volunteer name; Submit disabled
+- [ ] Click → `/profiles/:slug/consent` — shows volunteer name; Submit disabled
 - [ ] Tick Privacy only → Submit enabled; submit → Privacy Consent: Accepted, Photo Consent: Declined
 - [ ] Tick both → submit → both Accepted
 - [ ] Return to profile → record pills show updated status and today's date
 - [ ] `POST /api/profiles/:id/consent` — `{ privacyConsent: true, photoConsent: false }` → 200
 - [ ] `POST /api/profiles/:id/consent` — `{ privacyConsent: false }` → 400 (privacy required)
-- [ ] Read Only: `POST /api/profiles/:id/consent` → 403
 - [ ] **Entry detail consent button** (Check In / Admin): visible when volunteer has no Privacy Consent record; hidden once they have an Accepted record
-- [ ] Entry detail consent button: hidden for Read Only users
-- [ ] Entry detail consent button: clicking navigates to `/profiles/:slug/consent.html`
+- [ ] Entry detail consent button: clicking navigates to `/profiles/:slug/consent`
 - [ ] **Self-Service**: consent button visible on own entry detail when no privacy consent signed
-- [ ] Self-Service: clicking navigates to `/profiles/:slug/consent.html`; can submit successfully
+- [ ] Self-Service: clicking navigates to `/profiles/:slug/consent`; can submit successfully
 - [ ] Self-Service: `POST /api/profiles/:id/consent` for own profile → 200
 - [ ] Self-Service: `POST /api/profiles/:id/consent` for a different profile ID → 403
 
@@ -242,7 +232,7 @@ Run with `npm run dev` at http://localhost:3000. Log in via Microsoft Entra ID.
 
 ### H24b. Entries page (admin)
 
-- [ ] Admin: "Entries" nav link visible in header; non-admin users (Check In, Read Only, Self-Service, Public) do not see the link
+- [ ] Admin: "Entries" nav link visible in header; non-admin users (Check In, Self-Service, Public) do not see the link
 - [ ] Navigate to `/entries` as admin → `GET /api/entries` called; entries list loads with totals ("N entries · H hours")
 - [ ] Navigate to `/entries` as non-admin → 403 (API blocked by `require-admin.ts`)
 - [ ] Notes search: type 3+ chars → results filter to entries whose notes contain the search term (case-insensitive)
@@ -331,13 +321,13 @@ Run with `npm run dev` at http://localhost:3000. Log in via Microsoft Entra ID.
 - [ ] Forces fresh data on next request
 
 ### H28. Upload button (entry detail — check-in/admin)
-- [ ] Entry detail → "Upload" button visible for Admin and Check In; hidden for Read Only and Self-Service (`checkin-only` class)
-- [ ] Click button → browser navigates directly to `/upload.html?entryId=:id` (no API call, no intermediate step)
-- [ ] Self-service user on **session detail** page: "Upload" link rendered next to their own entry (if they have one); navigates to `/upload.html?entryId=:id`
+- [ ] Entry detail → "Upload" button visible for Admin and Check In; hidden for Self-Service (`checkin-only` class)
+- [ ] Click button → browser navigates directly to `/upload?entryId=:id` (no API call, no intermediate step)
+- [ ] Self-service user on **session detail** page: "Upload" link rendered next to their own entry (if they have one); navigates to `/upload?entryId=:id`
 - [ ] Self-service user on **entry detail**: Upload button not visible
 
-### H29. Volunteer photo upload page (`/upload.html`)
-- [ ] Visit `/upload.html?entryId=:id` in incognito (no session) → redirected to `/login.html?returnTo=/upload.html?entryId=:id`
+### H29. Volunteer photo upload page (`/upload`)
+- [ ] Visit `/upload?entryId=:id` in incognito (no session) → redirected to `/login` with `returnTo` preserving upload URL
 - [ ] Visit with no `entryId` param or non-numeric ID → error: "No upload link found. Please use the link from your session page."
 - [ ] Visit with valid `entryId` for a different volunteer (self-service wrong account) → error: "This upload link is not for your account."
 - [ ] Visit with non-existent `entryId` → error: "Upload link not found. Please check the link and try again."
@@ -361,20 +351,20 @@ Run with `npm run dev` at http://localhost:3000. Log in via Microsoft Entra ID.
 - [ ] Admin/Check In: lightbox shows "Public gallery" checkbox and title/alt-text input per item
 - [ ] Toggling "Public gallery" checkbox calls `PATCH /api/media/:itemId` — `{ isPublic: true/false }`; change persists on reload
 - [ ] Admin/Check In: can set cover image via lightbox "Set as cover" control; cover updates above carousel
-- [ ] `PATCH /api/media/:itemId` for Read Only or Self-Service → 403
+- [ ] `PATCH /api/media/:itemId` for Self-Service → 403 (Check In / Admin allowed)
 - [ ] **Media cache**: loading session detail twice → second load shows `[Cache] Hit: media_folder_*` in server logs (no repeat Graph call)
 - [ ] **Media cache bust**: upload a photo to a session → immediately reload the session gallery → new photo appears (cache was busted by upload)
 
 ### H30c. Standalone media gallery (`/media/`)
 
-- [ ] Visit `/media/` without login → redirected to `/login.html`
+- [ ] Visit `/media/` without login → redirected to `/login`
 - [ ] Visit `/media/` logged in → page loads; sessions with photos appear as a horizontal carousel
 - [ ] Each carousel slide shows the session cover image, date, and group name as a caption
 - [ ] Clicking a session slide navigates to `/media/session.html?groupKey=…&date=…`
 - [ ] Sessions with no photos (`mediaCount === 0`) do not appear in the library
 
 **Session gallery (`/media/session.html?groupKey=…&date=…`):**
-- [ ] Visit without login → redirected to `/login.html`
+- [ ] Visit without login → redirected to `/login`
 - [ ] Valid `groupKey` + `date` → session gallery loads; all photos/videos appear as carousel slides
 - [ ] Carousel scrolls freely with momentum (multiple slides per swipe); centred slide is full-brightness
 - [ ] Non-selected slides are dimmed; centred slide shows caption overlay (`N / total`)
@@ -460,7 +450,7 @@ Run with `npm run dev` at http://localhost:3000. Log in via Microsoft Entra ID.
 - [ ] `GET /auth/me` — determines inline hours editing permissions
 - [ ] All emails shown as individual mailto links (one per line)
 - [ ] Profile with comma-separated emails in SharePoint → multiple mailto links shown
-- [ ] Admin, Check In, or Read Only viewing a profile with warnings — warnings section appears in the right column (dirt background, white text) listing each warning
+- [ ] Admin or Check In viewing a profile with warnings — warnings section appears in the right column (dirt background, white text) listing each warning
 - [ ] Self-Service user viewing the same profile — warnings section absent
 - [ ] Profile with no warnings — warnings section not rendered
 
@@ -614,7 +604,7 @@ Run with `npm run dev` at http://localhost:3000. Log in via Microsoft Entra ID.
 ### L18. Upload and consent buttons (entry detail)
 - [ ] Upload button positioned top-right of entry header card alongside h1
 - [ ] Displays cloud-upload SVG icon + "Upload" label
-- [ ] Upload button visible for Admin and Check In; hidden for Read Only and Self-Service (checkin-only CSS class)
+- [ ] Upload button visible for Admin and Check In; hidden for Self-Service (checkin-only CSS class)
 - [ ] Consent button (checkboxes icon + "Consent" label) shown next to Upload when volunteer has no Accepted Privacy Consent
 - [ ] Consent button hidden when volunteer already has Accepted Privacy Consent
-- [ ] Consent button visible for Admin, Check In, and Self-Service; hidden for Read Only (checkin-or-selfservice CSS class)
+- [ ] Consent button visible for Admin, Check In, and Self-Service (`checkin-or-selfservice` / equivalent gating)

--- a/docs/testing/smoke-test-manual.md
+++ b/docs/testing/smoke-test-manual.md
@@ -47,7 +47,7 @@ A fast human-run sanity check after any non-trivial change. Not a substitute for
 
 ## 8. Cache clear (30 sec)
 
-- [ ] Admin page → click "Refresh" → `POST /api/cache/clear` → success message shown
+- [ ] Admin page → SharePoint section → "Clear all server caches" → confirm → `POST /api/cache/clear` → success message shown
 
 ## 9. Automated tests (2 min)
 

--- a/frontend/src/components/AboutModal.vue
+++ b/frontend/src/components/AboutModal.vue
@@ -6,6 +6,10 @@
         <span>DTV Tracker App</span>
       </div>
       <div class="flex gap-3">
+        <span class="font-bold w-24 shrink-0">Logged in</span>
+        <span>{{ loginTierLabel }}</span>
+      </div>
+      <div class="flex gap-3">
         <span class="font-bold w-24 shrink-0">Build</span>
         <span>{{ build }}</span>
       </div>
@@ -32,6 +36,14 @@
 
 <script setup lang="ts">
 import ModalLayout from './ModalLayout.vue'
+
+withDefaults(
+  defineProps<{
+    /** Public / My Tracker / Tracker Assist / Tracker Admin (from `loginTierLabel()`). */
+    loginTierLabel?: string
+  }>(),
+  { loginTierLabel: '—' }
+)
 
 const emit = defineEmits<{ close: [] }>()
 

--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -23,7 +23,7 @@
           <RouterLink to="/groups" @click="open = false" class="text-white font-bold uppercase tracking-wide text-sm py-3 border-b border-white/10 hover:text-dtv-green transition-colors">Groups</RouterLink>
           <RouterLink v-if="profile.isTrusted" to="/profiles" @click="open = false" class="text-white font-bold uppercase tracking-wide text-sm py-3 border-b border-white/10 hover:text-dtv-green transition-colors">Profiles</RouterLink>
           <RouterLink v-if="profile.isAdmin" to="/entries" @click="open = false" class="text-white font-bold uppercase tracking-wide text-sm py-3 border-b border-white/10 hover:text-dtv-green transition-colors">Entries</RouterLink>
-          <RouterLink v-if="profile.isAdmin" to="/admin" @click="open = false" class="text-white font-bold uppercase tracking-wide text-sm py-3 border-b border-white/10 hover:text-dtv-green transition-colors">Tools</RouterLink>
+          <RouterLink v-if="profile.isAdmin" to="/admin" @click="open = false" class="text-white font-bold uppercase tracking-wide text-sm py-3 border-b border-white/10 hover:text-dtv-green transition-colors">{{ ACCESS_LABEL_ADMIN }}</RouterLink>
           <button @click="openAbout" class="text-white font-bold uppercase tracking-wide text-sm py-3 border-b border-white/10 hover:text-dtv-green transition-colors text-left">About</button>
           <RouterLink v-if="isDev || profile.isAdmin" to="/sandbox" @click="open = false" class="text-white font-bold uppercase tracking-wide text-sm py-3 border-b border-white/10 hover:text-dtv-green transition-colors">Sandbox</RouterLink>
 
@@ -52,6 +52,7 @@ import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useRoute } from 'vue-router'
 import { useViewer } from '../composables/useViewer'
 import AboutModal from './AboutModal.vue'
+import { ACCESS_LABEL_ADMIN } from '../utils/accessLabels'
 
 const isDev = import.meta.env.DEV
 const route = useRoute()

--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -23,7 +23,7 @@
           <RouterLink to="/groups" @click="open = false" class="text-white font-bold uppercase tracking-wide text-sm py-3 border-b border-white/10 hover:text-dtv-green transition-colors">Groups</RouterLink>
           <RouterLink v-if="profile.isTrusted" to="/profiles" @click="open = false" class="text-white font-bold uppercase tracking-wide text-sm py-3 border-b border-white/10 hover:text-dtv-green transition-colors">Profiles</RouterLink>
           <RouterLink v-if="profile.isAdmin" to="/entries" @click="open = false" class="text-white font-bold uppercase tracking-wide text-sm py-3 border-b border-white/10 hover:text-dtv-green transition-colors">Entries</RouterLink>
-          <RouterLink v-if="profile.isAdmin" to="/admin" @click="open = false" class="text-white font-bold uppercase tracking-wide text-sm py-3 border-b border-white/10 hover:text-dtv-green transition-colors">{{ ACCESS_LABEL_ADMIN }}</RouterLink>
+          <RouterLink v-if="profile.isAdmin" :to="toolsPath()" @click="open = false" class="text-white font-bold uppercase tracking-wide text-sm py-3 border-b border-white/10 hover:text-dtv-green transition-colors">{{ ACCESS_LABEL_ADMIN_TOOLS_PAGE }}</RouterLink>
           <button @click="openAbout" class="text-white font-bold uppercase tracking-wide text-sm py-3 border-b border-white/10 hover:text-dtv-green transition-colors text-left">About</button>
           <RouterLink v-if="isDev || profile.isAdmin" to="/sandbox" @click="open = false" class="text-white font-bold uppercase tracking-wide text-sm py-3 border-b border-white/10 hover:text-dtv-green transition-colors">Sandbox</RouterLink>
 
@@ -50,9 +50,10 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useRoute } from 'vue-router'
+import { toolsPath } from '../router'
 import { useViewer } from '../composables/useViewer'
 import AboutModal from './AboutModal.vue'
-import { ACCESS_LABEL_ADMIN } from '../utils/accessLabels'
+import { ACCESS_LABEL_ADMIN_TOOLS_PAGE } from '../utils/accessLabels'
 
 const isDev = import.meta.env.DEV
 const route = useRoute()

--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -44,7 +44,7 @@
       </div>
     </div>
   </header>
-  <AboutModal v-if="showAbout" @close="showAbout = false" />
+  <AboutModal v-if="showAbout" :login-tier-label="aboutLoginTierLabel" @close="showAbout = false" />
 </template>
 
 <script setup lang="ts">
@@ -53,7 +53,7 @@ import { useRoute } from 'vue-router'
 import { toolsPath } from '../router'
 import { useViewer } from '../composables/useViewer'
 import AboutModal from './AboutModal.vue'
-import { ACCESS_LABEL_ADMIN_TOOLS_PAGE } from '../utils/accessLabels'
+import { ACCESS_LABEL_ADMIN_TOOLS_PAGE, loginTierLabel } from '../utils/accessLabels'
 
 const isDev = import.meta.env.DEV
 const route = useRoute()
@@ -66,6 +66,16 @@ const loginPath = computed(() => {
 })
 const showAbout = ref(false)
 const profile = useViewer()
+
+const aboutLoginTierLabel = computed(() =>
+  loginTierLabel({
+    ready: profile.ready,
+    isAdmin: profile.isAdmin,
+    isCheckIn: profile.isCheckIn,
+    isSelfService: profile.isSelfService,
+    isPublic: profile.isPublic,
+  })
+)
 
 function toggleMenu() {
   open.value = !open.value

--- a/frontend/src/components/PersonalContainer.vue
+++ b/frontend/src/components/PersonalContainer.vue
@@ -1,65 +1,31 @@
 <template>
-  <PersonalPrompt
-    v-if="message"
-    :message="message"
-    :next-session="nextSession"
-    :previous-session="previousSession"
-  />
+  <PersonalPrompt :welcome="welcome" :next-session="nextSession" />
 </template>
 
 <script setup lang="ts">
 import { computed } from 'vue'
 import PersonalPrompt from './PersonalPrompt.vue'
 import type { SessionSummary } from './PersonalPrompt.vue'
+import {
+  ACCESS_LABEL_ADMIN,
+  ACCESS_LABEL_CHECK_IN,
+  ACCESS_LABEL_SELF_SERVICE,
+} from '../utils/accessLabels'
 
 const props = defineProps<{
   isAdmin: boolean
   isCheckIn: boolean
-  isReadOnly: boolean
   isSelfService: boolean
-  isNew: boolean
-  isRepeat: boolean
-  isRegular: boolean
-  hasBooking: boolean
-  hasAttended: boolean
   nextSession: SessionSummary | null
-  previousSession: SessionSummary | null
 }>()
 
-const message = computed<string | null>(() => {
-  if (props.isAdmin || props.isReadOnly) {
-    return "You're a DTV Tracker admin"
+const welcome = computed(() => {
+  if (props.isAdmin) {
+    return `Welcome to ${ACCESS_LABEL_ADMIN}`
   }
-
   if (props.isCheckIn) {
-    return 'Ready to manage your sessions and volunteers'
+    return `Welcome to ${ACCESS_LABEL_CHECK_IN}`
   }
-
-  if (!props.isSelfService) return null
-
-  const next = props.nextSession?.groupName
-  const prev = props.previousSession?.groupName
-
-  if (props.isNew && props.hasBooking && next) {
-    return `Your first ${next} is booked, read all about it`
-  }
-
-  if (props.isRepeat && props.hasBooking && next) {
-    return `Your next ${next} is booked, check the details`
-  }
-
-  if (props.isNew && !props.hasBooking && props.hasAttended && prev) {
-    return `You completed your first ${prev}, see photos and get booked on the next`
-  }
-
-  if (props.isRegular && props.hasBooking && next) {
-    return `You're booked onto ${next}, check the latest details`
-  }
-
-  if (props.isRegular && !props.hasBooking && prev) {
-    return `Catch up on ${prev} and check what's coming up next`
-  }
-
-  return null
+  return `Welcome to ${ACCESS_LABEL_SELF_SERVICE}`
 })
 </script>

--- a/frontend/src/components/PersonalPrompt.vue
+++ b/frontend/src/components/PersonalPrompt.vue
@@ -1,16 +1,11 @@
 <template>
   <div class="personal-prompt">
-    <p class="personal-prompt__message">{{ message }}</p>
+    <p class="personal-prompt__welcome">{{ welcome }}</p>
     <div class="personal-prompt__actions">
       <AppButton
-        v-if="nextSession"
-        label="View Next Session"
-        :href="nextSessionPath"
-      />
-      <AppButton
-        v-if="previousSession"
-        label="View Last Session"
-        :href="previousSessionPath"
+        usage="task"
+        label="Your Next Session"
+        :href="nextSessionHref"
       />
     </div>
   </div>
@@ -19,7 +14,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import AppButton from './AppButton.vue'
-import { sessionPath } from '../router'
+import { sessionPath, sessionsPath } from '../router'
 
 export interface SessionSummary {
   groupKey: string
@@ -28,13 +23,16 @@ export interface SessionSummary {
 }
 
 const props = defineProps<{
-  message: string
+  welcome: string
   nextSession: SessionSummary | null
-  previousSession: SessionSummary | null
 }>()
 
-const nextSessionPath     = computed(() => props.nextSession     ? sessionPath(props.nextSession.groupKey,     props.nextSession.date)     : '')
-const previousSessionPath = computed(() => props.previousSession ? sessionPath(props.previousSession.groupKey, props.previousSession.date) : '')
+/** Concrete next session, or sessions list when none scheduled. */
+const nextSessionHref = computed(() =>
+  props.nextSession
+    ? sessionPath(props.nextSession.groupKey, props.nextSession.date)
+    : sessionsPath(),
+)
 </script>
 
 <style scoped>
@@ -49,17 +47,16 @@ const previousSessionPath = computed(() => props.previousSession ? sessionPath(p
   gap: 1rem;
 }
 
-.personal-prompt__message {
+.personal-prompt__welcome {
   font-size: 0.95rem;
   line-height: 1.4;
   flex: 1;
   min-width: 0;
+  margin: 0;
 }
 
 .personal-prompt__actions {
   display: flex;
-  flex-direction: row;
-  gap: 0.5rem;
   flex-shrink: 0;
 }
 
@@ -71,7 +68,11 @@ const previousSessionPath = computed(() => props.previousSession ? sessionPath(p
 
   .personal-prompt__actions {
     width: 100%;
-    flex-direction: column;
+  }
+
+  .personal-prompt__actions :deep(.app-btn) {
+    width: 100%;
+    justify-content: center;
   }
 }
 </style>

--- a/frontend/src/components/entries/EntryListItem.vue
+++ b/frontend/src/components/entries/EntryListItem.vue
@@ -37,7 +37,18 @@ const props = defineProps<{
   selected?: boolean
 }>()
 
-const icons = computed(() => iconsForEntry({ isGroup: props.entry.isGroup, isChild: !!props.entry.accompanyingAdultId, labels: props.entry.labels, eventbriteAttendeeId: props.entry.eventbriteAttendeeId }))
+const icons = computed(() =>
+  iconsForEntry({
+    trackerAccess: props.entry.trackerAccess,
+    isMember: props.entry.isMember,
+    isGroup: props.entry.isGroup,
+    cardStatus: props.entry.cardStatus,
+    isChild: !!props.entry.accompanyingAdultId,
+    labels: props.entry.labels,
+    hasProfileWarning: props.entry.hasProfileWarning,
+    eventbriteAttendeeId: props.entry.eventbriteAttendeeId,
+  })
+)
 
 function formatDate(date: string): string {
   return new Date(date).toLocaleDateString('en-GB', { day: 'numeric', month: 'short' })

--- a/frontend/src/components/forms/AlertBanner.vue
+++ b/frontend/src/components/forms/AlertBanner.vue
@@ -4,10 +4,8 @@
       :src="`/icons/status/${iconName}.svg`"
       class="alert-banner-icon"
       :class="iconTintClass"
-      aria-hidden="true"
-      width="16"
-      height="16"
       alt=""
+      aria-hidden="true"
     />
     <span class="alert-banner-message">{{ message }}</span>
   </div>
@@ -48,11 +46,13 @@ const iconTintClass = computed(() => {
   font-weight: 500;
 }
 
+/* Match `AppButton` `.app-btn__icon` (1.1rem) for visual consistency */
 .alert-banner-icon {
   flex-shrink: 0;
-  width: 1rem;
-  height: 1rem;
-  margin-top: 0.25rem; /* align with first line of text */
+  width: 1.1rem;
+  height: 1.1rem;
+  object-fit: contain;
+  margin-top: 0.2rem; /* optical align with first line of text */
 }
 
 .alert-banner-message {

--- a/frontend/src/components/forms/AlertBanner.vue
+++ b/frontend/src/components/forms/AlertBanner.vue
@@ -1,6 +1,14 @@
 <template>
   <div class="alert-banner" :class="`alert-banner--${type}`">
-    <img :src="`/icons/status/${iconName}.svg`" class="alert-banner-icon" aria-hidden="true" width="16" height="16" alt="" />
+    <img
+      :src="`/icons/status/${iconName}.svg`"
+      class="alert-banner-icon"
+      :class="iconTintClass"
+      aria-hidden="true"
+      width="16"
+      height="16"
+      alt=""
+    />
     <span class="alert-banner-message">{{ message }}</span>
   </div>
 </template>
@@ -20,6 +28,13 @@ const iconName = computed(() => {
   if (props.type === 'info')  return 'info'
   return 'warning'
 })
+
+/** Global helpers from `icons.css` — match banner text / background. */
+const iconTintClass = computed(() => {
+  if (props.type === 'error') return 'svg-white'
+  if (props.type === 'info') return 'svg-black'
+  return 'svg-dirt-dark'
+})
 </script>
 
 <style scoped>
@@ -28,7 +43,6 @@ const iconName = computed(() => {
   align-items: flex-start;
   gap: 0.6rem;
   padding: 0.85rem 1rem;
-  border: 2px solid;
   font-size: 0.9rem;
   line-height: 1.5;
   font-weight: 500;
@@ -41,39 +55,25 @@ const iconName = computed(() => {
   margin-top: 0.25rem; /* align with first line of text */
 }
 
-/* Colour each status icon to match its text colour */
-.alert-banner--warning .alert-banner-icon {
-  filter: brightness(0) saturate(100%) invert(28%) sepia(50%) saturate(800%) hue-rotate(20deg) brightness(90%);
-}
-.alert-banner--error .alert-banner-icon {
-  filter: brightness(0) saturate(100%) invert(22%) sepia(50%) saturate(700%) hue-rotate(320deg) brightness(90%);
-}
-.alert-banner--info .alert-banner-icon {
-  filter: brightness(0);
-}
-
 .alert-banner-message {
   flex: 1;
   min-width: 0;
 }
 
-/* Warning */
+/* Warning — dirt tint (general caution; same family as profile/entry highlights) */
 .alert-banner--warning {
-  border-color: #f59e0b;
-  background: #fffbeb;
-  color: #78350f;
-}
-
-/* Error */
-.alert-banner--error {
-  border-color: var(--color-dtv-dirt);
   background: var(--color-dtv-dirt-light);
   color: var(--color-dtv-dirt-dark);
 }
 
+/* Error — solid dirt + light text (matches FlashMessage error, stronger than warning) */
+.alert-banner--error {
+  background: var(--color-dtv-dirt);
+  color: var(--color-dtv-light);
+}
+
 /* Info */
 .alert-banner--info {
-  border-color: var(--color-dtv-sand-dark);
   background: var(--color-dtv-sand-light);
   color: var(--color-dtv-dark);
 }

--- a/frontend/src/components/profiles/ProfileListItem.vue
+++ b/frontend/src/components/profiles/ProfileListItem.vue
@@ -20,6 +20,20 @@
           :alt="`Card: ${profile.cardStatus}`"
           :title="`Card: ${profile.cardStatus}`"
         />
+        <img
+          v-if="profile.trackerAccess === 'admin'"
+          src="/icons/badges/tracker-admin.svg"
+          class="pli-badge svg-black"
+          :alt="ACCESS_LABEL_ADMIN"
+          :title="ACCESS_LABEL_ADMIN"
+        />
+        <img
+          v-if="profile.trackerAccess === 'checkin'"
+          src="/icons/badges/tracker-checkin.svg"
+          class="pli-badge svg-black"
+          :alt="ACCESS_LABEL_CHECK_IN"
+          :title="ACCESS_LABEL_CHECK_IN"
+        />
       </span>
     </span>
     <span class="pli-meta">
@@ -33,6 +47,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { profilePath } from '../../router/index'
+import { ACCESS_LABEL_ADMIN, ACCESS_LABEL_CHECK_IN } from '../../utils/accessLabels'
 import type { ProfileResponse } from '../../../../types/api-responses'
 
 const props = defineProps<{

--- a/frontend/src/components/sessions/SessionCard.vue
+++ b/frontend/src/components/sessions/SessionCard.vue
@@ -8,7 +8,7 @@
     </div>
 
     <div class="session-card__footer">
-      <ul v-if="isOperational" class="session-card__stats">
+      <ul v-if="hasCheckInAccess" class="session-card__stats">
         <li v-if="display.count || display.totalLimit">
           {{ display.count }}<template v-if="display.totalLimit">/{{ display.totalLimit }}</template> Total
         </li>
@@ -46,7 +46,7 @@ const props = defineProps<{
   profile?: RoleContext
 }>()
 
-const isOperational = computed(() => props.profile?.isOperational ?? false)
+const hasCheckInAccess = computed(() => props.profile?.hasCheckInAccess ?? false)
 
 const viewPath = computed(() => sessionPath(props.session.groupKey!, props.session.date))
 

--- a/frontend/src/components/sessions/SessionEntryList.vue
+++ b/frontend/src/components/sessions/SessionEntryList.vue
@@ -22,7 +22,7 @@
         :title-to="allowEdit ? undefined : (e.profile.slug ? profilePath(e.profile.slug) : undefined)"
         :checked-in="e.checkedIn"
         :hours="e.hours"
-        :icons="iconsForEntry({ ...e.profile, isChild: !!e.accompanyingAdultId, labels: e.labels, isNew: e.isNew, noPhoto: e.profile.noPhoto, isFirstAiderAvailable: e.profile.isFirstAiderAvailable, eventbriteAttendeeId: e.eventbriteAttendeeId })"
+        :icons="iconsForEntry({ trackerAccess: e.trackerAccess, ...e.profile, isChild: !!e.accompanyingAdultId, labels: e.labels, isNew: e.isNew, noPhoto: e.profile.noPhoto, isFirstAiderAvailable: e.profile.isFirstAiderAvailable, eventbriteAttendeeId: e.eventbriteAttendeeId })"
         :allow-edit="allowEdit"
         :working="workingId === e.id"
         :cancelled="!!e.cancelled"

--- a/frontend/src/composables/useAuth.ts
+++ b/frontend/src/composables/useAuth.ts
@@ -2,7 +2,7 @@ import { ref, onMounted } from 'vue'
 
 export interface AuthUser {
   displayName: string
-  role: 'admin' | 'checkin' | 'readonly' | 'selfservice'
+  role: 'admin' | 'checkin' | 'selfservice'
   profileSlug?: string
   profileStats?: {
     sessionsByFY: Record<string, number>

--- a/frontend/src/composables/useViewer.test.ts
+++ b/frontend/src/composables/useViewer.test.ts
@@ -18,20 +18,18 @@ function viewer(role: string | null, ready = true) {
 
 describe('useViewer role matrix', () => {
   it.each([
-    { role: 'admin',       isAdmin: true,  isCheckIn: false, isReadOnly: false, isSelfService: false, isTrusted: true,  isAuthenticated: true,  isOperational: true  },
-    { role: 'checkin',     isAdmin: false, isCheckIn: true,  isReadOnly: false, isSelfService: false, isTrusted: true,  isAuthenticated: true,  isOperational: true  },
-    { role: 'readonly',    isAdmin: false, isCheckIn: false, isReadOnly: true,  isSelfService: false, isTrusted: true,  isAuthenticated: true,  isOperational: false },
-    { role: 'selfservice', isAdmin: false, isCheckIn: false, isReadOnly: false, isSelfService: true,  isTrusted: false, isAuthenticated: true,  isOperational: false },
-    { role: null,          isAdmin: false, isCheckIn: false, isReadOnly: false, isSelfService: false, isTrusted: false, isAuthenticated: false, isOperational: false },
-  ])('$role', ({ role, isAdmin, isCheckIn, isReadOnly, isSelfService, isTrusted, isAuthenticated, isOperational }) => {
+    { role: 'admin',       isAdmin: true,  isCheckIn: false, isSelfService: false, isTrusted: true,  isAuthenticated: true,  hasCheckInAccess: true  },
+    { role: 'checkin',     isAdmin: false, isCheckIn: true,  isSelfService: false, isTrusted: true,  isAuthenticated: true,  hasCheckInAccess: true  },
+    { role: 'selfservice', isAdmin: false, isCheckIn: false, isSelfService: true,  isTrusted: false, isAuthenticated: true,  hasCheckInAccess: false },
+    { role: null,          isAdmin: false, isCheckIn: false, isSelfService: false, isTrusted: false, isAuthenticated: false, hasCheckInAccess: false },
+  ])('$role', ({ role, isAdmin, isCheckIn, isSelfService, isTrusted, isAuthenticated, hasCheckInAccess }) => {
     const v = viewer(role)
     expect(v.isAdmin).toBe(isAdmin)
     expect(v.isCheckIn).toBe(isCheckIn)
-    expect(v.isReadOnly).toBe(isReadOnly)
     expect(v.isSelfService).toBe(isSelfService)
     expect(v.isTrusted).toBe(isTrusted)
     expect(v.isAuthenticated).toBe(isAuthenticated)
-    expect(v.isOperational).toBe(isOperational)
+    expect(v.hasCheckInAccess).toBe(hasCheckInAccess)
   })
 })
 
@@ -52,12 +50,11 @@ describe('useViewer — context snapshot', () => {
     expect(v.context).toEqual({
       isAdmin: true,
       isCheckIn: false,
-      isReadOnly: false,
       isSelfService: false,
       isTrusted: true,
       isAuthenticated: true,
       isPublic: false,
-      isOperational: true,
+      hasCheckInAccess: true,
     })
   })
 })

--- a/frontend/src/composables/useViewer.ts
+++ b/frontend/src/composables/useViewer.ts
@@ -6,12 +6,12 @@ import { useAuth } from './useAuth'
 export interface RoleContext {
   isAdmin: boolean
   isCheckIn: boolean
-  isReadOnly: boolean
   isSelfService: boolean
   isTrusted: boolean
   isAuthenticated: boolean
   isPublic: boolean
-  isOperational: boolean
+  /** Check-in tier: field-day / registration capabilities (admin includes this). */
+  hasCheckInAccess: boolean
 }
 
 export function useViewer() {
@@ -21,24 +21,22 @@ export function useViewer() {
 
   const isAdmin         = computed(() => role.value === 'admin')
   const isCheckIn       = computed(() => role.value === 'checkin')
-  const isReadOnly      = computed(() => role.value === 'readonly')
   const isSelfService   = computed(() => role.value === 'selfservice')
-  const isTrusted       = computed(() => role.value === 'admin' || role.value === 'checkin' || role.value === 'readonly')
+  const isTrusted       = computed(() => role.value === 'admin' || role.value === 'checkin')
   const isAuthenticated = computed(() => user.value !== null)
   const isPublic        = computed(() => ready.value && !isAuthenticated.value)
-  const isOperational   = computed(() => isAdmin.value || isCheckIn.value)
+  const hasCheckInAccess = computed(() => isAdmin.value || isCheckIn.value)
 
   // Snapshot object for passing to components as a `profile` prop
   const context = computed<RoleContext>(() => ({
     isAdmin: isAdmin.value,
     isCheckIn: isCheckIn.value,
-    isReadOnly: isReadOnly.value,
     isSelfService: isSelfService.value,
     isTrusted: isTrusted.value,
     isAuthenticated: isAuthenticated.value,
     isPublic: isPublic.value,
-    isOperational: isOperational.value,
+    hasCheckInAccess: hasCheckInAccess.value,
   }))
 
-  return reactive({ user, ready, role, isAdmin, isCheckIn, isReadOnly, isSelfService, isTrusted, isAuthenticated, isPublic, isOperational, context })
+  return reactive({ user, ready, role, isAdmin, isCheckIn, isSelfService, isTrusted, isAuthenticated, isPublic, hasCheckInAccess, context })
 }

--- a/frontend/src/pages/AdminPage.vue
+++ b/frontend/src/pages/AdminPage.vue
@@ -1,6 +1,6 @@
 <template>
   <DefaultLayout>
-    <PageHeader>{{ ACCESS_LABEL_ADMIN }}</PageHeader>
+    <PageHeader>{{ ACCESS_LABEL_ADMIN_TOOLS_PAGE }}</PageHeader>
     <div class="pt-3 pb-8">
 
       <LoadingSpinner v-if="!profile.ready" />
@@ -68,30 +68,19 @@
           <div v-if="sessionStatsResult"   :class="['ap-result', sessionStatsError   && 'ap-error']">{{ sessionStatsResult }}</div>
         </div>
 
-        <!-- SharePoint: shortcuts + full cache clear after manual list edits -->
+        <!-- SharePoint: shortcuts + full cache clear -->
         <div class="ap-section">
           <h2 class="ap-title">
             <a v-if="siteUrl" :href="siteUrl" target="_blank" rel="noopener">{{ siteLabel }}</a>
             <template v-else>SharePoint</template>
           </h2>
-          <p class="ap-sharepoint-hint">
-            If you change list data directly in SharePoint, clear the app cache here so the next request loads fresh data from Graph (not memory).
-          </p>
-          <div class="ap-actions ap-actions--cache-clear">
-            <AppButton
-              label="Clear all server caches"
-              variant="danger"
-              usage="task"
-              :working="cacheClearLoading"
-              @click="clearAllServerCaches"
-            />
-          </div>
-          <div v-if="cacheClearResult" :class="['ap-result', cacheClearError && 'ap-error']">{{ cacheClearResult }}</div>
-          <div class="ap-actions ap-actions--shortcuts">
+          <div class="ap-actions">
+            <AppButton label="Clear all server caches" :working="cacheClearLoading" @click="clearAllServerCaches" />
             <AppButton label="Site Contents" :href="siteContentsUrl" target="_blank" />
             <AppButton label="Term Store" :href="termStoreUrl" target="_blank" />
             <AppButton label="Backup" :working="backupLoading" @click="exportBackup" />
           </div>
+          <div v-if="cacheClearResult" :class="['ap-result', cacheClearError && 'ap-error']">{{ cacheClearResult }}</div>
           <div v-if="backupResult" :class="['ap-result', backupError && 'ap-error']">{{ backupResult }}</div>
         </div>
 
@@ -127,9 +116,9 @@ import { useViewer } from '../composables/useViewer'
 import { usePageTitle } from '../composables/usePageTitle'
 import { LABEL_ICONS } from '../utils/labelIcons'
 
-import { ACCESS_LABEL_ADMIN } from '../utils/accessLabels'
+import { ACCESS_LABEL_ADMIN_TOOLS_PAGE } from '../utils/accessLabels'
 
-usePageTitle(ACCESS_LABEL_ADMIN)
+usePageTitle(ACCESS_LABEL_ADMIN_TOOLS_PAGE)
 
 const router = useRouter()
 const profile = useViewer()
@@ -306,13 +295,6 @@ const cacheClearResult  = ref('')
 const cacheClearError   = ref(false)
 
 async function clearAllServerCaches() {
-  if (
-    !confirm(
-      'Clear all server-side caches (SharePoint list data, column schema, taxonomy, media, cover images)? The next pages may load more slowly.'
-    )
-  ) {
-    return
-  }
   cacheClearLoading.value = true
   cacheClearResult.value = ''
   cacheClearError.value = false
@@ -387,31 +369,6 @@ onMounted(loadSiteConfig)
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
-}
-
-.ap-sharepoint-hint {
-  margin: 0 0 1rem;
-  font-size: 0.9rem;
-  color: var(--color-text-muted);
-  line-height: 1.45;
-  max-width: 42rem;
-}
-
-.ap-actions--cache-clear {
-  margin-bottom: 0.75rem;
-}
-
-.ap-actions--cache-clear :deep(.app-btn) {
-  width: 100%;
-  justify-content: center;
-  min-height: 3rem;
-  font-size: 1.05rem;
-}
-
-.ap-actions--shortcuts {
-  margin-top: 0.5rem;
-  padding-top: 0.75rem;
-  border-top: 1px solid var(--color-border);
 }
 
 .ap-result {

--- a/frontend/src/pages/AdminPage.vue
+++ b/frontend/src/pages/AdminPage.vue
@@ -68,12 +68,26 @@
           <div v-if="sessionStatsResult"   :class="['ap-result', sessionStatsError   && 'ap-error']">{{ sessionStatsResult }}</div>
         </div>
 
-        <!-- Site shortcuts (shown when config returns a SharePoint site URL) -->
-        <div v-if="siteUrl" class="ap-section">
+        <!-- SharePoint: shortcuts + full cache clear after manual list edits -->
+        <div class="ap-section">
           <h2 class="ap-title">
-            <a :href="siteUrl" target="_blank" rel="noopener">{{ siteLabel }}</a>
+            <a v-if="siteUrl" :href="siteUrl" target="_blank" rel="noopener">{{ siteLabel }}</a>
+            <template v-else>SharePoint</template>
           </h2>
-          <div class="ap-actions">
+          <p class="ap-sharepoint-hint">
+            If you change list data directly in SharePoint, clear the app cache here so the next request loads fresh data from Graph (not memory).
+          </p>
+          <div class="ap-actions ap-actions--cache-clear">
+            <AppButton
+              label="Clear all server caches"
+              variant="danger"
+              usage="task"
+              :working="cacheClearLoading"
+              @click="clearAllServerCaches"
+            />
+          </div>
+          <div v-if="cacheClearResult" :class="['ap-result', cacheClearError && 'ap-error']">{{ cacheClearResult }}</div>
+          <div class="ap-actions ap-actions--shortcuts">
             <AppButton label="Site Contents" :href="siteContentsUrl" target="_blank" />
             <AppButton label="Term Store" :href="termStoreUrl" target="_blank" />
             <AppButton label="Backup" :working="backupLoading" @click="exportBackup" />
@@ -287,6 +301,35 @@ const backupLoading   = ref(false)
 const backupResult    = ref('')
 const backupError     = ref(false)
 
+const cacheClearLoading = ref(false)
+const cacheClearResult  = ref('')
+const cacheClearError   = ref(false)
+
+async function clearAllServerCaches() {
+  if (
+    !confirm(
+      'Clear all server-side caches (SharePoint list data, column schema, taxonomy, media, cover images)? The next pages may load more slowly.'
+    )
+  ) {
+    return
+  }
+  cacheClearLoading.value = true
+  cacheClearResult.value = ''
+  cacheClearError.value = false
+  try {
+    const res = await fetch('/api/cache/clear', { method: 'POST' })
+    const data = await res.json()
+    if (!res.ok || !data.success) throw new Error(data.error || data.message || 'Clear failed')
+    cacheClearResult.value = data.message || 'Caches cleared.'
+  } catch (e: any) {
+    cacheClearResult.value = e.message || 'Clear failed'
+    cacheClearError.value = true
+    console.error('Cache clear failed:', e)
+  } finally {
+    cacheClearLoading.value = false
+  }
+}
+
 async function loadSiteConfig() {
   try {
     const res = await fetch('/api/config')
@@ -294,7 +337,7 @@ async function loadSiteConfig() {
     if (data.success && data.data.sharepointSiteUrl) {
       siteUrl.value = data.data.sharepointSiteUrl
     }
-  } catch { /* site section stays hidden */ }
+  } catch { /* site title stays plain "SharePoint" */ }
 }
 
 async function exportBackup() {
@@ -344,6 +387,31 @@ onMounted(loadSiteConfig)
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
+}
+
+.ap-sharepoint-hint {
+  margin: 0 0 1rem;
+  font-size: 0.9rem;
+  color: var(--color-text-muted);
+  line-height: 1.45;
+  max-width: 42rem;
+}
+
+.ap-actions--cache-clear {
+  margin-bottom: 0.75rem;
+}
+
+.ap-actions--cache-clear :deep(.app-btn) {
+  width: 100%;
+  justify-content: center;
+  min-height: 3rem;
+  font-size: 1.05rem;
+}
+
+.ap-actions--shortcuts {
+  margin-top: 0.5rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--color-border);
 }
 
 .ap-result {

--- a/frontend/src/pages/AdminPage.vue
+++ b/frontend/src/pages/AdminPage.vue
@@ -1,6 +1,6 @@
 <template>
   <DefaultLayout>
-    <PageHeader>Admin</PageHeader>
+    <PageHeader>{{ ACCESS_LABEL_ADMIN }}</PageHeader>
     <div class="pt-3 pb-8">
 
       <LoadingSpinner v-if="!profile.ready" />
@@ -113,7 +113,9 @@ import { useViewer } from '../composables/useViewer'
 import { usePageTitle } from '../composables/usePageTitle'
 import { LABEL_ICONS } from '../utils/labelIcons'
 
-usePageTitle('Admin')
+import { ACCESS_LABEL_ADMIN } from '../utils/accessLabels'
+
+usePageTitle(ACCESS_LABEL_ADMIN)
 
 const router = useRouter()
 const profile = useViewer()

--- a/frontend/src/pages/HomePage.vue
+++ b/frontend/src/pages/HomePage.vue
@@ -5,20 +5,13 @@
     <LoadingSpinner v-if="store.loading" />
     <template v-else>
 
-    <!-- Personal prompt — shown to all logged-in users when a message applies -->
+    <!-- Welcome banner + next session (all signed-in roles) -->
     <PersonalContainer
       v-if="profile.isAuthenticated"
       :is-admin="profile.isAdmin"
       :is-check-in="profile.isCheckIn"
-      :is-read-only="profile.isReadOnly"
       :is-self-service="profile.isSelfService"
-      :is-new="isNewVolunteer"
-      :is-repeat="isRepeatVolunteer"
-      :is-regular="isRegularVolunteer"
-      :has-booking="hasBooking"
-      :has-attended="hasAttended"
       :next-session="nextSession"
-      :previous-session="previousSession"
     />
 
     <LayoutColumns class="pt-2 mb-8">
@@ -112,7 +105,7 @@
     </LayoutColumns>
 
     <!-- Recent sign-ups — admin/check-in only -->
-    <section v-if="profile.isOperational" class="mb-8">
+    <section v-if="profile.hasCheckInAccess" class="mb-8">
       <SectionHeader>Recent Bookings</SectionHeader>
       <RecentEntryList :is-admin="profile.isAdmin" />
     </section>

--- a/frontend/src/pages/LoginPage.vue
+++ b/frontend/src/pages/LoginPage.vue
@@ -64,10 +64,10 @@
           </FormSubmitRow>
         </FormCard>
 
-        <!-- Microsoft work account (Tracker Assist / Tracker Admin at auth) -->
+        <!-- Microsoft sign-in (Tracker Assist / Tracker Admin at auth) -->
         <FormCard
           :title="ACCESS_LABEL_CHECK_IN"
-          subtitle="Sign in with your Microsoft (work account) ending with @dtv.org.uk"
+          subtitle="Sign in with your Microsoft account, using an address ending @dtv.org.uk"
         >
           <FormSubmitRow>
             <AppButton usage="task" variant="secondary" icon="brands/microsoft" label="Log-in with Microsoft" :href="microsoftHref" />
@@ -122,11 +122,7 @@ import FormCard from '../components/forms/FormCard.vue'
 import FormInput from '../components/forms/FormInput.vue'
 import FormSubmitRow from '../components/forms/FormSubmitRow.vue'
 import AppButton from '../components/AppButton.vue'
-import {
-  ACCESS_LABEL_ADMIN,
-  ACCESS_LABEL_CHECK_IN,
-  ACCESS_LABEL_SELF_SERVICE,
-} from '../utils/accessLabels'
+import { ACCESS_LABEL_CHECK_IN, ACCESS_LABEL_SELF_SERVICE } from '../utils/accessLabels'
 
 usePageTitle('Login')
 
@@ -173,7 +169,7 @@ const reasons: Record<string, (email?: string) => string> = {
   'not-found':    (e) => `We don't have an account for ${e ?? 'that email address'}. Contact your group organiser to get set up.`,
   'invalid-state': () => 'That sign-in link has expired or is invalid — enter your email below to get a new one.',
   'dtv-not-authorised': () =>
-    `Access denied. Your work account is not set up for ${ACCESS_LABEL_CHECK_IN} or ${ACCESS_LABEL_ADMIN}. Please contact a ${ACCESS_LABEL_ADMIN} to resolve this.`,
+    `Access denied. Your Microsoft account is not set up for ${ACCESS_LABEL_CHECK_IN}. Please contact your admin.`,
 }
 
 async function sendLoginEmail() {

--- a/frontend/src/pages/LoginPage.vue
+++ b/frontend/src/pages/LoginPage.vue
@@ -15,7 +15,11 @@
     <div class="login-stack">
 
       <!-- Reason banner -->
-      <AlertBanner v-if="reasonMessage" :message="reasonMessage" />
+      <AlertBanner
+        v-if="reasonMessage"
+        :message="reasonMessage"
+        :type="loginReasonBannerType"
+      />
 
       <!-- Login cards -->
       <template v-if="!sent">
@@ -23,8 +27,8 @@
         <!-- Volunteer sign-in (magic link / verification code) -->
         <FormCard
           v-if="magicEnabled || verifyEnabled"
-          title="Your email log-in"
-          subtitle="View your volunteer profile, manage your sessions, and upload photos."
+          :title="ACCESS_LABEL_SELF_SERVICE"
+          subtitle="Sign in with email to view your volunteer profile, manage your sessions, and upload photos."
         >
           <!-- Method selector — only shown when both options are available -->
           <p v-if="magicEnabled && verifyEnabled" class="method-prompt">Choose how we verify your email.</p>
@@ -60,10 +64,10 @@
           </FormSubmitRow>
         </FormCard>
 
-        <!-- DTV Teams account (Microsoft) -->
+        <!-- Microsoft work account (Tracker Assist / Tracker Admin at auth) -->
         <FormCard
-          title="DTV Teams Only"
-          subtitle="For dig leads, coordinators and admins — you must use your @dtv.org.uk account."
+          :title="ACCESS_LABEL_CHECK_IN"
+          subtitle="Sign in with your Microsoft (work account) ending with @dtv.org.uk"
         >
           <FormSubmitRow>
             <AppButton usage="task" variant="secondary" icon="brands/microsoft" label="Log-in with Microsoft" :href="microsoftHref" />
@@ -118,6 +122,11 @@ import FormCard from '../components/forms/FormCard.vue'
 import FormInput from '../components/forms/FormInput.vue'
 import FormSubmitRow from '../components/forms/FormSubmitRow.vue'
 import AppButton from '../components/AppButton.vue'
+import {
+  ACCESS_LABEL_ADMIN,
+  ACCESS_LABEL_CHECK_IN,
+  ACCESS_LABEL_SELF_SERVICE,
+} from '../utils/accessLabels'
 
 usePageTitle('Login')
 
@@ -148,6 +157,10 @@ const microsoftHref = computed(() =>
   returnTo.value ? `/auth/login?returnTo=${encodeURIComponent(returnTo.value)}` : '/auth/login'
 )
 
+const loginReasonBannerType = computed<'warning' | 'error'>(() =>
+  route.query.reason === 'dtv-not-authorised' ? 'error' : 'warning'
+)
+
 const expired = computed(() => sent.value && countdownSeconds.value <= 0)
 
 const countdown = computed(() => {
@@ -159,6 +172,8 @@ const reasons: Record<string, (email?: string) => string> = {
   'not-approved': (e) => `We don't have an account for ${e ?? 'that email address'}. Contact your group organiser to get set up.`,
   'not-found':    (e) => `We don't have an account for ${e ?? 'that email address'}. Contact your group organiser to get set up.`,
   'invalid-state': () => 'That sign-in link has expired or is invalid — enter your email below to get a new one.',
+  'dtv-not-authorised': () =>
+    `Access denied. Your work account is not set up for ${ACCESS_LABEL_CHECK_IN} or ${ACCESS_LABEL_ADMIN}. Please contact a ${ACCESS_LABEL_ADMIN} to resolve this.`,
 }
 
 async function sendLoginEmail() {

--- a/frontend/src/pages/PrivacyPage.vue
+++ b/frontend/src/pages/PrivacyPage.vue
@@ -37,10 +37,9 @@
       <section>
         <h2 class="text-xl font-bold mb-2">Who can see your data</h2>
         <ul class="list-disc pl-6 space-y-1">
-          <li><strong>Admins and Check-In users</strong> &mdash; can view and edit all volunteer data.</li>
-          <li><strong>Read-only users</strong> &mdash; can view all data but cannot make changes.</li>
-          <li><strong>You (self-service login)</strong> &mdash; can view your own profile, sessions, and uploaded media.</li>
-          <li><strong>Public (unauthenticated)</strong> &mdash; can view sessions, groups, and aggregate statistics. Individual volunteer names and profiles are not visible without logging in.</li>
+          <li><strong>{{ ACCESS_LABEL_CHECK_IN }} &amp; {{ ACCESS_LABEL_ADMIN }}</strong> (Microsoft sign-in) &mdash; can view and edit volunteer data for their role. Access is only granted when your volunteer profile is linked to your work account.</li>
+          <li><strong>{{ ACCESS_LABEL_SELF_SERVICE }}</strong> (email sign-in) &mdash; can view your own profile, sessions, and uploaded media.</li>
+          <li><strong>{{ ACCESS_LABEL_PUBLIC }}</strong> (without signing in) &mdash; can view sessions, groups, and aggregate statistics. Individual volunteer names and profiles are not visible without logging in.</li>
         </ul>
       </section>
 
@@ -81,6 +80,12 @@
 import DefaultLayout from '../layouts/DefaultLayout.vue'
 import { usePageTitle } from '../composables/usePageTitle'
 import PageHeader from '../components/PageHeader.vue'
+import {
+  ACCESS_LABEL_PUBLIC,
+  ACCESS_LABEL_SELF_SERVICE,
+  ACCESS_LABEL_CHECK_IN,
+  ACCESS_LABEL_ADMIN,
+} from '../utils/accessLabels'
 
 usePageTitle('Privacy Policy')
 </script>

--- a/frontend/src/pages/PrivacyPage.vue
+++ b/frontend/src/pages/PrivacyPage.vue
@@ -37,7 +37,7 @@
       <section>
         <h2 class="text-xl font-bold mb-2">Who can see your data</h2>
         <ul class="list-disc pl-6 space-y-1">
-          <li><strong>{{ ACCESS_LABEL_CHECK_IN }} &amp; {{ ACCESS_LABEL_ADMIN }}</strong> (Microsoft sign-in) &mdash; can view and edit volunteer data for their role. Access is only granted when your volunteer profile is linked to your work account.</li>
+          <li><strong>{{ ACCESS_LABEL_CHECK_IN }} &amp; {{ ACCESS_LABEL_ADMIN }}</strong> (Microsoft sign-in) &mdash; can view and edit volunteer data for their role. Access is only granted when your volunteer profile is linked to your Microsoft sign-in email.</li>
           <li><strong>{{ ACCESS_LABEL_SELF_SERVICE }}</strong> (email sign-in) &mdash; can view your own profile, sessions, and uploaded media.</li>
           <li><strong>{{ ACCESS_LABEL_PUBLIC }}</strong> (without signing in) &mdash; can view sessions, groups, and aggregate statistics. Individual volunteer names and profiles are not visible without logging in.</li>
         </ul>

--- a/frontend/src/pages/ProfileDetailPage.vue
+++ b/frontend/src/pages/ProfileDetailPage.vue
@@ -36,13 +36,27 @@
             <div class="pd-badges">
               <img v-if="isMember" src="/icons/badges/member.svg" class="pd-badge" alt="Member" title="Member" />
               <img v-if="store.profile.isGroup" src="/icons/badges/group.svg" class="pd-badge" alt="Group" title="Group" />
+              <img
+                v-if="store.profile.trackerAccess === 'admin'"
+                src="/icons/badges/tracker-admin.svg"
+                class="pd-badge"
+                :alt="ACCESS_LABEL_ADMIN"
+                :title="ACCESS_LABEL_ADMIN"
+              />
+              <img
+                v-if="store.profile.trackerAccess === 'checkin'"
+                src="/icons/badges/tracker-checkin.svg"
+                class="pd-badge"
+                :alt="ACCESS_LABEL_CHECK_IN"
+                :title="ACCESS_LABEL_CHECK_IN"
+              />
             </div>
             <div v-for="email in store.profile.emails" :key="email" class="pd-email">
               <a :href="`mailto:${email}`">{{ email }}</a>
             </div>
           </div>
           <ProfileLinkedAccounts
-            v-if="viewer.isOperational && store.profile.linkedProfiles?.length"
+            v-if="viewer.hasCheckInAccess && store.profile.linkedProfiles?.length"
             :linked-profiles="store.profile.linkedProfiles"
           />
         </template>
@@ -60,7 +74,7 @@
             @transfer-profile="onTransferProfile"
           />
           <ProfileWarnings
-            v-if="viewer.isOperational && store.profile.warnings?.length"
+            v-if="viewer.hasCheckInAccess && store.profile.warnings?.length"
             :warnings="store.profile.warnings!"
           />
         </template>
@@ -74,7 +88,7 @@
       />
 
       <RegularEditModal
-        v-if="editingRegular && viewer.isOperational"
+        v-if="editingRegular && viewer.hasCheckInAccess"
         :regular="editingRegular"
         :adults="[]"
         view-link-label="View Group"
@@ -90,7 +104,7 @@
         :records="store.profile.records ?? []"
         :profile-id="store.profile.id"
         :profile-slug="store.profile.slug"
-        :show-consent-link="viewer.isOperational || viewer.isSelfService"
+        :show-consent-link="viewer.hasCheckInAccess || viewer.isSelfService"
         :allow-edit="viewer.isAdmin"
         :types="recordTypes"
         :statuses="recordStatuses"
@@ -105,7 +119,7 @@
         <template #left>
           <ProfileEntryList
             :entries="entries"
-            :allow-edit="viewer.isOperational"
+            :allow-edit="viewer.hasCheckInAccess"
             :is-admin="viewer.isAdmin"
             :working-id="workingId"
             ref="entryListRef"
@@ -185,6 +199,7 @@ import type { AddRecordPayload } from './modals/RecordAddModal.vue'
 import type { SaveRecordPayload } from './modals/RecordEditModal.vue'
 import type { EntryItem } from '../types/entry'
 import { fetchSessionAdults } from '../utils/fetchSessionAdults'
+import { ACCESS_LABEL_ADMIN, ACCESS_LABEL_CHECK_IN } from '../utils/accessLabels'
 import type { PickerProfile } from '../components/ProfilePicker.vue'
 import LayoutColumns from '../components/LayoutColumns.vue'
 import SectionHeader from '../components/SectionHeader.vue'

--- a/frontend/src/pages/SessionDetailPage.vue
+++ b/frontend/src/pages/SessionDetailPage.vue
@@ -49,7 +49,7 @@
 
       <!-- SECOND ROW -->
        <!-- TODO display a different set of text depending on the session category (dig, fund raising, behind the scenes etc.) -->
-      <LayoutColumns ratio="1-1-1" v-if="store.session.isBookable && !profile.isOperational">
+      <LayoutColumns ratio="1-1-1" v-if="store.session.isBookable && !profile.hasCheckInAccess">
         <template #header>
           <SectionHeader >What to expect?</SectionHeader>
         </template>
@@ -93,7 +93,7 @@
 
       </LayoutColumns>
 
-      <LayoutColumns ratio="1-2" v-if="!store.session.isBookable || store.session.description !== null || (store.session.metadata?.length ?? 0) > 0 || profile.isOperational">
+      <LayoutColumns ratio="1-2" v-if="!store.session.isBookable || store.session.description !== null || (store.session.metadata?.length ?? 0) > 0 || profile.hasCheckInAccess">
 
         <template #header>
           <SectionHeader v-if="!store.session.isBookable">What we got up to?</SectionHeader>
@@ -118,7 +118,7 @@
             :edit-working="editWorking"
             :edit-error="editError"
             :allow-edit="profile.isCheckIn || profile.isAdmin"
-            :allow-email="profile.isOperational"
+            :allow-email="profile.hasCheckInAccess"
             :is-self-service="profile.isSelfService"
             @session-save="onSessionSave"
             @session-delete="onSessionDelete"
@@ -163,13 +163,13 @@
 
 
       <!-- BOTTOM ROW -->
-      <LayoutColumns ratio="1" :reverse="true" v-if="profile.isOperational">
+      <LayoutColumns ratio="1" :reverse="true" v-if="profile.hasCheckInAccess">
         <template #header><SectionHeader>Who's booked on?</SectionHeader></template>
         <template #left>
           <SessionEntryList
             ref="entryListRef"
             :entries="entries"
-            :allow-edit="profile.isOperational"
+            :allow-edit="profile.hasCheckInAccess"
             :is-admin="profile.isAdmin"
             :profiles="profiles"
             :working-id="workingId"
@@ -367,6 +367,7 @@ function mapEntry(e: EntryResponse): EntryItem {
   return {
     id: e.id,
     profileId: e.profileId,
+    trackerAccess: e.trackerAccess,
     checkedIn: e.checkedIn,
     hours: e.hours,
     count: e.count,

--- a/frontend/src/pages/TermsPage.vue
+++ b/frontend/src/pages/TermsPage.vue
@@ -10,7 +10,7 @@
 
       <section>
         <h2 class="text-xl font-bold mb-2">Who can use this application</h2>
-        <p>DTV Tracker is an internal tool for Dean Trail Volunteers trusted users and volunteers. Some parts of the application are publicly accessible without an account. Full access requires an invitation from a DTV administrator.</p>
+        <p>DTV Tracker is an internal tool for {{ ACCESS_LABEL_CHECK_IN }}, {{ ACCESS_LABEL_ADMIN }}, and {{ ACCESS_LABEL_SELF_SERVICE }} users. Some areas are open to {{ ACCESS_LABEL_PUBLIC }} visitors without signing in. Named access is granted when your volunteer profile is configured by the organisation.</p>
       </section>
 
       <section>
@@ -72,6 +72,12 @@
 import DefaultLayout from '../layouts/DefaultLayout.vue'
 import { usePageTitle } from '../composables/usePageTitle'
 import PageHeader from '../components/PageHeader.vue'
+import {
+  ACCESS_LABEL_PUBLIC,
+  ACCESS_LABEL_SELF_SERVICE,
+  ACCESS_LABEL_CHECK_IN,
+  ACCESS_LABEL_ADMIN,
+} from '../utils/accessLabels'
 
 usePageTitle('Terms of Use')
 </script>

--- a/frontend/src/pages/sandbox/SandboxActionBars.vue
+++ b/frontend/src/pages/sandbox/SandboxActionBars.vue
@@ -8,7 +8,7 @@
       <div class="sandbox-warning">Login to view some components</div>
 
       <h2>SessionDetailActions</h2>
-      <h3>Admin / Check-In view</h3>
+      <h3>Tracker Assist / Tracker Admin</h3>
       <SessionDetailActions
         :session="mockSession"
         group-key="sheepskull"
@@ -20,7 +20,7 @@
         :is-self-service="false"
       />
 
-      <h3>Self-service view (registered)</h3>
+      <h3>My Tracker (registered)</h3>
       <SessionDetailActions
         :session="mockSessionRegistered"
         group-key="sheepskull"

--- a/frontend/src/pages/sandbox/SandboxLoginPage.vue
+++ b/frontend/src/pages/sandbox/SandboxLoginPage.vue
@@ -134,7 +134,7 @@ const cardSubtitleEmail =
   'Sign in with email to view your volunteer profile, manage your sessions, and upload photos.'
 const cardTitleMs = ACCESS_LABEL_CHECK_IN
 const cardSubtitleMs =
-  'Sign in with your Microsoft (work account) ending with @dtv.org.uk'
+  'Sign in with your Microsoft account, using an address ending @dtv.org.uk'
 
 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 

--- a/frontend/src/pages/sandbox/SandboxLoginPage.vue
+++ b/frontend/src/pages/sandbox/SandboxLoginPage.vue
@@ -7,13 +7,13 @@
       <!-- Both cards (magic + Microsoft) -->
       <h2>Cards — magic + Microsoft</h2>
       <div class="task-body">
-        <FormCard title="Volunteer Sign In" subtitle="View your volunteer profile, register for sessions, and upload photos.">
+        <FormCard :title="cardTitleEmail" :subtitle="cardSubtitleEmail">
           <FormInput v-model="email" type="email" placeholder="your@email.com" autocomplete="email" />
           <FormSubmitRow>
             <AppButton usage="task" label="Send sign-in link" :disabled="!emailValid" />
           </FormSubmitRow>
         </FormCard>
-        <FormCard title="DTV Teams Account" subtitle="For dig leads, coordinators and admins — use your @dtv.org.uk Microsoft account.">
+        <FormCard :title="cardTitleMs" :subtitle="cardSubtitleMs">
           <FormSubmitRow>
             <AppButton usage="task" variant="secondary" icon="brands/microsoft" label="Continue with Microsoft" href="/auth/login" />
           </FormSubmitRow>
@@ -23,7 +23,7 @@
       <!-- Microsoft only (magic disabled) -->
       <h2>Cards — Microsoft only</h2>
       <div class="task-body">
-        <FormCard title="DTV Teams Account" subtitle="For dig leads, coordinators and admins — use your @dtv.org.uk Microsoft account.">
+        <FormCard :title="cardTitleMs" :subtitle="cardSubtitleMs">
           <FormSubmitRow>
             <AppButton usage="task" variant="secondary" icon="brands/microsoft" label="Continue with Microsoft" href="/auth/login" />
           </FormSubmitRow>
@@ -34,13 +34,13 @@
       <h2>Reason banner — not approved</h2>
       <div class="task-body">
         <AlertBanner message="We don't have an account for jane@example.com. Contact your group organiser to get set up." />
-        <FormCard title="Volunteer Sign In" subtitle="View your volunteer profile, register for sessions, and upload photos.">
+        <FormCard :title="cardTitleEmail" :subtitle="cardSubtitleEmail">
           <FormInput v-model="emailReason" type="email" placeholder="your@email.com" autocomplete="email" />
           <FormSubmitRow>
             <AppButton usage="task" label="Send sign-in link" :disabled="!emailReasonValid" />
           </FormSubmitRow>
         </FormCard>
-        <FormCard title="DTV Teams Account" subtitle="For dig leads, coordinators and admins — use your @dtv.org.uk Microsoft account.">
+        <FormCard :title="cardTitleMs" :subtitle="cardSubtitleMs">
           <FormSubmitRow>
             <AppButton usage="task" variant="secondary" icon="brands/microsoft" label="Continue with Microsoft" href="/auth/login" />
           </FormSubmitRow>
@@ -51,13 +51,13 @@
       <h2>Reason banner — expired link</h2>
       <div class="task-body">
         <AlertBanner message="That sign-in link has expired or is invalid — enter your email below to get a new one." type="info" />
-        <FormCard title="Volunteer Sign In" subtitle="View your volunteer profile, register for sessions, and upload photos.">
+        <FormCard :title="cardTitleEmail" :subtitle="cardSubtitleEmail">
           <FormInput v-model="emailExpired" type="email" placeholder="your@email.com" autocomplete="email" />
           <FormSubmitRow>
             <AppButton usage="task" label="Send sign-in link" :disabled="!emailExpiredValid" />
           </FormSubmitRow>
         </FormCard>
-        <FormCard title="DTV Teams Account" subtitle="For dig leads, coordinators and admins — use your @dtv.org.uk Microsoft account.">
+        <FormCard :title="cardTitleMs" :subtitle="cardSubtitleMs">
           <FormSubmitRow>
             <AppButton usage="task" variant="secondary" icon="brands/microsoft" label="Continue with Microsoft" href="/auth/login" />
           </FormSubmitRow>
@@ -67,13 +67,13 @@
       <!-- Sending -->
       <h2>Sending…</h2>
       <div class="task-body">
-        <FormCard title="Volunteer Sign In" subtitle="View your volunteer profile, register for sessions, and upload photos.">
+        <FormCard :title="cardTitleEmail" :subtitle="cardSubtitleEmail">
           <FormInput :model-value="'jane@example.com'" type="email" placeholder="your@email.com" :disabled="true" />
           <FormSubmitRow>
             <AppButton usage="task" label="Sending…" :working="true" />
           </FormSubmitRow>
         </FormCard>
-        <FormCard title="DTV Teams Account" subtitle="For dig leads, coordinators and admins — use your @dtv.org.uk Microsoft account.">
+        <FormCard :title="cardTitleMs" :subtitle="cardSubtitleMs">
           <FormSubmitRow>
             <AppButton usage="task" variant="secondary" icon="brands/microsoft" label="Continue with Microsoft" href="/auth/login" />
           </FormSubmitRow>
@@ -83,14 +83,14 @@
       <!-- Send error -->
       <h2>Send error</h2>
       <div class="task-body">
-        <FormCard title="Volunteer Sign In" subtitle="View your volunteer profile, register for sessions, and upload photos.">
+        <FormCard :title="cardTitleEmail" :subtitle="cardSubtitleEmail">
           <FormInput v-model="emailError" type="email" placeholder="your@email.com" autocomplete="email" />
           <FormSubmitRow>
             <AppButton usage="task" label="Send sign-in link" :disabled="!emailErrorValid" />
             <p class="form-error">Something went wrong. Please try again.</p>
           </FormSubmitRow>
         </FormCard>
-        <FormCard title="DTV Teams Account" subtitle="For dig leads, coordinators and admins — use your @dtv.org.uk Microsoft account.">
+        <FormCard :title="cardTitleMs" :subtitle="cardSubtitleMs">
           <FormSubmitRow>
             <AppButton usage="task" variant="secondary" icon="brands/microsoft" label="Continue with Microsoft" href="/auth/login" />
           </FormSubmitRow>
@@ -125,8 +125,16 @@ import FormInput from '../../components/forms/FormInput.vue'
 import FormSubmitRow from '../../components/forms/FormSubmitRow.vue'
 import AppButton from '../../components/AppButton.vue'
 import AlertBanner from '../../components/forms/AlertBanner.vue'
+import { ACCESS_LABEL_CHECK_IN, ACCESS_LABEL_SELF_SERVICE } from '../../utils/accessLabels'
 
 usePageTitle('Sandbox — LoginPage')
+
+const cardTitleEmail = ACCESS_LABEL_SELF_SERVICE
+const cardSubtitleEmail =
+  'Sign in with email to view your volunteer profile, manage your sessions, and upload photos.'
+const cardTitleMs = ACCESS_LABEL_CHECK_IN
+const cardSubtitleMs =
+  'Sign in with your Microsoft (work account) ending with @dtv.org.uk'
 
 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 

--- a/frontend/src/pages/sandbox/SandboxPersonalPrompt.vue
+++ b/frontend/src/pages/sandbox/SandboxPersonalPrompt.vue
@@ -3,89 +3,57 @@
     <div class="sandbox">
       <SandboxBackLink />
       <h1>PersonalPrompt</h1>
-      <p>Presentational banner rendered by PersonalContainer. All variants shown with static props.</p>
+      <p>Banner: welcome line + single “Your Next Session” button (session URL or sessions list).</p>
 
-      <h2>Role messages</h2>
+      <h2>PersonalPrompt — welcome + next session</h2>
       <div class="pp-stack">
         <div class="pp-item">
-          <p class="pp-label">isAdmin / isReadOnly</p>
-          <PersonalPrompt
-            message="You're a DTV Tracker admin"
-            :next-session="nextSession"
-            :previous-session="previousSession"
-          />
+          <p class="pp-label">Welcome to My Tracker</p>
+          <PersonalPrompt :welcome="welcomeMy" :next-session="nextSession" />
         </div>
         <div class="pp-item">
-          <p class="pp-label">isCheckIn</p>
-          <PersonalPrompt
-            message="Ready to manage your sessions and volunteers"
-            :next-session="nextSession"
-            :previous-session="previousSession"
-          />
+          <p class="pp-label">Welcome to Tracker Assist</p>
+          <PersonalPrompt :welcome="welcomeAssist" :next-session="nextSession" />
+        </div>
+        <div class="pp-item">
+          <p class="pp-label">Welcome to Tracker Admin</p>
+          <PersonalPrompt :welcome="welcomeAdmin" :next-session="nextSession" />
+        </div>
+        <div class="pp-item">
+          <p class="pp-label">No upcoming session (button → /sessions)</p>
+          <PersonalPrompt :welcome="welcomeMy" :next-session="null" />
         </div>
       </div>
 
-      <h2>Self-service volunteer messages</h2>
+      <h2>PersonalContainer (role → welcome)</h2>
       <div class="pp-stack">
         <div class="pp-item">
-          <p class="pp-label">isNew + hasBooking</p>
-          <PersonalPrompt
-            message="Your first Wednesday Dig is booked, read all about it"
+          <p class="pp-label">Admin</p>
+          <PersonalContainer
+            :is-admin="true"
+            :is-check-in="false"
+            :is-self-service="false"
             :next-session="nextSession"
-            :previous-session="null"
           />
         </div>
         <div class="pp-item">
-          <p class="pp-label">isRepeat + hasBooking</p>
-          <PersonalPrompt
-            message="Your next Wednesday Dig is booked, check the details"
+          <p class="pp-label">Tracker Assist only</p>
+          <PersonalContainer
+            :is-admin="false"
+            :is-check-in="true"
+            :is-self-service="false"
             :next-session="nextSession"
-            :previous-session="previousSession"
           />
         </div>
         <div class="pp-item">
-          <p class="pp-label">isNew + !hasBooking + hasAttended</p>
-          <PersonalPrompt
-            message="You completed your first Wednesday Dig, see photos and get booked on the next"
+          <p class="pp-label">My Tracker, no next session</p>
+          <PersonalContainer
+            :is-admin="false"
+            :is-check-in="false"
+            :is-self-service="true"
             :next-session="null"
-            :previous-session="previousSession"
           />
         </div>
-        <div class="pp-item">
-          <p class="pp-label">isRegular + hasBooking</p>
-          <PersonalPrompt
-            message="You're booked onto Wednesday Dig, check the latest details"
-            :next-session="nextSession"
-            :previous-session="previousSession"
-          />
-        </div>
-        <div class="pp-item">
-          <p class="pp-label">isRegular + !hasBooking</p>
-          <PersonalPrompt
-            message="Catch up on Wednesday Dig and check what's coming up next"
-            :next-session="null"
-            :previous-session="previousSession"
-          />
-        </div>
-      </div>
-
-      <h2>No message (null) — nothing should render</h2>
-      <div class="pp-item">
-        <p class="pp-label">PersonalContainer with no matching condition</p>
-        <PersonalContainer
-          :is-admin="false"
-          :is-check-in="false"
-          :is-read-only="false"
-          :is-self-service="false"
-          :is-new="false"
-          :is-repeat="false"
-          :is-regular="false"
-          :has-booking="false"
-          :has-attended="false"
-          :next-session="null"
-          :previous-session="null"
-        />
-        <p class="pp-empty-note">↑ nothing visible above this line = correct</p>
       </div>
     </div>
   </DefaultLayout>
@@ -98,16 +66,23 @@ import DefaultLayout from '../../layouts/DefaultLayout.vue'
 import SandboxBackLink from './SandboxBackLink.vue'
 import PersonalPrompt from '../../components/PersonalPrompt.vue'
 import PersonalContainer from '../../components/PersonalContainer.vue'
+import {
+  ACCESS_LABEL_ADMIN,
+  ACCESS_LABEL_CHECK_IN,
+  ACCESS_LABEL_SELF_SERVICE,
+} from '../../utils/accessLabels'
 
 usePageTitle('Sandbox')
 
-const nextSession     = { groupKey: 'wednesday-dig', groupName: 'Wednesday Dig', date: '2026-04-20' }
-const previousSession = { groupKey: 'wednesday-dig', groupName: 'Wednesday Dig', date: '2026-03-16' }
+const nextSession = { groupKey: 'wednesday-dig', groupName: 'Wednesday Dig', date: '2026-04-20' }
+
+const welcomeMy = `Welcome to ${ACCESS_LABEL_SELF_SERVICE}`
+const welcomeAssist = `Welcome to ${ACCESS_LABEL_CHECK_IN}`
+const welcomeAdmin = `Welcome to ${ACCESS_LABEL_ADMIN}`
 </script>
 
 <style scoped>
 .pp-stack { display: flex; flex-direction: column; gap: 1.5rem; margin-bottom: 2rem; }
 .pp-item  { display: flex; flex-direction: column; gap: 0.25rem; }
 .pp-label { font-size: 0.8rem; font-family: monospace; opacity: 0.6; margin: 0; }
-.pp-empty-note { font-size: 0.8rem; font-style: italic; opacity: 0.5; margin: 0.25rem 0 0; }
 </style>

--- a/frontend/src/pages/sandbox/SandboxProfileListItem.vue
+++ b/frontend/src/pages/sandbox/SandboxProfileListItem.vue
@@ -45,6 +45,16 @@
         <ProfileListItem :profile="noEmail" :display-hours="8.5" :display-sessions="3" />
       </div>
 
+      <h2>Tracker Assist badge (Profile `User` set)</h2>
+      <div class="demo">
+        <ProfileListItem :profile="trackerCheckin" :display-hours="12" :display-sessions="5" />
+      </div>
+
+      <h2>Tracker Admin badge</h2>
+      <div class="demo">
+        <ProfileListItem :profile="trackerAdmin" :display-hours="20" :display-sessions="8" />
+      </div>
+
       <h2>FY: All — shows hoursAll</h2>
       <div class="demo">
         <ProfileListItem :profile="standard" :display-hours="97.5" :display-sessions="42" />
@@ -176,6 +186,28 @@ const noEmail: ProfileResponse = {
   email: undefined,
   hoursThisFY: 8.5,
   sessionsThisFY: 3,
+}
+
+const trackerCheckin: ProfileResponse = {
+  ...base,
+  id: 10,
+  slug: 'ian-diglead-10',
+  name: 'Ian Diglead',
+  user: 'ian@dtv.org.uk',
+  trackerAccess: 'checkin',
+  hoursThisFY: 12,
+  sessionsThisFY: 5,
+}
+
+const trackerAdmin: ProfileResponse = {
+  ...base,
+  id: 11,
+  slug: 'jane-admin-11',
+  name: 'Jane Admin',
+  user: 'jane@dtv.org.uk',
+  trackerAccess: 'admin',
+  hoursThisFY: 20,
+  sessionsThisFY: 8,
 }
 
 const mockProfiles: ProfileResponse[] = [standard, group, member, cardAccepted, cardInvited]

--- a/frontend/src/pages/sandbox/SandboxSessionCard.vue
+++ b/frontend/src/pages/sandbox/SandboxSessionCard.vue
@@ -19,7 +19,7 @@
         </template>
       </LayoutColumns>
 
-      <h2>Admin / Check-In</h2>
+      <h2>Tracker Assist / Tracker Admin</h2>
 
       <LayoutColumns ratio="1-1-1">
         <template #left>
@@ -44,9 +44,9 @@ import type { RoleContext } from '../../composables/useViewer'
 usePageTitle('Sandbox')
 
 const adminProfile: RoleContext = {
-  isAdmin: true, isCheckIn: false, isReadOnly: false,
+  isAdmin: true, isCheckIn: false,
   isSelfService: false, isTrusted: true, isAuthenticated: true,
-  isPublic: false, isOperational: true,
+  isPublic: false, hasCheckInAccess: true,
 }
 
 const base: Session = {

--- a/frontend/src/router/index.test.ts
+++ b/frontend/src/router/index.test.ts
@@ -38,18 +38,8 @@ describe('authGuard — protected routes', () => {
     expect(await authGuard(to('/profiles', { requiresTrusted: true }))).toBeUndefined()
   })
 
-  it('readonly to requiresTrusted route → allowed', async () => {
-    mockUser.value = { role: 'readonly' }
-    expect(await authGuard(to('/profiles', { requiresTrusted: true }))).toBeUndefined()
-  })
-
   it('non-admin (checkin) to requiresAdmin route → /forbidden', async () => {
     mockUser.value = { role: 'checkin' }
-    expect(await authGuard(to('/entries', { requiresAdmin: true }))).toBe('/forbidden')
-  })
-
-  it('non-admin (readonly) to requiresAdmin route → /forbidden', async () => {
-    mockUser.value = { role: 'readonly' }
     expect(await authGuard(to('/entries', { requiresAdmin: true }))).toBe('/forbidden')
   })
 
@@ -79,8 +69,8 @@ describe('authGuard — sandbox gating', () => {
     expect(await authGuard(to('/sandbox/icons'))).toBe('/')
   })
 
-  it('non-admin in prod to /sandbox → /', async () => {
-    mockUser.value = { role: 'readonly' }
+  it('non-admin (check-in) in prod to /sandbox → /', async () => {
+    mockUser.value = { role: 'checkin' }
     expect(await authGuard(to('/sandbox/icons'))).toBe('/')
   })
 

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -3,7 +3,7 @@ import { ensureAuth, user } from '../composables/useAuth'
 
 declare module 'vue-router' {
   interface RouteMeta {
-    requiresTrusted?: boolean  // Admin / Check In / Read Only only
+    requiresTrusted?: boolean  // Microsoft trusted: Admin or Check-In
     requiresAdmin?: boolean    // Admin only
     requiresAuth?: boolean     // Any authenticated user (self-service included)
   }

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -32,7 +32,7 @@ export const profilePath = (slug: string) => `/profiles/${slug}`
 export const addEntryPath = (groupKey: string, date: string) => `/sessions/${groupKey}/${date}/add-entry`
 export const entryPath = (id: number) => `/entries/${id}`
 export const entriesPath = () => '/entries'
-export const adminPath = () => '/admin'
+export const toolsPath = () => '/tools'
 export const consentPath = (slug: string) => `/profiles/${slug}/consent`
 export const uploadPath  = (entryId: number) => `/upload?entryId=${entryId}`
 
@@ -49,7 +49,8 @@ export const router = createRouter({
     { path: '/terms', component: TermsPage },
     { path: '/login', component: LoginPage },
     { path: '/entries', component: EntriesPage, meta: { requiresAdmin: true } },
-    { path: '/admin', component: AdminPage },
+    { path: '/admin', redirect: '/tools' },
+    { path: '/tools', component: AdminPage },
     { path: '/not-found', component: () => import('../pages/NotFoundPage.vue') },
     { path: '/forbidden', component: () => import('../pages/ForbiddenPage.vue') },
     { path: '/profiles', component: ProfileListPage, meta: { requiresTrusted: true } },

--- a/frontend/src/types/entry.ts
+++ b/frontend/src/types/entry.ts
@@ -18,6 +18,7 @@ export interface EntrySessionSummary {
 export interface EntryItem {
   id: number
   profileId?: number
+  trackerAccess?: 'none' | 'checkin' | 'admin'
   checkedIn: boolean
   hours: number
   count: number

--- a/frontend/src/utils/accessLabels.ts
+++ b/frontend/src/utils/accessLabels.ts
@@ -4,3 +4,6 @@ export const ACCESS_LABEL_PUBLIC = 'Public'
 export const ACCESS_LABEL_SELF_SERVICE = 'My Tracker'
 export const ACCESS_LABEL_CHECK_IN = 'Tracker Assist'
 export const ACCESS_LABEL_ADMIN = 'Tracker Admin'
+
+/** Burger menu + `/tools` page heading only (utilities). Badges, welcome, and legal copy use {@link ACCESS_LABEL_ADMIN}. */
+export const ACCESS_LABEL_ADMIN_TOOLS_PAGE = 'Tools'

--- a/frontend/src/utils/accessLabels.ts
+++ b/frontend/src/utils/accessLabels.ts
@@ -7,3 +7,22 @@ export const ACCESS_LABEL_ADMIN = 'Tracker Admin'
 
 /** Burger menu + `/tools` page heading only (utilities). Badges, welcome, and legal copy use {@link ACCESS_LABEL_ADMIN}. */
 export const ACCESS_LABEL_ADMIN_TOOLS_PAGE = 'Tools'
+
+/** Snapshot for the About modal “Logged in” row — same flags as `useViewer().context`. */
+export interface LoginTierSnapshot {
+  ready: boolean
+  isAdmin: boolean
+  isCheckIn: boolean
+  isSelfService: boolean
+  isPublic: boolean
+}
+
+/** User-facing tier: Public, My Tracker, Tracker Assist, or Tracker Admin. */
+export function loginTierLabel(s: LoginTierSnapshot): string {
+  if (!s.ready) return 'Loading…'
+  if (s.isPublic) return ACCESS_LABEL_PUBLIC
+  if (s.isAdmin) return ACCESS_LABEL_ADMIN
+  if (s.isCheckIn) return ACCESS_LABEL_CHECK_IN
+  if (s.isSelfService) return ACCESS_LABEL_SELF_SERVICE
+  return ACCESS_LABEL_PUBLIC
+}

--- a/frontend/src/utils/accessLabels.ts
+++ b/frontend/src/utils/accessLabels.ts
@@ -1,0 +1,6 @@
+/** User-facing names for access tiers (UI copy only). */
+
+export const ACCESS_LABEL_PUBLIC = 'Public'
+export const ACCESS_LABEL_SELF_SERVICE = 'My Tracker'
+export const ACCESS_LABEL_CHECK_IN = 'Tracker Assist'
+export const ACCESS_LABEL_ADMIN = 'Tracker Admin'

--- a/frontend/src/utils/labelIcons.test.ts
+++ b/frontend/src/utils/labelIcons.test.ts
@@ -1,5 +1,24 @@
 import { describe, it, expect } from 'vitest'
 import { iconsForEntry } from './labelIcons'
+import { ACCESS_LABEL_ADMIN, ACCESS_LABEL_CHECK_IN } from './accessLabels'
+
+describe('iconsForEntry — tracker access badges', () => {
+  it('shows Tracker Admin badge alt when trackerAccess is admin', () => {
+    const icons = iconsForEntry({ trackerAccess: 'admin' })
+    expect(icons.some(i => i.alt === ACCESS_LABEL_ADMIN)).toBe(true)
+  })
+
+  it('shows Tracker Assist badge alt when trackerAccess is checkin', () => {
+    const icons = iconsForEntry({ trackerAccess: 'checkin' })
+    expect(icons.some(i => i.alt === ACCESS_LABEL_CHECK_IN)).toBe(true)
+  })
+
+  it('omits tracker badges when trackerAccess omitted', () => {
+    const icons = iconsForEntry({})
+    expect(icons.some(i => i.alt === ACCESS_LABEL_ADMIN)).toBe(false)
+    expect(icons.some(i => i.alt === ACCESS_LABEL_CHECK_IN)).toBe(false)
+  })
+})
 
 describe('iconsForEntry — isChild', () => {
   it('shows child icon when isChild is true', () => {

--- a/frontend/src/utils/labelIcons.ts
+++ b/frontend/src/utils/labelIcons.ts
@@ -1,3 +1,5 @@
+import { ACCESS_LABEL_ADMIN, ACCESS_LABEL_CHECK_IN } from './accessLabels'
+
 export interface LabelIcon {
   icon: string
   alt: string
@@ -32,6 +34,8 @@ export const LABEL_ICONS: LabelIcon[] = [
 export const EDITABLE_LABEL_ICONS = LABEL_ICONS.filter(t => t.labelKey !== undefined)
 
 interface EntryIconSource {
+  /** Trusted session/entries API only — Microsoft Tracker tier for this volunteer */
+  trackerAccess?: 'none' | 'checkin' | 'admin'
   isMember?: boolean
   isGroup?: boolean
   cardStatus?: string
@@ -48,6 +52,20 @@ interface EntryIconSource {
 export function iconsForEntry(e: EntryIconSource): LabelIcon[] {
   const icons: LabelIcon[] = []
   const labels = e.labels ?? []
+
+  if (e.trackerAccess === 'admin') {
+    icons.push({
+      icon: 'badges/tracker-admin.svg',
+      alt: ACCESS_LABEL_ADMIN,
+      type: 'badge',
+    })
+  } else if (e.trackerAccess === 'checkin') {
+    icons.push({
+      icon: 'badges/tracker-checkin.svg',
+      alt: ACCESS_LABEL_CHECK_IN,
+      type: 'badge',
+    })
+  }
 
   // Profile-level badges (always from profile fields)
   if (e.isMember) icons.push({ icon: 'badges/member.svg', alt: 'Charity Member', type: 'badge' })

--- a/public/icons/badges/tracker-admin.svg
+++ b/public/icons/badges/tracker-admin.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+  <path d="M8 1.5 10.2 5.8 15 6.5 11.5 9.7 12.4 14.5 8 12.1 3.6 14.5 4.5 9.7 1 6.5 5.8 5.8 8 1.5Z" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round"/>
+</svg>

--- a/public/icons/badges/tracker-checkin.svg
+++ b/public/icons/badges/tracker-checkin.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+  <circle cx="8" cy="8" r="7" stroke="currentColor" stroke-width="1.5"/>
+  <path d="M4.5 8.2 6.8 10.5 11.5 5.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/types/api-responses.ts
+++ b/types/api-responses.ts
@@ -58,12 +58,17 @@ export interface SessionResponse {
   metadata?: Array<{ label: string; termGuid: string }>;
 }
 
+/** Microsoft Tracker role implied by Profile User + ADMIN_USERS — only on trusted responses. */
+export type TrackerAccess = 'none' | 'checkin' | 'admin';
+
 export interface ProfileResponse {
   id: number;
   slug: string;
   name?: string;
   email?: string;
   user?: string;
+  /** Present for admin/check-in callers only — who has Microsoft Tracker access for this volunteer. */
+  trackerAccess?: TrackerAccess;
   isGroup: boolean;
   isMember: boolean;
   cardStatus?: string;
@@ -121,6 +126,8 @@ export interface ProfileDetailResponse {
   emails: string[];
   matchName?: string;
   user?: string;
+  /** Trusted Microsoft callers only. */
+  trackerAccess?: TrackerAccess;
   isGroup: boolean;
   isMember?: boolean;
   cardStatus?: string;
@@ -169,7 +176,9 @@ export interface EntryResponse {
   notes?: string;
   accompanyingAdultId?: number;
   cancelled?: string;          // ISO datetime if booking was cancelled
-  email?: string;              // only present for operational users (admin/check-in)
+  email?: string;              // only present for check-in tier users (admin/check-in)
+  /** Trusted Microsoft callers only. */
+  trackerAccess?: TrackerAccess;
   labels?: string[];
   isNew?: boolean;             // profile.stats.sessionIds[0] === this session
   noPhoto?: boolean;           // profile.stats.noPhoto (current)
@@ -297,6 +306,8 @@ export interface EntryListItemResponse {
   cancelled?: string;
   labels?: string[];
   eventbriteAttendeeId?: string;
+  /** Trusted Microsoft callers only (entries list admin page). */
+  trackerAccess?: TrackerAccess;
 }
 
 export interface TagHoursItem {

--- a/types/express-session.d.ts
+++ b/types/express-session.d.ts
@@ -6,7 +6,7 @@ declare module 'express-session' {
       id: string;
       displayName: string;
       email: string;
-      role: 'admin' | 'checkin' | 'readonly' | 'selfservice';
+      role: 'admin' | 'checkin' | 'selfservice';
       profileSlug?: string;
       profileId?: number;       // set for checkin and selfservice; used for ownership enforcement
       profileIds?: number[];    // all profiles for this email (selfservice with multiple linked profiles)


### PR DESCRIPTION
## Summary
- require Profile `User` linkage for Microsoft sign-in, remove read-only fallback, and keep admin/check-in as trusted additive tiers
- add `trackerAccess` enrichment for trusted profile/entry responses and show Tracker Assist/Admin badges in relevant UI surfaces
- align frontend copy/components/docs around clean role labels (`Public`, `My Tracker`, `Tracker Assist`, `Tracker Admin`) and simplify personal welcome banner/actions

## Test plan
- [x] `npm run build`
- [ ] `cd frontend && npm test --run`
- [ ] Manual auth flow check: Microsoft without Profile `User` redirects to `/login?reason=dtv-not-authorised`
- [ ] Manual UI check: role labels and personal welcome/next-session button render correctly for self-service, check-in, and admin