### PR TITLE
Fix media edit modal when cover photo is not public

### DIFF
--- a/docs/testing/full-regression.md
+++ b/docs/testing/full-regression.md
@@ -357,6 +357,7 @@ Run with `npm run dev` at http://localhost:3000. Log in via Microsoft Entra ID.
 - [ ] Admin/Check In: lightbox shows "Public gallery" checkbox and title/alt-text input per item
 - [ ] Toggling "Public gallery" checkbox calls `PATCH /api/media/:itemId` — `{ isPublic: true/false }`; change persists on reload
 - [ ] Admin/Check In: can set cover image via lightbox "Set as cover" control; cover updates above carousel
+- [ ] **Cover + private (invalid)**: session cover points at a photo with `IsPublic` false (e.g. after stale gallery + accidental save) → edit modal shows Public off and Cover on, both checkboxes enabled, hint shown, **Save disabled**, **Delete disabled** → tick Public → Save enabled, Delete still disabled → save → file public and still cover; or untick Cover → Save and Delete enabled → save → private and not cover
 - [ ] `PATCH /api/media/:itemId` for Self-Service → 403 (Check In / Admin allowed)
 - [ ] **Media cache**: loading session detail twice → second load shows `[Cache] Hit: media_folder_*` in server logs (no repeat Graph call)
 - [ ] **Media cache bust**: upload a photo to a session → immediately reload the session gallery → new photo appears (cache was busted by upload)

--- a/frontend/src/pages/modals/MediaEditModal.vue
+++ b/frontend/src/pages/modals/MediaEditModal.vue
@@ -4,7 +4,8 @@
     action="Save"
     action-icon="save"
     :show-delete="showDelete"
-    :delete-disabled="form.isCover"
+    :delete-disabled="deleteDisabled"
+    :action-disabled="saveDisabled"
     :working="working"
     :error="error"
     @close="emit('close')"
@@ -22,12 +23,30 @@
     </div>
 
     <FormLayout :disabled="working">
-      <FormRow title="Public" :disabled="form.isCover">
-        <input id="emm-public" v-model="form.isPublic" type="checkbox" class="emm-checkbox" :disabled="form.isCover" @change="onPublicChange" />
+      <p v-if="isCoverPrivateInvalid" class="emm-hint">
+        Cover photos must be public, or remove as cover before saving.
+      </p>
+
+      <FormRow title="Public" :disabled="publicRowDisabled">
+        <input
+          id="emm-public"
+          v-model="form.isPublic"
+          type="checkbox"
+          class="emm-checkbox"
+          :disabled="publicCheckboxDisabled"
+          @change="onPublicChange"
+        />
       </FormRow>
 
-      <FormRow v-if="showCover" title="Cover" :disabled="!form.isPublic">
-        <input id="emm-cover" v-model="form.isCover" type="checkbox" class="emm-checkbox" :disabled="!form.isPublic" @change="onCoverChange" />
+      <FormRow v-if="showCover" title="Cover" :disabled="coverRowDisabled">
+        <input
+          id="emm-cover"
+          v-model="form.isCover"
+          type="checkbox"
+          class="emm-checkbox"
+          :disabled="coverCheckboxDisabled"
+          @change="onCoverChange"
+        />
       </FormRow>
 
       <FormRow title="Title" :full-width="true">
@@ -47,7 +66,7 @@
 </template>
 
 <script setup lang="ts">
-import { reactive, ref } from 'vue'
+import { reactive, ref, computed } from 'vue'
 import ModalLayout from '../../components/ModalLayout.vue'
 import AppButton from '../../components/AppButton.vue'
 import FormLayout from '../../components/FormLayout.vue'
@@ -82,6 +101,21 @@ const form = reactive({
   isCover: props.isCover ?? false,
 })
 
+/** Session cover points at this file but IsPublic is false (SharePoint or stale list). */
+const isCoverPrivateInvalid = computed(() => form.isCover && !form.isPublic)
+
+const saveDisabled = computed(() => isCoverPrivateInvalid.value)
+
+const deleteDisabled = computed(() => form.isCover)
+
+/** Normal cover+public: cannot uncheck Public without clearing cover first. Invalid state: Public stays enabled. */
+const publicCheckboxDisabled = computed(() => form.isCover && form.isPublic)
+const publicRowDisabled = publicCheckboxDisabled
+
+/** Normal private: Cover off until Public on. Invalid cover+private: Cover stays enabled. */
+const coverCheckboxDisabled = computed(() => !form.isPublic && !isCoverPrivateInvalid.value)
+const coverRowDisabled = coverCheckboxDisabled
+
 function onPublicChange() {
   if (!form.isPublic) form.isCover = false
 }
@@ -91,6 +125,7 @@ function onCoverChange() {
 }
 
 function save() {
+  if (saveDisabled.value) return
   emit('save', { title: form.title, isPublic: form.isPublic, isCover: form.isCover })
 }
 
@@ -110,6 +145,15 @@ function doDelete() {
 .emm-actions--blocked {
   pointer-events: none;
   opacity: 0.5;
+}
+
+.emm-hint {
+  margin: 0 0 0.75rem;
+  padding: 0.5rem 0.6rem;
+  font-size: 0.85rem;
+  line-height: 1.4;
+  color: var(--color-text);
+  background: var(--color-dtv-light);
 }
 
 .emm-input {


### PR DESCRIPTION
## Summary
- Handles invalid state where the session cover points at a photo with `IsPublic` false (SharePoint, stale gallery, or accidental second save).
- In that state: Public and Cover checkboxes reflect SharePoint and stay enabled; Save is disabled until the user makes the photo public or removes cover; Delete stays disabled while the item is cover.
- Unchecking Cover enables Save and Delete; ticking Public enables Save only (Delete still disabled while cover).
- Adds a short hint and blocks `save()` when invalid; regression checklist item in H30b.

## Test plan
- [ ] Simulate cover + private (session `coverMediaId` set, file `IsPublic` false) → open edit → hint, Save/Delete disabled, both checkboxes enabled
- [ ] Tick Public → Save enabled, Delete disabled → Save → SharePoint `IsPublic` Yes, still cover
- [ ] Reset invalid state → uncheck Cover → Save and Delete enabled → Save → private, session cover cleared
- [ ] Normal edit: public + cover → Public disabled, Save works; private non-cover → Delete enabled