### PR TITLE
Refresh auth before session edit modal

### DIFF
--- a/frontend/src/components/sessions/SessionDetailActions.vue
+++ b/frontend/src/components/sessions/SessionDetailActions.vue
@@ -4,7 +4,14 @@
     <AppButton icon="group" label="Group" mode="icon-only" @click="router.push(groupPath(groupKey))" />
     <AppButton v-if="canUpload" icon="uploadphoto" label="Upload" mode="icon-only" @click="onUpload" />
     <AppButton v-if="allowEmail" icon="email" label="Email" mode="icon-only" @click="showEmail = true" />
-    <AppButton v-if="allowEdit" icon="edit" label="Edit" mode="icon-only" @click="showEdit = true" />
+    <AppButton
+      v-if="allowEdit"
+      icon="edit"
+      label="Edit"
+      mode="icon-only"
+      :working="sessionEditAuthChecking"
+      @click="onSessionEditClick"
+    />
 
     <EntryUploadPickerModal
       v-if="showPicker"
@@ -58,6 +65,8 @@ const props = defineProps<{
   allowEdit: boolean
   allowEmail: boolean
   isSelfService: boolean
+  /** When set, awaited before opening session edit; return false to keep the modal closed. */
+  beforeSessionEdit?: () => Promise<boolean>
 }>()
 
 const emit = defineEmits<{
@@ -68,6 +77,7 @@ const emit = defineEmits<{
 const router = useRouter()
 const showPicker = ref(false)
 const showEdit = ref(false)
+const sessionEditAuthChecking = ref(false)
 const showEmail = ref(false)
 const emailWorking = ref(false)
 const emailError = ref<string | undefined>()
@@ -137,6 +147,19 @@ async function onEmailSend({ recipient, preview, template }: { recipient: number
   } finally {
     emailWorking.value = false
   }
+}
+
+async function onSessionEditClick() {
+  if (props.beforeSessionEdit) {
+    sessionEditAuthChecking.value = true
+    try {
+      const ok = await props.beforeSessionEdit()
+      if (!ok) return
+    } finally {
+      sessionEditAuthChecking.value = false
+    }
+  }
+  showEdit.value = true
 }
 
 function closeEdit() {

--- a/frontend/src/composables/useAuth.ts
+++ b/frontend/src/composables/useAuth.ts
@@ -21,10 +21,13 @@ export const user = ref<AuthUser | null>(null)
 const ready = ref(false)
 let fetchPromise: Promise<void> | null = null
 
-async function fetchMe() {
+async function loadMe(): Promise<void> {
   try {
     const res = await fetch('/auth/me')
-    if (!res.ok) return
+    if (!res.ok) {
+      user.value = null
+      return
+    }
     const data = await res.json()
     user.value = data.authenticated ? data.user : null
   } catch {
@@ -32,6 +35,17 @@ async function fetchMe() {
   } finally {
     ready.value = true
   }
+}
+
+async function fetchMe() {
+  await loadMe()
+}
+
+/** Re-fetches `/auth/me` and updates `user`. Returns true if admin or check-in session is still active. */
+export async function refreshAuth(): Promise<boolean> {
+  await loadMe()
+  const u = user.value
+  return u !== null && (u.role === 'admin' || u.role === 'checkin')
 }
 
 // Ensures auth is resolved — safe to call from router guards (outside components)

--- a/frontend/src/composables/useViewer.test.ts
+++ b/frontend/src/composables/useViewer.test.ts
@@ -6,6 +6,7 @@ const mockAuth = vi.hoisted(() => ({
 }))
 vi.mock('./useAuth', () => ({
   useAuth: () => ({ user: mockAuth.user, ready: mockAuth.ready }),
+  refreshAuth: vi.fn(async () => true),
 }))
 
 import { useViewer } from './useViewer'

--- a/frontend/src/composables/useViewer.ts
+++ b/frontend/src/composables/useViewer.ts
@@ -1,7 +1,7 @@
 // Single UI composable for auth/role context of the logged-in viewer.
 // Pages and components import from here only — never from useAuth or useRole directly.
 import { computed, reactive } from 'vue'
-import { useAuth } from './useAuth'
+import { useAuth, refreshAuth } from './useAuth'
 
 export interface RoleContext {
   isAdmin: boolean
@@ -38,5 +38,18 @@ export function useViewer() {
     hasCheckInAccess: hasCheckInAccess.value,
   }))
 
-  return reactive({ user, ready, role, isAdmin, isCheckIn, isSelfService, isTrusted, isAuthenticated, isPublic, hasCheckInAccess, context })
+  return reactive({
+    user,
+    ready,
+    role,
+    isAdmin,
+    isCheckIn,
+    isSelfService,
+    isTrusted,
+    isAuthenticated,
+    isPublic,
+    hasCheckInAccess,
+    context,
+    refreshAuth,
+  })
 }

--- a/frontend/src/pages/LoginPage.vue
+++ b/frontend/src/pages/LoginPage.vue
@@ -170,6 +170,8 @@ const reasons: Record<string, (email?: string) => string> = {
   'invalid-state': () => 'That sign-in link has expired or is invalid — enter your email below to get a new one.',
   'dtv-not-authorised': () =>
     `Access denied. Your Microsoft account is not set up for ${ACCESS_LABEL_CHECK_IN}. Please contact your admin.`,
+  'session-expired': () =>
+    'Your sign-in has expired. Sign in again to continue — you will return to this page afterwards.',
 }
 
 async function sendLoginEmail() {

--- a/frontend/src/pages/SessionDetailPage.vue
+++ b/frontend/src/pages/SessionDetailPage.vue
@@ -120,6 +120,7 @@
             :allow-edit="profile.isCheckIn || profile.isAdmin"
             :allow-email="profile.hasCheckInAccess"
             :is-self-service="profile.isSelfService"
+            :before-session-edit="beforeSessionEdit"
             @session-save="onSessionSave"
             @session-delete="onSessionDelete"
           />
@@ -415,6 +416,14 @@ const titleText = computed(() => {
   return `${formatDate(store.session.date)} | ${store.session.groupName}`
 })
 usePageTitle(titleText)
+
+/** Re-check express session before session edit — public session GET can outlive login. */
+async function beforeSessionEdit(): Promise<boolean> {
+  const ok = await profile.refreshAuth()
+  if (ok) return true
+  await router.push({ path: '/login', query: { returnTo: route.fullPath, reason: 'session-expired' } })
+  return false
+}
 
 async function onSaveTags(tags: Array<{ label: string; termGuid: string }>) {
   const groupKey = route.params.groupKey as string


### PR DESCRIPTION
Session detail pages can still load via public GET while the Express session has expired, which led to a 401 on save.

- Add \efreshAuth()\ in \useAuth\ (re-fetches \/auth/me\) and expose it from \useViewer\.
- Session edit waits for a fresh trusted session before opening the modal; shows a spinner on the edit button while checking.
- If the session is gone, redirect to \/login\ with \eturnTo\ and a \session-expired\ banner message.

Made with [Cursor](https://cursor.com)