### PR TITLE
Group sessions: entries, stats, hours, regulars

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,6 +190,8 @@ This codebase is maintained by a small team (often volunteers). **Prefer linear,
 - **Same behaviour for every login** where possible: API consumers should see the same rules; differences should be driven by **data the caller is allowed to see** (e.g. no entry list for public), not by a second formula.
 - **Tests follow the pipeline**: Favour unit tests on shared functions (e.g. `data-layer.ts`) over branching integration tests per route.
 
+For a concise, language-agnostic checklist (naming, SRP, DRY, KISS, comments, YAGNI, etc.), see [Clean code cheat sheet](https://gist.github.com/wojteklu/73c6914cc446146b8b533c0988cf8d29) — general reference only; **project-specific rules in this file take precedence** when they differ.
+
 ### Caching Architecture
 
 Four independent caches:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,6 +182,14 @@ All data computation is server-side in the stats pipeline (ProfileStats → Sess
 - Lowercase-hyphen naming for files (e.g. `data-layer.ts`, `test-auth.js`)
 - Keep code simple and maintainable; follow existing patterns
 
+### Clean code and maintainability
+
+This codebase is maintained by a small team (often volunteers). **Prefer linear, single paths** over “clever” optimisations that duplicate logic.
+
+- **One source of truth**: If aggregates are stored (e.g. session `Stats` JSON), compute them in the existing stats pipeline (`calculateSessionStats` → `computeAndSaveSessionStats` / bulk refresh). **Do not** recompute the same numbers again in a route handler for some roles only — that doubles behaviour to test and risks drift between public and trusted views.
+- **Same behaviour for every login** where possible: API consumers should see the same rules; differences should be driven by **data the caller is allowed to see** (e.g. no entry list for public), not by a second formula.
+- **Tests follow the pipeline**: Favour unit tests on shared functions (e.g. `data-layer.ts`) over branching integration tests per route.
+
 ### Caching Architecture
 
 Four independent caches:
@@ -207,7 +215,7 @@ Targeted invalidation: each repository write evicts only its own key(s). Entry w
 
 Always calculate derived values (hours totals, counts) from source entries at query time. The app is the source of truth — no Power Automate flows update fields. NodeCache keeps this performant.
 
-**Exception — Pre-computed Stats fields**: The Sessions list has a `Stats` JSON field for performance (avoids fetching ~5,000 entries on listing page load). Kept fresh by `computeAndSaveSessionStats()` after every entry/record/media write and a nightly bulk refresh. Only computed aggregates belong in Stats — editable config fields (e.g. `Limits`) must never be stored there.
+**Exception — Pre-computed Stats fields**: The Sessions list has a `Stats` JSON field for performance (avoids fetching ~5,000 entries on listing page load). Kept fresh by `computeAndSaveSessionStats()` after every entry/record/media write and a nightly bulk refresh. Only computed aggregates belong in Stats — editable config fields (e.g. `Limits`) must never be stored there. Session detail responses use this persisted `Stats` for the `stats` payload for **all** roles (public and authenticated); do not overlay alternate totals in `routes/sessions.ts` — fix drift by refreshing stored stats instead.
 
 The Profiles list also has a `Stats` JSON field storing `hoursByFY`, `sessionsByFY`, `isMember`, `cardStatus`, `regularGroupIds`, `repeatGroupIds`, `sessionIds`, `linkedProfileIds`, `isFirstAider`, and `warnings`. The `warnings` array holds human-readable flag strings (e.g. `"Possible Duplicate"`, `"Child No Adult"`) computed during stats refresh. The warnings filter on the volunteers listing reads from this stored value. Adding a new warning type means adding a detection pass in `runProfileStatsRefresh()` and `computeAndSaveProfileStats()` in `backend/services/profile-stats.ts`; removing one requires only deleting the detection — it disappears from all profiles on the next refresh.
 

--- a/backend/routes/groups.ts
+++ b/backend/routes/groups.ts
@@ -260,9 +260,12 @@ router.get('/groups/:key', async (req: Request, res: Response) => {
       }
     }
 
-    // Filter to ≥6h, attach name/slug/isRegular/regularId/accompanyingAdultId
+    // Repeats: ≥6h in rolling year for this group. Formal regulars below that threshold are appended
+    // so check-in can still view/edit the Regulars list relationship.
     const MIN_REGULAR_HOURS = 6;
     const rollingRegulars: import('../../types/api-responses').GroupRegularResponse[] = [];
+    const includedProfileIds = new Set<number>();
+
     for (const [profileId, hours] of profileHoursMap) {
       if (hours < MIN_REGULAR_HOURS) continue;
       const spProfile = profileMap.get(profileId);
@@ -278,7 +281,26 @@ router.get('/groups/:key', async (req: Request, res: Response) => {
         ...(regularInfo !== undefined && { regularId: regularInfo.regularId }),
         ...(regularInfo?.accompanyingAdultId !== undefined && { accompanyingAdultId: regularInfo.accompanyingAdultId }),
       });
+      includedProfileIds.add(profileId);
     }
+
+    for (const [profileId, regularInfo] of regularsForGroupMap) {
+      if (includedProfileIds.has(profileId)) continue;
+      const spProfile = profileMap.get(profileId);
+      if (!spProfile) continue;
+      const p = convertProfile(spProfile);
+      const hours = profileHoursMap.get(profileId) ?? 0;
+      rollingRegulars.push({
+        profileId: p.id,
+        name: p.name || spProfile.Title || '',
+        slug: profileSlug(p.name, p.id),
+        hours: Math.round(hours * 10) / 10,
+        isRegular: true,
+        regularId: regularInfo.regularId,
+        ...(regularInfo.accompanyingAdultId !== undefined && { accompanyingAdultId: regularInfo.accompanyingAdultId }),
+      });
+    }
+
     rollingRegulars.sort((a, b) => b.hours - a.hours || a.name.localeCompare(b.name));
 
     const selfServiceProfileIds = role === 'selfservice'

--- a/backend/routes/sessions.ts
+++ b/backend/routes/sessions.ts
@@ -463,6 +463,34 @@ router.get('/sessions/:group/:date', async (req: Request, res: Response) => {
     const profiles = validateArray(rawProfiles, validateProfile, 'Profile');
     const profileMap = new Map(profiles.map(p => [p.ID, p]));
 
+    // Check-in tier: recompute aggregate counts from live entries (weights SharePoint Count / headcount).
+    // Stored session Stats can lag until the next write or bulk refresh.
+    let statsForResponse = storedStats;
+    if (hasCheckInTier && sessionEntries.length > 0) {
+      const profileFirstSessionMap = new Map<number, number>();
+      for (const p of profiles) {
+        try {
+          const ps = JSON.parse(p[PROFILE_STATS] || '{}');
+          if (Array.isArray(ps.sessionIds) && ps.sessionIds.length > 0) {
+            profileFirstSessionMap.set(p.ID, ps.sessionIds[0]);
+          }
+        } catch { /* ignore */ }
+      }
+      const liveMap = calculateSessionStats(sessionEntries, profileFirstSessionMap);
+      const live = liveMap.get(String(spSession.ID));
+      if (live) {
+        statsForResponse = {
+          ...storedStats,
+          count: live.registrations,
+          hours: Math.round(live.hours * 10) / 10,
+          new: live.newCount || undefined,
+          child: live.childCount || undefined,
+          regular: live.regularCount || undefined,
+          eventbrite: live.eventbriteCount || undefined,
+        };
+      }
+    }
+
     // All session entries returned to check-in tier users (with cancelled flag).
     const entryResponses: EntryResponse[] = sessionEntries.map(e => {
       const volunteerId = safeParseLookupId(e[PROFILE_LOOKUP]);
@@ -559,9 +587,8 @@ router.get('/sessions/:group/:date', async (req: Request, res: Response) => {
       limits: sessionLimits,
       storedLimits: rawLimits,
       regularsCount,
-      // Session stats are persisted on the session item and refreshed after writes.
-      // Keep this endpoint consistent across public, trusted, and self-service callers.
-      stats: storedStats,
+      // Session stats: persisted snapshot in statsRaw; check-in tier gets live headcount aggregates above.
+      stats: statsForResponse,
       financialYear: `FY${calculateFinancialYear(new Date(spSession.Date))}`,
       isBookable: spSession.Date >= today,
       eventbriteEventId: spSession.EventbriteEventID,

--- a/backend/routes/sessions.ts
+++ b/backend/routes/sessions.ts
@@ -24,7 +24,6 @@ import {
   parseHours,
   profileSlug,
   extractMetadataTags,
-  calculateSessionStats,
   parseEmails
 } from '../services/data-layer';
 import { parseSessionStats } from '../services/data-layer';
@@ -463,34 +462,6 @@ router.get('/sessions/:group/:date', async (req: Request, res: Response) => {
     const profiles = validateArray(rawProfiles, validateProfile, 'Profile');
     const profileMap = new Map(profiles.map(p => [p.ID, p]));
 
-    // Check-in tier: recompute aggregate counts from live entries (weights SharePoint Count / headcount).
-    // Stored session Stats can lag until the next write or bulk refresh.
-    let statsForResponse = storedStats;
-    if (hasCheckInTier && sessionEntries.length > 0) {
-      const profileFirstSessionMap = new Map<number, number>();
-      for (const p of profiles) {
-        try {
-          const ps = JSON.parse(p[PROFILE_STATS] || '{}');
-          if (Array.isArray(ps.sessionIds) && ps.sessionIds.length > 0) {
-            profileFirstSessionMap.set(p.ID, ps.sessionIds[0]);
-          }
-        } catch { /* ignore */ }
-      }
-      const liveMap = calculateSessionStats(sessionEntries, profileFirstSessionMap);
-      const live = liveMap.get(String(spSession.ID));
-      if (live) {
-        statsForResponse = {
-          ...storedStats,
-          count: live.registrations,
-          hours: Math.round(live.hours * 10) / 10,
-          new: live.newCount || undefined,
-          child: live.childCount || undefined,
-          regular: live.regularCount || undefined,
-          eventbrite: live.eventbriteCount || undefined,
-        };
-      }
-    }
-
     // All session entries returned to check-in tier users (with cancelled flag).
     const entryResponses: EntryResponse[] = sessionEntries.map(e => {
       const volunteerId = safeParseLookupId(e[PROFILE_LOOKUP]);
@@ -587,8 +558,8 @@ router.get('/sessions/:group/:date', async (req: Request, res: Response) => {
       limits: sessionLimits,
       storedLimits: rawLimits,
       regularsCount,
-      // Session stats: persisted snapshot in statsRaw; check-in tier gets live headcount aggregates above.
-      stats: statsForResponse,
+      // Session stats: persisted Stats JSON on the session item (same for all callers — see AGENTS.md).
+      stats: storedStats,
       financialYear: `FY${calculateFinancialYear(new Date(spSession.Date))}`,
       isBookable: spSession.Date >= today,
       eventbriteEventId: spSession.EventbriteEventID,

--- a/backend/services/data-layer.test.ts
+++ b/backend/services/data-layer.test.ts
@@ -105,6 +105,31 @@ describe('calculateSessionStats', () => {
     expect(stats.get('1')?.eventbriteCount).toBe(1)
   })
 
+  it('weights registrations and newCount by entry Count (headcount)', () => {
+    const profileFirstSessionMap = new Map([[10, 1]])
+    const stats = calculateSessionStats(
+      [
+        entry('1', { ProfileLookupId: '10', Count: 5 }),
+        entry('1', { ProfileLookupId: '11' }),
+      ],
+      profileFirstSessionMap
+    )
+    expect(stats.get('1')?.registrations).toBe(6)
+    expect(stats.get('1')?.newCount).toBe(5)
+  })
+
+  it('weights childCount, regularCount, eventbriteCount by entry Count', () => {
+    const stats = calculateSessionStats([
+      entry('1', { Labels: ['Regular'], Count: 3 }),
+      entry('1', { AccompanyingAdultLookupId: 9, Count: 2 }),
+      entry('1', { EventbriteAttendeeID: 'eb', Count: 4 }),
+    ])
+    expect(stats.get('1')?.regularCount).toBe(3)
+    expect(stats.get('1')?.childCount).toBe(2)
+    expect(stats.get('1')?.eventbriteCount).toBe(4)
+    expect(stats.get('1')?.registrations).toBe(9)
+  })
+
   it('handles multiple sessions independently', () => {
     const stats = calculateSessionStats([entry('1'), entry('1'), entry('2')])
     expect(stats.get('1')?.registrations).toBe(2)

--- a/backend/services/data-layer.ts
+++ b/backend/services/data-layer.ts
@@ -231,6 +231,7 @@ export function buildLookupMap<T, V>(
 
 /** Aggregate counts computed from entries — internal to calculateSessionStats */
 interface EntryAggregateStats {
+  /** Sum of entry headcounts (SharePoint `Count`, default 1) — not number of rows */
   registrations: number;
   hours: number;
   newCount: number;
@@ -239,8 +240,15 @@ interface EntryAggregateStats {
   eventbriteCount: number;
 }
 
+function entryHeadcount(entry: SharePointEntry): number {
+  const c = entry.Count;
+  if (typeof c === 'number' && Number.isFinite(c) && c >= 1) return Math.floor(c);
+  return 1;
+}
+
 /**
  * Calculates statistics for sessions based on entries.
+ * Registration and category counts use each entry's headcount (`Count`, default 1), not row count.
  * profileFirstSessionMap: profileId → first sessionId (from profile.stats.sessionIds[0]) — used for new count.
  * Returns a map of sessionId (as string) -> stats
  */
@@ -267,20 +275,21 @@ export function calculateSessionStats(
     }
 
     const stats = statsMap.get(sessionId)!;
-    stats.registrations++;
+    const headcount = entryHeadcount(entry);
+    stats.registrations += headcount;
     stats.hours += parseFloat(String(entry.Hours)) || 0;
 
     const profileId = safeParseLookupId(entry[PROFILE_LOOKUP]);
     const sessionIdNum = safeParseLookupId(sessionId);
 
     if (profileId !== undefined && sessionIdNum !== undefined && profileFirstSessionMap.get(profileId) === sessionIdNum && !entry.Labels?.includes('Regular'))
-      stats.newCount++;
+      stats.newCount += headcount;
     if (entry.AccompanyingAdultLookupId)
-      stats.childCount++;
+      stats.childCount += headcount;
     if (entry.Labels?.includes('Regular'))
-      stats.regularCount++;
+      stats.regularCount += headcount;
     if (entry.EventbriteAttendeeID)
-      stats.eventbriteCount++;
+      stats.eventbriteCount += headcount;
   });
 
   return statsMap;

--- a/backend/services/profile-stats.ts
+++ b/backend/services/profile-stats.ts
@@ -123,7 +123,9 @@ export async function computeAndSaveProfileStats(profileId: number): Promise<voi
   if (hasDuplicate) warnings.push({ text: 'Possible Duplicate', url: `/profiles?fy=all&search=${encodeURIComponent(thisProfile?.Title || '')}` });
   if (hasMatchNameError) warnings.push({ text: 'Match Name Error' });
   if (hasChildNoAdult) warnings.push({ text: 'Child No Adult', url: `/entries?q=%23child&fy=all&accompanyingAdult=empty&profileId=${profileId}&profileName=${encodeURIComponent(thisProfile?.Title || '')}` });
-  if (hasFutureBooking && (!hasPrivacyConsent || !hasPhotoConsent)) warnings.push({ text: 'No Consent' });
+  if (!thisProfile?.IsGroup && hasFutureBooking && (!hasPrivacyConsent || !hasPhotoConsent)) {
+    warnings.push({ text: 'No Consent' });
+  }
 
   let isMember = false;
   let cardStatus: string | null = null;
@@ -296,7 +298,9 @@ export async function runProfileStatsRefresh(): Promise<ProfileStatsRefreshResul
         if (possibleDuplicateIds.has(spProfile.ID)) warnings.push({ text: 'Possible Duplicate', url: `/profiles?fy=all&search=${encodeURIComponent(spProfile.Title || '')}` });
         if (spProfile.Title && spProfile.MatchName && toMatchName(spProfile.Title) !== spProfile.MatchName) warnings.push({ text: 'Match Name Error' });
         if (childNoAdultIds.has(spProfile.ID)) warnings.push({ text: 'Child No Adult', url: `/entries?q=%23child&fy=all&accompanyingAdult=empty&profileId=${spProfile.ID}&profileName=${encodeURIComponent(spProfile.Title || '')}` });
-        if (futureBookingIds.has(spProfile.ID) && (!consentedPrivacyIds.has(spProfile.ID) || !consentedPhotoIds.has(spProfile.ID))) warnings.push({ text: 'No Consent' });
+        if (!spProfile.IsGroup && futureBookingIds.has(spProfile.ID) && (!consentedPrivacyIds.has(spProfile.ID) || !consentedPhotoIds.has(spProfile.ID))) {
+          warnings.push({ text: 'No Consent' });
+        }
         if (spProfile.IsGroup && memberIds.has(spProfile.ID)) warnings.push({ text: 'Group + Member' });
 
         const newStats = {

--- a/frontend/src/components/EntryCard.vue
+++ b/frontend/src/components/EntryCard.vue
@@ -6,12 +6,12 @@
       <div class="ec-card-left">
 
         <button v-if="allowEdit" class="ec-name ec-name--btn" @click="emit('editEntry')">
-          {{ title }}
+          {{ displayTitle }}
         </button>
         <RouterLink v-else-if="titleTo" :to="titleTo" class="ec-name">
-          {{ title }}
+          {{ displayTitle }}
         </RouterLink>
-        <span v-else class="ec-name ec-name--plain">{{ title }}</span>
+        <span v-else class="ec-name ec-name--plain">{{ displayTitle }}</span>
 
         <span
           v-for="icon in icons"
@@ -64,12 +64,14 @@
 </template>
 
 <script setup lang="ts">
-import { ref, nextTick } from 'vue'
+import { ref, nextTick, computed } from 'vue'
 import { RouterLink, type RouteLocationRaw } from 'vue-router'
 import type { LabelIcon } from '../utils/labelIcons'
 
 const props = defineProps<{
   title: string
+  /** Entry headcount; when greater than 1, shown as "Nx " before the title. */
+  count?: number
   titleTo?: RouteLocationRaw
   checkedIn: boolean
   hours: number
@@ -79,6 +81,12 @@ const props = defineProps<{
   working?: boolean
   cancelled?: boolean
 }>()
+
+const displayTitle = computed(() => {
+  const n = props.count ?? 1
+  if (n <= 1) return props.title
+  return `${n}x ${props.title}`
+})
 
 const emit = defineEmits<{
   'update': [checkedIn: boolean, hours: number]

--- a/frontend/src/components/RegularList.vue
+++ b/frontend/src/components/RegularList.vue
@@ -7,7 +7,7 @@
       </h2>
     </div>
 
-    <p v-if="!items.length" class="rl-empty">No regulars in the past year.</p>
+    <p v-if="!items.length" class="rl-empty">No repeats or regulars to list.</p>
 
     <div v-else class="rl-grid">
       <RegularItem

--- a/frontend/src/components/profiles/ProfileEntryList.vue
+++ b/frontend/src/components/profiles/ProfileEntryList.vue
@@ -24,6 +24,7 @@
         v-for="e in filteredEntries"
         :key="e.id"
         :title="cardTitle(e)"
+        :count="e.count"
         :title-to="allowEdit ? undefined : sessionPath(e.session.groupKey, e.session.date)"
         :checked-in="e.checkedIn"
         :hours="e.hours"

--- a/frontend/src/components/sessions/SessionEntryList.vue
+++ b/frontend/src/components/sessions/SessionEntryList.vue
@@ -19,6 +19,7 @@
         v-for="e in entries"
         :key="e.id"
         :title="e.profile.name"
+        :count="e.count"
         :title-to="allowEdit ? undefined : (e.profile.slug ? profilePath(e.profile.slug) : undefined)"
         :checked-in="e.checkedIn"
         :hours="e.hours"

--- a/frontend/src/components/sessions/SessionEntryList.vue
+++ b/frontend/src/components/sessions/SessionEntryList.vue
@@ -114,8 +114,20 @@ const setHoursError = ref('')
 
 const router = useRouter()
 
-const activeCount = computed(() => props.entries.filter(e => !e.cancelled).length)
-const checkedCount = computed(() => props.entries.filter(e => e.checkedIn && !e.cancelled).length)
+function entryHeadcount(e: EntryItem): number {
+  const c = e.count
+  if (typeof c === 'number' && Number.isFinite(c) && c >= 1) return Math.floor(c)
+  return 1
+}
+
+const activeCount = computed(() =>
+  props.entries.filter(e => !e.cancelled).reduce((sum, e) => sum + entryHeadcount(e), 0)
+)
+const checkedCount = computed(() =>
+  props.entries
+    .filter(e => e.checkedIn && !e.cancelled)
+    .reduce((sum, e) => sum + entryHeadcount(e), 0)
+)
 const eligibleCount = computed(() => props.entries.filter(e => e.checkedIn && !e.hours).length)
 const sessionAdults = computed(() =>
   props.entries

--- a/frontend/src/pages/GroupDetailPage.vue
+++ b/frontend/src/pages/GroupDetailPage.vue
@@ -386,9 +386,9 @@ async function onRegularDelete() {
   try {
     const res = await fetch(`/api/regulars/${regularId}`, { method: 'DELETE' })
     if (!res.ok) throw new Error(`Delete failed (${res.status})`)
-    const item = store.group.regulars.find(r => r.slug === slug)
-    if (item) { item.isRegular = false; item.regularId = undefined; item.accompanyingAdultId = undefined }
     editingRegular.value = null
+    const ok = await store.refresh(store.group.key)
+    if (!ok) regularError.value = 'Regular removed but list could not be refreshed.'
   } catch (e) {
     console.error('[GroupDetailPage] onRegularDelete failed', e)
     regularModalError.value = 'Failed to delete — please try again'

--- a/frontend/src/pages/SessionDetailPage.vue
+++ b/frontend/src/pages/SessionDetailPage.vue
@@ -523,17 +523,56 @@ async function onAddEntry(payload: { profileId: number } | { newName: string; ne
   const groupKey = route.params.groupKey as string
   const date = store.session!.date
   try {
+    let profileId: number
+    if ('profileId' in payload) {
+      profileId = payload.profileId
+    } else {
+      const name = payload.newName.trim()
+      if (!name) {
+        entryListRef.value?.onAddError('Name is required')
+        return
+      }
+      const createRes = await fetch('/api/profiles', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name,
+          email: payload.newEmail.trim() || undefined,
+        }),
+      })
+      if (!createRes.ok) {
+        let msg = `Could not create profile (${createRes.status})`
+        try {
+          const body = await createRes.json()
+          if (body && typeof body.error === 'string' && body.error) msg = body.error
+        } catch { /* ignore */ }
+        throw new Error(msg)
+      }
+      const created = await createRes.json()
+      const id = created?.data?.id
+      if (typeof id !== 'number') throw new Error('Invalid response from server')
+      profileId = id
+    }
+
     const res = await fetch(`/api/sessions/${groupKey}/${date}/entries`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
+      body: JSON.stringify({ profileId }),
     })
-    if (!res.ok) throw new Error(`Add failed (${res.status})`)
+    if (!res.ok) {
+      let msg = `Add failed (${res.status})`
+      try {
+        const body = await res.json()
+        if (body && typeof body.error === 'string' && body.error) msg = body.error
+      } catch { /* ignore */ }
+      throw new Error(msg)
+    }
     await store.fetch(groupKey, date)
     entryListRef.value?.onAddSuccess()
   } catch (e) {
     console.error('[SessionDetailPage] onAddEntry failed', e)
-    entryListRef.value?.onAddError('Failed to add entry — please try again')
+    const msg = e instanceof Error ? e.message : 'Failed to add entry — please try again'
+    entryListRef.value?.onAddError(msg)
   }
 }
 

--- a/frontend/src/pages/SessionDetailPage.vue
+++ b/frontend/src/pages/SessionDetailPage.vue
@@ -501,16 +501,22 @@ async function onEntryUpdate(entry: EntryItem, checkedIn: boolean, hours: number
   }
 }
 
-async function onSetHours(hours: number) {
+function entryHeadcountForHours(count: number | undefined): number {
+  if (typeof count === 'number' && Number.isFinite(count) && count >= 1) return Math.floor(count)
+  return 1
+}
+
+async function onSetHours(hoursPerPerson: number) {
   const eligible = store.session?.entries.filter(e => e.checkedIn && !e.hours) ?? []
   try {
-    await Promise.all(eligible.map(e =>
-      fetch(`/api/entries/${e.id}`, {
+    await Promise.all(eligible.map(e => {
+      const storedHours = hoursPerPerson * entryHeadcountForHours(e.count)
+      return fetch(`/api/entries/${e.id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ checkedIn: true, hours }),
+        body: JSON.stringify({ checkedIn: true, hours: storedHours }),
       })
-    ))
+    }))
     await store.fetch(route.params.groupKey as string, store.session!.date)
     entryListRef.value?.onSetHoursSuccess()
   } catch (e) {

--- a/frontend/src/pages/modals/SessionSetHoursModal.vue
+++ b/frontend/src/pages/modals/SessionSetHoursModal.vue
@@ -10,12 +10,11 @@
   >
     <p class="shm-desc">
       Sets hours for all checked-in entries where hours are not yet recorded.
-      The value is <strong>per person</strong>; each entry saves as hours × attendance count (e.g. 5 × 3h → 15h).
-      <strong>{{ entryCount }} entries</strong> will be updated.
+      {{ entryCount === 1 ? '1 entry' : `${entryCount} entries` }} will be updated.
     </p>
 
     <FormLayout :disabled="working">
-      <FormRow title="Hours (each)">
+      <FormRow title="Hours (per person)">
         <input v-model.number="hours" type="number" min="0" step="0.5" class="shm-input" />
       </FormRow>
     </FormLayout>

--- a/frontend/src/pages/modals/SessionSetHoursModal.vue
+++ b/frontend/src/pages/modals/SessionSetHoursModal.vue
@@ -10,11 +10,12 @@
   >
     <p class="shm-desc">
       Sets hours for all checked-in entries where hours are not yet recorded.
+      The value is <strong>per person</strong>; each entry saves as hours × attendance count (e.g. 5 × 3h → 15h).
       <strong>{{ entryCount }} entries</strong> will be updated.
     </p>
 
     <FormLayout :disabled="working">
-      <FormRow title="Hours">
+      <FormRow title="Hours (each)">
         <input v-model.number="hours" type="number" min="0" step="0.5" class="shm-input" />
       </FormRow>
     </FormLayout>

--- a/frontend/src/pages/sandbox/SandboxEntryCard.vue
+++ b/frontend/src/pages/sandbox/SandboxEntryCard.vue
@@ -66,6 +66,7 @@
       <div class="demo">
         <EntryCard
           title="Dean Heritage Volunteers Ltd"
+          :count="5"
           :checked-in="false"
           :hours="0"
           :icons="iconsForEntry({ isGroup: true })"

--- a/frontend/src/stores/groupDetail.test.ts
+++ b/frontend/src/stores/groupDetail.test.ts
@@ -37,4 +37,24 @@ describe('groupDetail store', () => {
     await store.fetch('foo')
     expect(store.loading).toBe(false)
   })
+
+  it('refresh updates group in place on success', async () => {
+    const g1 = { id: 1, key: 'foo', displayName: 'Foo', regulars: [] as unknown[] }
+    mockFetch({ data: g1 })
+    const store = useGroupDetailStore()
+    await store.fetch('foo')
+    const g2 = { id: 1, key: 'foo', displayName: 'Foo Updated', regulars: [{ profileId: 1 }] }
+    mockFetch({ data: g2 })
+    const ok = await store.refresh('foo')
+    expect(ok).toBe(true)
+    expect(store.group?.displayName).toBe('Foo Updated')
+    expect(store.group?.regulars?.length).toBe(1)
+  })
+
+  it('refresh returns false on error response', async () => {
+    mockFetch({}, false, 500)
+    const store = useGroupDetailStore()
+    const ok = await store.refresh('foo')
+    expect(ok).toBe(false)
+  })
 })

--- a/frontend/src/stores/groupDetail.ts
+++ b/frontend/src/stores/groupDetail.ts
@@ -27,5 +27,20 @@ export const useGroupDetailStore = defineStore('groupDetail', () => {
     }
   }
 
-  return { group, loading, error, httpStatus, fetch }
+  /** Replace group payload without clearing `group` or `loading` — avoids list flash after small mutations (e.g. delete regular). */
+  async function refresh(key: string): Promise<boolean> {
+    try {
+      const res = await window.fetch(`/api/groups/${key}`)
+      httpStatus.value = res.status
+      if (!res.ok) return false
+      const json: { data: GroupDetailResponse } = await res.json()
+      group.value = json.data
+      return true
+    } catch (e) {
+      console.error('[groupDetail store] refresh', e)
+      return false
+    }
+  }
+
+  return { group, loading, error, httpStatus, fetch, refresh }
 })


### PR DESCRIPTION
## Summary
Branch \eature/groups\ — volunteer/group session UX and stats consistency.

## Changes
- **Add entry (new person):** Create profile via \POST /api/profiles\ then book entry (email optional). Fixes add-new flow that previously sent \
ewName\ to the entries endpoint.
- **Entry cards:** Show \Nx Name\ when entry \count\ > 1.
- **Session aggregates:** \calculateSessionStats\ weights registrations, new, child, regular, and Eventbrite counts by entry **headcount** (\Count\). Check-ins header \(checked / total)\ sums headcount. Session \Stats\ JSON is still the single source for the stats card (no live overlay in the session GET).
- **AGENTS:** Clean-code / single-path guidance for stats; link to [clean code cheat sheet gist](https://gist.github.com/wojteklu/73c6914cc446146b8b533c0988cf8d29).
- **Profile stats:** Do not add **No Consent** warning for **group** profiles.
- **Set hours:** Modal value is **per person**; PATCH stores \hours × entry count\. Shorter modal copy.
- **Group detail — Repeats and Regulars:** List formal **regulars** who are below the rolling-year repeat hour threshold so they can be viewed/edited.

## Testing
- \
pm run build\
- \
px vitest run backend/services/data-layer.test.ts\
- \cd frontend && npm test -- --run\

Made with [Cursor](https://cursor.com)