### PR TITLE
Add public governance Docs page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,7 +206,7 @@ Five independent caches:
 | **Column schema cache** | `sharepoint-client.ts` | SharePoint column definitions | 1 hr | Manual admin clear |
 | **Taxonomy tree cache** (`treeCache`) | `taxonomy-client.ts` | Term Store hierarchy | 1 hr | Manual admin clear |
 | **Cover image cache** (`coverCache`) | `services/cover-cache.ts` | Session cover image bytes | 1 hr | Bust on `coverMediaId` change |
-| **Project docs cache** (`project-docs-cache.ts`) | `project-docs-cache.ts` | Project file bytes for `/docs/projects/` proxy | 12 hr | Upload/delete; admin cache clear |
+| **File proxy caches** | `media-cache.ts`, `project-docs-cache.ts`, `governance-docs-cache.ts`, governance tree | Proxied media/doc bytes + governance folder tree | 6 hr | Upload/delete; admin cache clear |
 
 **NodeCache per-entity TTLs:**
 
@@ -214,7 +214,8 @@ Five independent caches:
 |---|---|---|
 | `groups`, `sessions`, `profiles`, `regulars` | 6 hr | Warmed nightly; covers check-in window |
 | `entries` | 5 min | Check-in tier — live writes on the day |
-| `records`, stats, media, slug/item keys | 24 hr | Targeted invalidation handles writes |
+| `records`, stats, slug/item keys | 24 hr | Targeted invalidation handles writes |
+| `fileProxy` (media folders, project/governance doc folders) | 6 hr | Shared with file proxy byte caches; admin cache clear |
 
 Targeted invalidation: each repository write evicts only its own key(s). Entry writes also clear `sessions_FY*` keys. **Admin cache clear** (`POST /api/cache/clear`) flushes NodeCache, column schema, taxonomy tree, cover images, and project doc bytes.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,7 @@ All pages are Vue 3 SPA routes defined in [frontend/src/router/index.ts](fronten
 - Unified sign-in page: verification code (self-service) + Microsoft (trusted) ([LoginPage.vue](frontend/src/pages/LoginPage.vue))
 - Volunteer media upload page ([UploadPage.vue](frontend/src/pages/UploadPage.vue))
 - Consent collection page at `/profiles/:slug/consent` ([ConsentPage.vue](frontend/src/pages/ConsentPage.vue))
+- Governance docs page at `/docs` — public; reads SharePoint `Docs/` folder; PDFs via tracker proxy ([DocsPage.vue](frontend/src/pages/DocsPage.vue))
 
 ---
 

--- a/app.js
+++ b/app.js
@@ -144,9 +144,9 @@ app.get('/media/:group/:date/:id', async (req, res) => {
     }
 });
 
-// Public project documents proxy — files under Projects/{key}/ on the Documents library drive.
+// Public project documents proxy — /projects/:key/files/:itemId (not under /docs/ — avoids governance path clash).
 // No SharePoint session required; bytes cached 12h in memory, 24h in browser.
-app.get('/docs/projects/:key/:itemId', async (req, res) => {
+app.get('/projects/:key/files/:itemId', async (req, res) => {
     const key = String(req.params.key).toLowerCase().replace(/[^a-z0-9-]/g, '');
     const itemId = String(req.params.itemId);
     if (!key || !itemId || itemId.length > 256 || !/^[\w.!-]+$/i.test(itemId)) {

--- a/app.js
+++ b/app.js
@@ -18,6 +18,8 @@ const { mediaDriveId } = require('./dist/backend/services/media-upload');
 const { sharePointClient } = require('./dist/backend/services/sharepoint-client');
 const { getMediaCache, setMediaCache } = require('./dist/backend/services/media-cache');
 const { getProjectDocCache, setProjectDocCache } = require('./dist/backend/services/project-docs-cache');
+const { getGovernanceDocCache, setGovernanceDocCache } = require('./dist/backend/services/governance-docs-cache');
+const { fetchGovernanceDocPdf } = require('./dist/backend/services/governance-docs-service');
 const { tryDocumentsDriveId } = require('./dist/backend/services/documents-drive');
 const { projectsRepository } = require('./dist/backend/services/repositories/projects-repository');
 const { findProjectByKey } = require('./dist/backend/services/data-layer');
@@ -180,6 +182,33 @@ app.get('/docs/projects/:key/:itemId', async (req, res) => {
         res.send(data);
     } catch (err) {
         console.error(`Error serving project doc ${key}/${itemId}:`, err);
+        res.status(502).end();
+    }
+});
+
+// Public governance docs proxy — PDFs under Docs/ on the Documents library drive.
+app.get(/^\/docs\/.+\.pdf$/i, async (req, res) => {
+    const slugPath = req.path.replace(/^\/docs\//, '');
+    if (!slugPath) return res.status(400).end();
+
+    const cached = getGovernanceDocCache(slugPath);
+    if (cached) {
+        res.set('Content-Type', cached.contentType);
+        res.set('Cache-Control', 'public, max-age=86400');
+        return res.send(cached.data);
+    }
+
+    try {
+        const data = await fetchGovernanceDocPdf(slugPath);
+        if (!data) return res.status(404).end();
+        setGovernanceDocCache(slugPath, data, 'application/pdf');
+        const safeName = slugPath.split('/').pop().replace(/[^\w.\-]/g, '_');
+        res.set('Content-Type', 'application/pdf');
+        res.set('Content-Disposition', `inline; filename="${safeName}"`);
+        res.set('Cache-Control', 'public, max-age=86400');
+        res.send(data);
+    } catch (err) {
+        console.error(`Error serving governance doc ${slugPath}:`, err);
         res.status(502).end();
     }
 });

--- a/app.js
+++ b/app.js
@@ -20,7 +20,7 @@ const { getMediaCache, setMediaCache } = require('./dist/backend/services/media-
 const { getProjectDocCache, setProjectDocCache } = require('./dist/backend/services/project-docs-cache');
 const { getGovernanceDocCache, setGovernanceDocCache } = require('./dist/backend/services/governance-docs-cache');
 const { fetchGovernanceDocPdf } = require('./dist/backend/services/governance-docs-service');
-const { tryDocumentsDriveId } = require('./dist/backend/services/documents-drive');
+const { fetchProjectDoc } = require('./dist/backend/services/project-docs-service');
 const { projectsRepository } = require('./dist/backend/services/repositories/projects-repository');
 const { findProjectByKey } = require('./dist/backend/services/data-layer');
 const axios = require('axios');
@@ -144,16 +144,13 @@ app.get('/media/:group/:date/:id', async (req, res) => {
     }
 });
 
-// Public project documents proxy — /projects/:key/files/:itemId (not under /docs/ — avoids governance path clash).
-// No SharePoint session required; bytes cached 12h in memory, 24h in browser.
-app.get('/projects/:key/files/:itemId', async (req, res) => {
-    const key = String(req.params.key).toLowerCase().replace(/[^a-z0-9-]/g, '');
-    const itemId = String(req.params.itemId);
-    if (!key || !itemId || itemId.length > 256 || !/^[\w.!-]+$/i.test(itemId)) {
-        return res.status(400).end();
-    }
+// Public project documents proxy — slug paths under /projects/:key/docs/ (recursive Projects/{key}/ tree).
+app.get(/^\/projects\/([a-z0-9-]+)\/docs\/(.+)$/i, async (req, res) => {
+    const key = String(req.params[0]).toLowerCase();
+    const slugPath = String(req.params[1]);
+    if (!key || !slugPath) return res.status(400).end();
 
-    const cacheKey = `${key}/${itemId}`;
+    const cacheKey = `${key}/${slugPath}`;
     const cached = getProjectDocCache(cacheKey);
     if (cached) {
         res.set('Content-Type', cached.contentType);
@@ -162,26 +159,20 @@ app.get('/projects/:key/files/:itemId', async (req, res) => {
     }
 
     try {
-        const driveId = tryDocumentsDriveId();
-        if (!driveId) return res.status(503).end();
-
         const rawProjects = await projectsRepository.getAll();
         if (!findProjectByKey(rawProjects, key)) return res.status(404).end();
 
-        const folderPath = `Projects/${key}`;
-        const files = await sharePointClient.listDriveFolderFiles(driveId, folderPath);
-        if (!files.some(f => f.id === itemId)) return res.status(404).end();
+        const result = await fetchProjectDoc(key, slugPath);
+        if (!result) return res.status(404).end();
 
-        const { data, contentType, name } = await sharePointClient.downloadDriveItem(driveId, itemId);
-        setProjectDocCache(cacheKey, data, contentType);
-
-        const safeName = String(name).replace(/[^\w.\-]/g, '_');
-        res.set('Content-Type', contentType);
+        setProjectDocCache(cacheKey, result.data, result.contentType);
+        const safeName = String(result.name).replace(/[^\w.\-]/g, '_');
+        res.set('Content-Type', result.contentType);
         res.set('Cache-Control', 'public, max-age=86400');
         res.set('Content-Disposition', `inline; filename="${safeName}"`);
-        res.send(data);
+        res.send(result.data);
     } catch (err) {
-        console.error(`Error serving project doc ${key}/${itemId}:`, err);
+        console.error(`Error serving project doc ${key}/${slugPath}:`, err);
         res.status(502).end();
     }
 });

--- a/backend/middleware/public-api-get-paths.ts
+++ b/backend/middleware/public-api-get-paths.ts
@@ -12,6 +12,7 @@ export const PUBLIC_API_GET_PATH_PREFIXES: readonly string[] = [
   '/api/projects',
   '/api/tags',
   '/api/media',
+  '/api/docs',
   '/api/email/sandbox',
 ];
 

--- a/backend/middleware/require-admin.ts
+++ b/backend/middleware/require-admin.ts
@@ -38,6 +38,7 @@ const SELFSERVICE_ALLOWED_GET_PATTERNS = [
   /^\/projects/,
   /^\/tags/,
   /^\/media/,
+  /^\/docs/,
   /^\/entries\/\d+$/,                  // own entry detail by ID; handler enforces ownership
   /^\/entries\/\d+\/upload-context$/, // own entry upload context; handler enforces ownership
 ];

--- a/backend/routes/api.ts
+++ b/backend/routes/api.ts
@@ -15,6 +15,7 @@ import eventbriteRoutes = require('./eventbrite');
 import mediaRoutes = require('./media');
 import tagsRoutes = require('./tags');
 import backupRoutes = require('./backup');
+import docsRoutes = require('./docs');
 import emailRoutes = require('./email');
 
 const router: Router = express.Router();
@@ -31,6 +32,7 @@ router.use(eventbriteRoutes);
 router.use(mediaRoutes);
 router.use(tagsRoutes);
 router.use(backupRoutes);
+router.use(docsRoutes);
 router.use('/email', emailRoutes);
 
 export = router;

--- a/backend/routes/docs.ts
+++ b/backend/routes/docs.ts
@@ -1,0 +1,17 @@
+import express, { Request, Response, Router } from 'express';
+import { getGovernanceDocsTree } from '../services/governance-docs-service';
+
+const router: Router = express.Router();
+
+// Returns the Docs/ folder tree with stable tracker-domain URLs on file nodes (project docs pattern).
+router.get('/docs', async (_req: Request, res: Response) => {
+  try {
+    const data = await getGovernanceDocsTree();
+    res.json({ success: true, data });
+  } catch (error: any) {
+    console.error('Error fetching governance docs tree:', error);
+    res.status(500).json({ success: false, error: error.message });
+  }
+});
+
+export = router;

--- a/backend/routes/projects.ts
+++ b/backend/routes/projects.ts
@@ -267,7 +267,7 @@ router.get('/projects/:key/attachments', async (req: Request, res: Response) => 
     const data: ProjectAttachmentResponse[] = attachments.map(a => ({
       id: a.id,
       name: a.name,
-      url: `/docs/projects/${key}/${encodeURIComponent(a.id)}`,
+      url: `/projects/${key}/files/${encodeURIComponent(a.id)}`,
     }));
     res.json({ success: true, data } as ApiResponse<ProjectAttachmentResponse[]>);
   } catch (error: any) {
@@ -329,7 +329,7 @@ async function handleProjectDocUpload(req: Request, res: Response) {
       uploaded.push({
         id: item.id,
         name: item.name,
-        url: `/docs/projects/${key}/${encodeURIComponent(item.id)}`,
+        url: `/projects/${key}/files/${encodeURIComponent(item.id)}`,
       });
     }
 

--- a/backend/routes/projects.ts
+++ b/backend/routes/projects.ts
@@ -32,12 +32,18 @@ import type {
   ProjectResponse,
   ProjectDetailResponse,
   ProjectAttachmentResponse,
+  DocsTreeNode,
   SessionResponse,
 } from '../../types/api-responses';
 import type { ApiResponse } from '../../types/sharepoint';
 import { sharePointClient } from '../services/sharepoint-client';
 import { documentsDriveId, tryDocumentsDriveId } from '../services/documents-drive';
 import { clearProjectDocsCache } from '../services/project-docs-cache';
+import {
+  getProjectDocsTree,
+  clearProjectDocsTreeCache,
+  projectDocUrlForFilename,
+} from '../services/project-docs-service';
 import { aggregateSessionStatsForScope } from '../services/session-entity-stats';
 import { normalizeMetadataTagsInput, updateListItemMetadata } from '../services/metadata-tags';
 import type { SharePointSession } from '../../types/session';
@@ -73,6 +79,8 @@ async function migrateProjectDocsFolder(oldKey: string, newKey: string): Promise
   sharePointClient.clearDocsFolderCache(newPath);
   clearProjectDocsCache(oldKey);
   clearProjectDocsCache(newKey);
+  clearProjectDocsTreeCache(oldKey);
+  clearProjectDocsTreeCache(newKey);
 }
 
 function safeProjectFilename(original: string): string {
@@ -256,20 +264,12 @@ router.get('/projects/:key/attachments', async (req: Request, res: Response) => 
     const driveId = tryDocumentsDriveId();
     if (!driveId) {
       console.warn('[projects] DOCUMENTS_DRIVE_ID not set — returning empty project documents');
-      res.json({ success: true, data: [] } as ApiResponse<ProjectAttachmentResponse[]>);
+      res.json({ success: true, data: [] } as ApiResponse<DocsTreeNode[]>);
       return;
     }
 
-    const attachments = await sharePointClient.listDriveFolderFiles(
-      driveId,
-      projectDocsFolderPath(key)
-    );
-    const data: ProjectAttachmentResponse[] = attachments.map(a => ({
-      id: a.id,
-      name: a.name,
-      url: `/projects/${key}/files/${encodeURIComponent(a.id)}`,
-    }));
-    res.json({ success: true, data } as ApiResponse<ProjectAttachmentResponse[]>);
+    const data = await getProjectDocsTree(key);
+    res.json({ success: true, data } as ApiResponse<DocsTreeNode[]>);
   } catch (error: any) {
     console.error('Error fetching project documents:', error.message || error);
     res.status(500).json({
@@ -329,7 +329,7 @@ async function handleProjectDocUpload(req: Request, res: Response) {
       uploaded.push({
         id: item.id,
         name: item.name,
-        url: `/projects/${key}/files/${encodeURIComponent(item.id)}`,
+        url: projectDocUrlForFilename(key, item.name),
       });
     }
 
@@ -339,7 +339,9 @@ async function handleProjectDocUpload(req: Request, res: Response) {
     }
 
     sharePointClient.clearDocsFolderCache(folderPath);
+    sharePointClient.clearProjectDocsFolderCache(key);
     clearProjectDocsCache(key);
+    clearProjectDocsTreeCache(key);
     res.json({ success: true, data: uploaded } as ApiResponse<ProjectAttachmentResponse[]>);
   } catch (error: any) {
     console.error('Error uploading project documents:', error.message || error);
@@ -370,7 +372,9 @@ router.delete('/projects/:key/attachments/:itemId', async (req: Request, res: Re
     const driveId = documentsDriveId();
     await sharePointClient.deleteMediaItem(driveId, itemId);
     sharePointClient.clearDocsFolderCache(projectDocsFolderPath(key));
+    sharePointClient.clearProjectDocsFolderCache(key);
     clearProjectDocsCache(key);
+    clearProjectDocsTreeCache(key);
     res.json({ success: true } as ApiResponse<void>);
   } catch (error: any) {
     console.error('Error deleting project document:', error.message || error);

--- a/backend/routes/stats.ts
+++ b/backend/routes/stats.ts
@@ -4,6 +4,7 @@ import { taxonomyClient } from '../services/taxonomy-client';
 import { clearMediaCache } from '../services/media-cache';
 import { clearCoverCache } from '../services/cover-cache';
 import { clearProjectDocsCache } from '../services/project-docs-cache';
+import { clearProjectDocsTreeCache } from '../services/project-docs-service';
 import { clearGovernanceDocsCache } from '../services/governance-docs-cache';
 import { clearGovernanceDocsTreeCache } from '../services/governance-docs-service';
 import { sessionsRepository } from '../services/repositories/sessions-repository';
@@ -219,6 +220,7 @@ router.post('/cache/clear', (req: Request, res: Response) => {
     clearMediaCache();
     clearCoverCache();
     clearProjectDocsCache();
+    clearProjectDocsTreeCache();
     clearGovernanceDocsCache();
     clearGovernanceDocsTreeCache();
     res.json({ success: true, message: 'Cache cleared successfully' });

--- a/backend/routes/stats.ts
+++ b/backend/routes/stats.ts
@@ -4,6 +4,8 @@ import { taxonomyClient } from '../services/taxonomy-client';
 import { clearMediaCache } from '../services/media-cache';
 import { clearCoverCache } from '../services/cover-cache';
 import { clearProjectDocsCache } from '../services/project-docs-cache';
+import { clearGovernanceDocsCache } from '../services/governance-docs-cache';
+import { clearGovernanceDocsTreeCache } from '../services/governance-docs-service';
 import { sessionsRepository } from '../services/repositories/sessions-repository';
 import { profilesRepository } from '../services/repositories/profiles-repository';
 import { calculateCurrentFY, calculateFinancialYear, safeParseLookupId } from '../services/data-layer';
@@ -217,6 +219,8 @@ router.post('/cache/clear', (req: Request, res: Response) => {
     clearMediaCache();
     clearCoverCache();
     clearProjectDocsCache();
+    clearGovernanceDocsCache();
+    clearGovernanceDocsTreeCache();
     res.json({ success: true, message: 'Cache cleared successfully' });
   } catch (error: any) {
     console.error('Error clearing cache:', error);

--- a/backend/services/file-proxy-cache-ttl.test.ts
+++ b/backend/services/file-proxy-cache-ttl.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { FILE_PROXY_CACHE_TTL_MS, isFileProxyCacheValid } from './file-proxy-cache-ttl';
+
+describe('isFileProxyCacheValid', () => {
+  it('returns true within TTL', () => {
+    const now = 1_000_000;
+    expect(isFileProxyCacheValid(now - FILE_PROXY_CACHE_TTL_MS + 1, now)).toBe(true);
+  });
+
+  it('returns false when expired', () => {
+    const now = 1_000_000;
+    expect(isFileProxyCacheValid(now - FILE_PROXY_CACHE_TTL_MS, now)).toBe(false);
+  });
+});

--- a/backend/services/file-proxy-cache-ttl.ts
+++ b/backend/services/file-proxy-cache-ttl.ts
@@ -1,0 +1,10 @@
+/**
+ * Shared TTL for session media, project docs, and governance docs:
+ * SharePoint folder listings (NodeCache) and in-memory proxied file bytes.
+ */
+export const FILE_PROXY_CACHE_TTL_SEC = 6 * 60 * 60; // 6 hr
+export const FILE_PROXY_CACHE_TTL_MS = FILE_PROXY_CACHE_TTL_SEC * 1000;
+
+export function isFileProxyCacheValid(fetchedAt: number, now = Date.now()): boolean {
+  return now - fetchedAt < FILE_PROXY_CACHE_TTL_MS;
+}

--- a/backend/services/governance-docs-cache.ts
+++ b/backend/services/governance-docs-cache.ts
@@ -1,4 +1,4 @@
-const TTL_MS = 12 * 60 * 60 * 1000; // 12h — governance PDFs change rarely
+import { isFileProxyCacheValid } from './file-proxy-cache-ttl';
 
 interface CacheEntry {
   data: Buffer;
@@ -11,7 +11,7 @@ const cache = new Map<string, CacheEntry>();
 export function getGovernanceDocCache(slugPath: string): CacheEntry | null {
   const entry = cache.get(slugPath);
   if (!entry) return null;
-  if (Date.now() - entry.fetchedAt > TTL_MS) {
+  if (!isFileProxyCacheValid(entry.fetchedAt)) {
     cache.delete(slugPath);
     return null;
   }

--- a/backend/services/governance-docs-cache.ts
+++ b/backend/services/governance-docs-cache.ts
@@ -1,0 +1,27 @@
+const TTL_MS = 12 * 60 * 60 * 1000; // 12h — governance PDFs change rarely
+
+interface CacheEntry {
+  data: Buffer;
+  contentType: string;
+  fetchedAt: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+export function getGovernanceDocCache(slugPath: string): CacheEntry | null {
+  const entry = cache.get(slugPath);
+  if (!entry) return null;
+  if (Date.now() - entry.fetchedAt > TTL_MS) {
+    cache.delete(slugPath);
+    return null;
+  }
+  return entry;
+}
+
+export function setGovernanceDocCache(slugPath: string, data: Buffer, contentType: string): void {
+  cache.set(slugPath, { data, contentType, fetchedAt: Date.now() });
+}
+
+export function clearGovernanceDocsCache(): void {
+  cache.clear();
+}

--- a/backend/services/governance-docs-service.test.ts
+++ b/backend/services/governance-docs-service.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { fileSlug } from './governance-docs-service';
+
+describe('fileSlug', () => {
+  it('slugifies PDF basename like profile nameToSlug and keeps .pdf', () => {
+    expect(fileSlug('(#2305774137) Certificate - C&SO Select Renewal Policy from Zurich.pdf'))
+      .toBe('2305774137-certificate-c-so-select-renewal-policy-from-zurich.pdf');
+  });
+
+  it('slugifies simple filenames', () => {
+    expect(fileSlug('sds1-aspen4.pdf')).toBe('sds1-aspen4.pdf');
+  });
+});

--- a/backend/services/governance-docs-service.ts
+++ b/backend/services/governance-docs-service.ts
@@ -1,0 +1,139 @@
+/**
+ * Governance docs — reads the Docs/ folder from the Documents library (DOCUMENTS_DRIVE_ID).
+ * Listing returns stable tracker URLs; PDF bytes are served via app.js proxy (project docs pattern).
+ */
+
+import { sharePointClient } from './sharepoint-client';
+import { tryDocumentsDriveId } from './documents-drive';
+import { nameToSlug } from './data-layer';
+import type { DocsTreeNode } from '../../types/api-responses';
+
+export const GOVERNANCE_DOCS_ROOT = 'Docs';
+
+interface InternalDocsNode {
+  name: string;
+  slug: string;
+  type: 'folder' | 'file';
+  spPath: string;
+  slugPath: string;
+  children?: InternalDocsNode[];
+}
+
+function folderSlug(name: string): string {
+  return nameToSlug(name);
+}
+
+/** URL segment for a PDF — same rules as profile nameToSlug, keeps .pdf suffix. */
+export function fileSlug(filename: string): string {
+  const match = filename.match(/^(.*)(\.pdf)$/i);
+  if (match) {
+    return `${nameToSlug(match[1])}.pdf`;
+  }
+  return nameToSlug(filename);
+}
+
+function docFileUrl(slugPath: string): string {
+  return `/docs/${slugPath}`;
+}
+
+function toPublicNode(node: InternalDocsNode): DocsTreeNode {
+  if (node.type === 'file') {
+    return {
+      name: node.name,
+      slug: node.slug,
+      type: 'file',
+      url: docFileUrl(node.slugPath),
+    };
+  }
+  return {
+    name: node.name,
+    slug: node.slug,
+    type: 'folder',
+    children: (node.children ?? []).map(toPublicNode),
+  };
+}
+
+async function buildInternalTree(
+  driveId: string,
+  spFolderPath: string,
+  slugSegments: string[],
+): Promise<InternalDocsNode[]> {
+  const children = await sharePointClient.listGovernanceFolderChildren(driveId, spFolderPath);
+  const nodes: InternalDocsNode[] = [];
+
+  for (const child of children) {
+    const childSpPath = `${spFolderPath}/${child.name}`;
+    if (child.isFolder) {
+      const slug = folderSlug(child.name);
+      const slugPath = [...slugSegments, slug].join('/');
+      const grandchildren = await buildInternalTree(driveId, childSpPath, [...slugSegments, slug]);
+      nodes.push({
+        name: child.name,
+        slug,
+        type: 'folder',
+        spPath: childSpPath,
+        slugPath,
+        children: grandchildren,
+      });
+    } else {
+      const slug = fileSlug(child.name);
+      const slugPath = [...slugSegments, slug].join('/');
+      nodes.push({
+        name: child.name,
+        slug,
+        type: 'file',
+        spPath: childSpPath,
+        slugPath,
+      });
+    }
+  }
+
+  return nodes;
+}
+
+let cachedInternalTree: InternalDocsNode[] | null = null;
+
+async function getInternalTree(): Promise<InternalDocsNode[]> {
+  if (cachedInternalTree) return cachedInternalTree;
+  const driveId = tryDocumentsDriveId();
+  if (!driveId) return [];
+  cachedInternalTree = await buildInternalTree(driveId, GOVERNANCE_DOCS_ROOT, []);
+  return cachedInternalTree;
+}
+
+export function clearGovernanceDocsTreeCache(): void {
+  cachedInternalTree = null;
+  sharePointClient.clearGovernanceFolderCache();
+}
+
+export async function getGovernanceDocsTree(): Promise<DocsTreeNode[]> {
+  const tree = await getInternalTree();
+  return tree.map(toPublicNode);
+}
+
+function findBySlugPath(nodes: InternalDocsNode[], segments: string[]): InternalDocsNode | undefined {
+  if (!segments.length) return undefined;
+  const [head, ...rest] = segments;
+  const node = nodes.find(n => n.slug === head);
+  if (!node) return undefined;
+  if (!rest.length) return node;
+  if (node.type !== 'folder' || !node.children) return undefined;
+  return findBySlugPath(node.children, rest);
+}
+
+export async function resolveGovernanceDocSlugPath(slugPath: string): Promise<string | null> {
+  const segments = slugPath.split('/').filter(Boolean);
+  if (!segments.length) return null;
+  const tree = await getInternalTree();
+  const node = findBySlugPath(tree, segments);
+  if (!node || node.type !== 'file') return null;
+  return node.spPath;
+}
+
+export async function fetchGovernanceDocPdf(slugPath: string): Promise<Buffer | null> {
+  const driveId = tryDocumentsDriveId();
+  if (!driveId) return null;
+  const spPath = await resolveGovernanceDocSlugPath(slugPath);
+  if (!spPath) return null;
+  return sharePointClient.downloadFile(driveId, spPath);
+}

--- a/backend/services/governance-docs-service.ts
+++ b/backend/services/governance-docs-service.ts
@@ -6,6 +6,7 @@
 import { sharePointClient } from './sharepoint-client';
 import { tryDocumentsDriveId } from './documents-drive';
 import { nameToSlug } from './data-layer';
+import { isFileProxyCacheValid } from './file-proxy-cache-ttl';
 import type { DocsTreeNode } from '../../types/api-responses';
 
 export const GOVERNANCE_DOCS_ROOT = 'Docs';
@@ -91,14 +92,17 @@ async function buildInternalTree(
   return nodes;
 }
 
-let cachedInternalTree: InternalDocsNode[] | null = null;
+let cachedInternalTree: { tree: InternalDocsNode[]; fetchedAt: number } | null = null;
 
 async function getInternalTree(): Promise<InternalDocsNode[]> {
-  if (cachedInternalTree) return cachedInternalTree;
+  if (cachedInternalTree && isFileProxyCacheValid(cachedInternalTree.fetchedAt)) {
+    return cachedInternalTree.tree;
+  }
   const driveId = tryDocumentsDriveId();
   if (!driveId) return [];
-  cachedInternalTree = await buildInternalTree(driveId, GOVERNANCE_DOCS_ROOT, []);
-  return cachedInternalTree;
+  const tree = await buildInternalTree(driveId, GOVERNANCE_DOCS_ROOT, []);
+  cachedInternalTree = { tree, fetchedAt: Date.now() };
+  return tree;
 }
 
 export function clearGovernanceDocsTreeCache(): void {

--- a/backend/services/media-cache.ts
+++ b/backend/services/media-cache.ts
@@ -1,4 +1,4 @@
-const TTL_MS = 12 * 60 * 60 * 1000; // 12h — within SharePoint pre-auth URL lifetime
+import { isFileProxyCacheValid } from './file-proxy-cache-ttl';
 
 interface CacheEntry {
   data: Buffer;
@@ -11,7 +11,7 @@ const cache = new Map<number, CacheEntry>();
 export function getMediaCache(listItemId: number): CacheEntry | null {
   const entry = cache.get(listItemId);
   if (!entry) return null;
-  if (Date.now() - entry.fetchedAt > TTL_MS) {
+  if (!isFileProxyCacheValid(entry.fetchedAt)) {
     cache.delete(listItemId);
     return null;
   }

--- a/backend/services/project-docs-cache.ts
+++ b/backend/services/project-docs-cache.ts
@@ -6,7 +6,7 @@ interface CacheEntry {
   fetchedAt: number;
 }
 
-/** Keys are `{projectKey}/{driveItemId}`. */
+/** Keys are `{projectKey}/{slugPath}`. */
 const cache = new Map<string, CacheEntry>();
 
 export function getProjectDocCache(cacheKey: string): CacheEntry | null {

--- a/backend/services/project-docs-cache.ts
+++ b/backend/services/project-docs-cache.ts
@@ -1,4 +1,4 @@
-const TTL_MS = 12 * 60 * 60 * 1000; // 12h — within SharePoint pre-auth URL lifetime
+import { isFileProxyCacheValid } from './file-proxy-cache-ttl';
 
 interface CacheEntry {
   data: Buffer;
@@ -12,7 +12,7 @@ const cache = new Map<string, CacheEntry>();
 export function getProjectDocCache(cacheKey: string): CacheEntry | null {
   const entry = cache.get(cacheKey);
   if (!entry) return null;
-  if (Date.now() - entry.fetchedAt > TTL_MS) {
+  if (!isFileProxyCacheValid(entry.fetchedAt)) {
     cache.delete(cacheKey);
     return null;
   }

--- a/backend/services/project-docs-service.ts
+++ b/backend/services/project-docs-service.ts
@@ -1,0 +1,188 @@
+/**
+ * Project documents — reads Projects/{key}/ on the Documents library (DOCUMENTS_DRIVE_ID).
+ * Listing returns a folder tree with stable tracker URLs; bytes are served via app.js proxy.
+ */
+
+import { sharePointClient } from './sharepoint-client';
+import { tryDocumentsDriveId } from './documents-drive';
+import { nameToSlug } from './data-layer';
+import { isFileProxyCacheValid } from './file-proxy-cache-ttl';
+import type { DocsTreeNode } from '../../types/api-responses';
+
+interface InternalProjectDocNode {
+  name: string;
+  slug: string;
+  type: 'folder' | 'file';
+  spPath: string;
+  slugPath: string;
+  itemId?: string;
+  children?: InternalProjectDocNode[];
+}
+
+function folderSlug(name: string): string {
+  return nameToSlug(name);
+}
+
+/** Slug for any project file — nameToSlug on basename, lowercase extension preserved. */
+export function projectFileSlug(filename: string): string {
+  const dot = filename.lastIndexOf('.');
+  if (dot > 0) {
+    return `${nameToSlug(filename.slice(0, dot))}${filename.slice(dot).toLowerCase()}`;
+  }
+  return nameToSlug(filename);
+}
+
+function projectDocsRoot(key: string): string {
+  return `Projects/${key}`;
+}
+
+function projectDocUrl(key: string, slugPath: string): string {
+  return `/projects/${key}/docs/${slugPath}`;
+}
+
+function toPublicNode(key: string, node: InternalProjectDocNode): DocsTreeNode {
+  if (node.type === 'file') {
+    return {
+      name: node.name,
+      slug: node.slug,
+      type: 'file',
+      url: projectDocUrl(key, node.slugPath),
+      id: node.itemId,
+    };
+  }
+  return {
+    name: node.name,
+    slug: node.slug,
+    type: 'folder',
+    children: (node.children ?? []).map(child => toPublicNode(key, child)),
+  };
+}
+
+async function buildInternalTree(
+  driveId: string,
+  spFolderPath: string,
+  slugSegments: string[],
+): Promise<InternalProjectDocNode[]> {
+  const children = await sharePointClient.listProjectDocsFolderChildren(driveId, spFolderPath);
+  const nodes: InternalProjectDocNode[] = [];
+
+  for (const child of children) {
+    const childSpPath = `${spFolderPath}/${child.name}`;
+    if (child.isFolder) {
+      const slug = folderSlug(child.name);
+      const grandchildren = await buildInternalTree(driveId, childSpPath, [...slugSegments, slug]);
+      nodes.push({
+        name: child.name,
+        slug,
+        type: 'folder',
+        spPath: childSpPath,
+        slugPath: [...slugSegments, slug].join('/'),
+        children: grandchildren,
+      });
+    } else {
+      const slug = projectFileSlug(child.name);
+      nodes.push({
+        name: child.name,
+        slug,
+        type: 'file',
+        spPath: childSpPath,
+        slugPath: [...slugSegments, slug].join('/'),
+        itemId: child.id,
+      });
+    }
+  }
+
+  return nodes;
+}
+
+const treeCache = new Map<string, { tree: InternalProjectDocNode[]; fetchedAt: number }>();
+
+async function getInternalTree(projectKey: string): Promise<InternalProjectDocNode[]> {
+  const cached = treeCache.get(projectKey);
+  if (cached && isFileProxyCacheValid(cached.fetchedAt)) {
+    return cached.tree;
+  }
+  const driveId = tryDocumentsDriveId();
+  if (!driveId) return [];
+  const root = projectDocsRoot(projectKey);
+  const tree = await buildInternalTree(driveId, root, []);
+  treeCache.set(projectKey, { tree, fetchedAt: Date.now() });
+  return tree;
+}
+
+export function clearProjectDocsTreeCache(projectKey?: string): void {
+  if (!projectKey) {
+    treeCache.clear();
+    sharePointClient.clearProjectDocsFolderCache();
+    return;
+  }
+  treeCache.delete(projectKey);
+  sharePointClient.clearProjectDocsFolderCache(projectKey);
+}
+
+export async function getProjectDocsTree(projectKey: string): Promise<DocsTreeNode[]> {
+  const tree = await getInternalTree(projectKey);
+  return tree.map(node => toPublicNode(projectKey, node));
+}
+
+function findBySlugPath(nodes: InternalProjectDocNode[], segments: string[]): InternalProjectDocNode | undefined {
+  if (!segments.length) return undefined;
+  const [head, ...rest] = segments;
+  const node = nodes.find(n => n.slug === head);
+  if (!node) return undefined;
+  if (!rest.length) return node;
+  if (node.type !== 'folder' || !node.children) return undefined;
+  return findBySlugPath(node.children, rest);
+}
+
+export async function resolveProjectDocSlugPath(
+  projectKey: string,
+  slugPath: string,
+): Promise<string | null> {
+  const segments = slugPath.split('/').filter(Boolean);
+  if (!segments.length) return null;
+  const tree = await getInternalTree(projectKey);
+  const node = findBySlugPath(tree, segments);
+  if (!node || node.type !== 'file') return null;
+  return node.spPath;
+}
+
+const MIME_BY_EXT: Record<string, string> = {
+  '.pdf': 'application/pdf',
+  '.doc': 'application/msword',
+  '.docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  '.xls': 'application/vnd.ms-excel',
+  '.xlsx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  '.ppt': 'application/vnd.ms-powerpoint',
+  '.pptx': 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  '.txt': 'text/plain',
+  '.csv': 'text/csv',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.png': 'image/png',
+};
+
+function contentTypeForFilename(name: string): string {
+  const dot = name.lastIndexOf('.');
+  if (dot < 0) return 'application/octet-stream';
+  return MIME_BY_EXT[name.slice(dot).toLowerCase()] ?? 'application/octet-stream';
+}
+
+export async function fetchProjectDoc(
+  projectKey: string,
+  slugPath: string,
+): Promise<{ data: Buffer; contentType: string; name: string } | null> {
+  const driveId = tryDocumentsDriveId();
+  if (!driveId) return null;
+  const spPath = await resolveProjectDocSlugPath(projectKey, slugPath);
+  if (!spPath) return null;
+  const data = await sharePointClient.downloadFile(driveId, spPath);
+  if (!data) return null;
+  const name = spPath.split('/').pop() ?? slugPath;
+  return { data, contentType: contentTypeForFilename(name), name };
+}
+
+/** Stable URL for a file uploaded to the project root folder. */
+export function projectDocUrlForFilename(projectKey: string, filename: string): string {
+  return projectDocUrl(projectKey, projectFileSlug(filename));
+}

--- a/backend/services/sharepoint-client.ts
+++ b/backend/services/sharepoint-client.ts
@@ -647,7 +647,7 @@ export class SharePointClient {
       }
 
       items.sort((a, b) => {
-        if (a.isFolder !== b.isFolder) return a.isFolder ? -1 : 1;
+        if (a.isFolder !== b.isFolder) return a.isFolder ? 1 : -1;
         return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
       });
 
@@ -662,6 +662,63 @@ export class SharePointClient {
 
   clearGovernanceFolderCache(): void {
     const keys = this.cache.keys().filter(k => typeof k === 'string' && k.startsWith('gov_docs_folder_'));
+    for (const key of keys) this.cache.del(key);
+  }
+
+  /**
+   * List subfolders and files under a Projects/{key}/ path (all file types).
+   * Returns [] if the folder does not exist.
+   */
+  async listProjectDocsFolderChildren(
+    driveId: string,
+    folderPath: string,
+  ): Promise<Array<{ name: string; isFolder: boolean; id?: string }>> {
+    const cacheKey = `project_docs_folder_${folderPath}`;
+    const cached = this.cache.get(cacheKey);
+    if (cached) {
+      console.log(`[Cache] Hit: ${cacheKey}`);
+      return cached as Array<{ name: string; isFolder: boolean; id?: string }>;
+    }
+
+    try {
+      const token = await this.getAccessToken();
+      const encodedPath = folderPath.split('/').map(encodeURIComponent).join('/');
+      let url: string | undefined =
+        `https://graph.microsoft.com/v1.0/drives/${driveId}/root:/${encodedPath}:/children?$select=name,folder,file,id`;
+
+      const items: Array<{ name: string; isFolder: boolean; id?: string }> = [];
+
+      while (url) {
+        const response = await axios.get(url, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        for (const item of response.data.value as any[]) {
+          if (item.folder && item.name) {
+            items.push({ name: item.name as string, isFolder: true });
+          } else if (item.file && item.name && item.id) {
+            items.push({ name: item.name as string, isFolder: false, id: item.id as string });
+          }
+        }
+        url = response.data['@odata.nextLink'] as string | undefined;
+      }
+
+      items.sort((a, b) => {
+        if (a.isFolder !== b.isFolder) return a.isFolder ? 1 : -1;
+        return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
+      });
+
+      this.cache.set(cacheKey, items, CACHE_TTL.fileProxy);
+      return items;
+    } catch (error: any) {
+      if (error.response?.status === 404) return [];
+      console.error(`Error listing project docs folder at ${folderPath}:`, error.response?.data || error.message);
+      throw error;
+    }
+  }
+
+  clearProjectDocsFolderCache(projectKey?: string): void {
+    const prefix = projectKey ? `project_docs_folder_Projects/${projectKey}` : 'project_docs_folder_';
+    const keys = this.cache.keys().filter(k => typeof k === 'string' && k.startsWith(prefix));
     for (const key of keys) this.cache.del(key);
   }
 

--- a/backend/services/sharepoint-client.ts
+++ b/backend/services/sharepoint-client.ts
@@ -609,6 +609,62 @@ export class SharePointClient {
   }
 
   /**
+   * List subfolders and PDF files under a governance Docs/ path.
+   * Returns [] if the folder does not exist.
+   */
+  async listGovernanceFolderChildren(
+    driveId: string,
+    folderPath: string,
+  ): Promise<Array<{ name: string; isFolder: boolean }>> {
+    const cacheKey = `gov_docs_folder_${folderPath}`;
+    const cached = this.cache.get(cacheKey);
+    if (cached) {
+      console.log(`[Cache] Hit: ${cacheKey}`);
+      return cached as Array<{ name: string; isFolder: boolean }>;
+    }
+
+    try {
+      const token = await this.getAccessToken();
+      const encodedPath = folderPath.split('/').map(encodeURIComponent).join('/');
+      let url: string | undefined =
+        `https://graph.microsoft.com/v1.0/drives/${driveId}/root:/${encodedPath}:/children?$select=name,folder,file`;
+
+      const items: Array<{ name: string; isFolder: boolean }> = [];
+
+      while (url) {
+        const response = await axios.get(url, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        for (const item of response.data.value as any[]) {
+          if (item.folder && item.name) {
+            items.push({ name: item.name as string, isFolder: true });
+          } else if (item.file?.mimeType === 'application/pdf' && item.name) {
+            items.push({ name: item.name as string, isFolder: false });
+          }
+        }
+        url = response.data['@odata.nextLink'] as string | undefined;
+      }
+
+      items.sort((a, b) => {
+        if (a.isFolder !== b.isFolder) return a.isFolder ? -1 : 1;
+        return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
+      });
+
+      this.cache.set(cacheKey, items, CACHE_TTL.projects);
+      return items;
+    } catch (error: any) {
+      if (error.response?.status === 404) return [];
+      console.error(`Error listing governance folder at ${folderPath}:`, error.response?.data || error.message);
+      throw error;
+    }
+  }
+
+  clearGovernanceFolderCache(): void {
+    const keys = this.cache.keys().filter(k => typeof k === 'string' && k.startsWith('gov_docs_folder_'));
+    for (const key of keys) this.cache.del(key);
+  }
+
+  /**
    * Upload a file to a SharePoint document library.
    * Uses the simple PUT upload (suitable for files up to ~4 MB).
    * Graph auto-creates intermediate folders in the path.

--- a/backend/services/sharepoint-client.ts
+++ b/backend/services/sharepoint-client.ts
@@ -8,6 +8,7 @@
 import axios from 'axios';
 import NodeCache from 'node-cache';
 import { DateTime } from 'luxon';
+import { FILE_PROXY_CACHE_TTL_SEC } from './file-proxy-cache-ttl';
 
 // ---------------------------------------------------------------------------
 // Regional date helpers
@@ -71,7 +72,7 @@ export const CACHE_TTL = {
   entries:    300,  //  5 min — check-in tier: live updates on the day
   records:  86400,  // 24 hr  — invalidated on write; rarely changes between sessions
   stats:    86400,  // 24 hr  — recomputed after every entry/session write anyway
-  media:     3600,  //  1 hr  — thumbnail URLs have ~24h token validity; shorter TTL recovers from missed invalidation
+  fileProxy: FILE_PROXY_CACHE_TTL_SEC, //  6 hr — media/doc folder listings; see file-proxy-cache-ttl.ts
   slug:     86400,  // 24 hr  — group+date→ID mappings; cleared on session create/update/delete
 } as const;
 
@@ -533,7 +534,7 @@ export class SharePointClient {
         }))
         .sort((a, b) => a.name.localeCompare(b.name));
 
-      this.cache.set(cacheKey, result, CACHE_TTL.projects);
+      this.cache.set(cacheKey, result, CACHE_TTL.fileProxy);
       return result;
     } catch (error: any) {
       if (error.response?.status === 404) return [];
@@ -650,7 +651,7 @@ export class SharePointClient {
         return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
       });
 
-      this.cache.set(cacheKey, items, CACHE_TTL.projects);
+      this.cache.set(cacheKey, items, CACHE_TTL.fileProxy);
       return items;
     } catch (error: any) {
       if (error.response?.status === 404) return [];
@@ -784,7 +785,7 @@ export class SharePointClient {
           counts.set(item.name as string, item.folder.childCount as number);
         }
       }
-      this.cache.set(cacheKey, counts, CACHE_TTL.media);
+      this.cache.set(cacheKey, counts, CACHE_TTL.fileProxy);
       return counts;
     } catch (error: any) {
       if (error.response?.status === 404) return new Map();
@@ -832,7 +833,7 @@ export class SharePointClient {
           title: (item.listItem?.fields?.Title as string | undefined) || null,
         }));
 
-      this.cache.set(cacheKey, result, CACHE_TTL.media);
+      this.cache.set(cacheKey, result, CACHE_TTL.fileProxy);
       return result;
     } catch (error: any) {
       if (error.response?.status === 404) return [];

--- a/docs/features/backend.md
+++ b/docs/features/backend.md
@@ -48,7 +48,7 @@ Handlebars template system (`templates/email/`). `renderEmail(template, vars)` r
 
 `POST /api/backup/export-all` exports all lists + taxonomy + schema to `Backups/` in the Shared Documents library as JSON. SHA-256 diff check skips unchanged files. Also runs as the final step of the nightly Eventbrite sync.
 
-Project documents live in `Projects/{slug}/` on the Documents library drive (`DOCUMENTS_DRIVE_ID`, same as `Backups/`). `GET /api/projects/:key/attachments` returns `{ id, name, url }` where `url` is a stable app path. Files are served to the public at `GET /projects/:key/files/:itemId` (mirrors `Projects/{key}/` on the drive; no SharePoint login; 6h server / 24h browser cache), matching the session media proxy pattern. Governance PDFs use `/docs/*.pdf` only. Renaming a project key (`PATCH`) moves the drive folder to `Projects/{newKey}/` before updating the list item (409 if the destination folder already exists).
+Project documents live in `Projects/{slug}/` on the Documents library drive (`DOCUMENTS_DRIVE_ID`, same as `Backups/`). Subfolders are supported. `GET /api/projects/:key/attachments` returns a `DocsTreeNode[]` tree (folders + files with slug URLs). Files are served to the public at `GET /projects/:key/docs/{slug-path}` (recursive mirror of `Projects/{key}/`; no SharePoint login; 6h server / 24h browser cache). Governance PDFs use `/docs/*.pdf` only. Renaming a project key (`PATCH`) moves the drive folder to `Projects/{newKey}/` before updating the list item (409 if the destination folder already exists).
 
 ## Stats Pipeline
 

--- a/docs/features/backend.md
+++ b/docs/features/backend.md
@@ -48,7 +48,7 @@ Handlebars template system (`templates/email/`). `renderEmail(template, vars)` r
 
 `POST /api/backup/export-all` exports all lists + taxonomy + schema to `Backups/` in the Shared Documents library as JSON. SHA-256 diff check skips unchanged files. Also runs as the final step of the nightly Eventbrite sync.
 
-Project documents live in `Projects/{slug}/` on the Documents library drive (`DOCUMENTS_DRIVE_ID`, same as `Backups/`). `GET /api/projects/:key/attachments` returns `{ id, name, url }` where `url` is a stable app path. Files are served to the public at `GET /docs/projects/:key/:itemId` (mirrors `Projects/{key}/` on the drive; no SharePoint login; 12h server / 24h browser cache), matching the session media proxy pattern. Renaming a project key (`PATCH`) moves the drive folder to `Projects/{newKey}/` before updating the list item (409 if the destination folder already exists).
+Project documents live in `Projects/{slug}/` on the Documents library drive (`DOCUMENTS_DRIVE_ID`, same as `Backups/`). `GET /api/projects/:key/attachments` returns `{ id, name, url }` where `url` is a stable app path. Files are served to the public at `GET /projects/:key/files/:itemId` (mirrors `Projects/{key}/` on the drive; no SharePoint login; 6h server / 24h browser cache), matching the session media proxy pattern. Governance PDFs use `/docs/*.pdf` only. Renaming a project key (`PATCH`) moves the drive folder to `Projects/{newKey}/` before updating the list item (409 if the destination folder already exists).
 
 ## Stats Pipeline
 

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -93,12 +93,12 @@ Check In and Admin share the **same** base visibility on these pages; **Admin** 
 | GET | `/api/sessions`, `/api/sessions/:group/:date` | No volunteer names/emails |
 | GET | `/api/groups`, `/api/groups/:key` | No regulars list (empty array returned) |
 | GET | `/api/projects`, `/api/projects/:key`, `/api/projects/:key/attachments` | Live all-FY totals from linked sessions; document `url` points at app proxy (not SharePoint) |
-| GET | `/docs/projects/:key/:itemId` | Public download/view of files in `Projects/{key}/` (no auth) |
+| GET | `/projects/:key/files/:itemId` | Public download/view of files in `Projects/{key}/` (no auth) |
 | GET | `/api/tags/*` | Tag metadata only; `?profile=` param requires auth |
 | GET | `/api/media/*` | `isPublic` items only; `name` and `webUrl` fields stripped (contain uploader's name in filename) |
 | GET | `/api/docs` | Governance folder tree from SharePoint `Docs/`; file nodes return stable tracker `url` only |
 | GET | `/docs/*.pdf` | Governance PDF byte proxy (app.js); server-side from Documents library |
-| GET | `/docs/projects/:key/:itemId` | Project document byte proxy (app.js); server-side from `Projects/{key}/` |
+| GET | `/projects/:key/files/:itemId` | Project document byte proxy (app.js); server-side from `Projects/{key}/` |
 
 All other endpoints require authentication (return 401 from `require-auth.ts`).
 
@@ -180,7 +180,7 @@ Check In can make a session photo non-public via `PATCH /media/:itemId`; permane
 
 1. **Role assignment** ([`routes/auth/dtv.ts`](../routes/auth/dtv.ts)): Microsoft callback requires a Profile **`User`** match; else session is destroyed and redirect **`/login?reason=dtv-not-authorised`**. If matched: `ADMIN_USERS` → **`admin`**, else **`checkin`**. Verify flow set **`selfservice`** when Profile **`Email`** matches; no match → `reason=not-approved`. Role is `req.session.user.role`. Public = no session.
 
-2. **Auth middleware** (`middleware/require-auth.ts`): Whitelist of public GET paths (`/api/stats`, `/api/sessions`, `/api/groups`, `/api/projects`, `/api/tags`, `/api/media`, `/api/docs`). All other paths require a session. Page requests redirect to `/login`; API requests return 401. API key auth bypasses this for `/api/eventbrite/` paths. Document proxies at `/docs/*.pdf` and `/docs/projects/:key/:itemId` require no session.
+2. **Auth middleware** (`middleware/require-auth.ts`): Whitelist of public GET paths (`/api/stats`, `/api/sessions`, `/api/groups`, `/api/projects`, `/api/tags`, `/api/media`, `/api/docs`). All other paths require a session. Page requests redirect to `/login`; API requests return 401. API key auth bypasses this for `/api/eventbrite/` paths. Document proxies at `/docs/*.pdf` and `/projects/:key/files/:itemId` require no session.
 
 3. **Role enforcement** (`middleware/require-admin.ts`): After `requireAuth` on API routes:
    - **Public GETs** (same path set as `require-auth.ts`, resolved with `baseUrl` + `path` inside the `/api` mount): **always** allowed without a session user so anonymous and post-logout home/session list loads are not blocked.

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -96,6 +96,9 @@ Check In and Admin share the **same** base visibility on these pages; **Admin** 
 | GET | `/docs/projects/:key/:itemId` | Public download/view of files in `Projects/{key}/` (no auth) |
 | GET | `/api/tags/*` | Tag metadata only; `?profile=` param requires auth |
 | GET | `/api/media/*` | `isPublic` items only; `name` and `webUrl` fields stripped (contain uploader's name in filename) |
+| GET | `/api/docs` | Governance folder tree from SharePoint `Docs/`; file nodes return stable tracker `url` only |
+| GET | `/docs/*.pdf` | Governance PDF byte proxy (app.js); server-side from Documents library |
+| GET | `/docs/projects/:key/:itemId` | Project document byte proxy (app.js); server-side from `Projects/{key}/` |
 
 All other endpoints require authentication (return 401 from `require-auth.ts`).
 
@@ -177,7 +180,7 @@ Check In can make a session photo non-public via `PATCH /media/:itemId`; permane
 
 1. **Role assignment** ([`routes/auth/dtv.ts`](../routes/auth/dtv.ts)): Microsoft callback requires a Profile **`User`** match; else session is destroyed and redirect **`/login?reason=dtv-not-authorised`**. If matched: `ADMIN_USERS` → **`admin`**, else **`checkin`**. Verify flow set **`selfservice`** when Profile **`Email`** matches; no match → `reason=not-approved`. Role is `req.session.user.role`. Public = no session.
 
-2. **Auth middleware** (`middleware/require-auth.ts`): Whitelist of public GET paths (`/api/stats`, `/api/sessions`, `/api/groups`, `/api/projects`, `/api/tags`, `/api/media`). All other paths require a session. Page requests redirect to `/login`; API requests return 401. API key auth bypasses this for `/api/eventbrite/` paths.
+2. **Auth middleware** (`middleware/require-auth.ts`): Whitelist of public GET paths (`/api/stats`, `/api/sessions`, `/api/groups`, `/api/projects`, `/api/tags`, `/api/media`, `/api/docs`). All other paths require a session. Page requests redirect to `/login`; API requests return 401. API key auth bypasses this for `/api/eventbrite/` paths. Document proxies at `/docs/*.pdf` and `/docs/projects/:key/:itemId` require no session.
 
 3. **Role enforcement** (`middleware/require-admin.ts`): After `requireAuth` on API routes:
    - **Public GETs** (same path set as `require-auth.ts`, resolved with `baseUrl` + `path` inside the `/api` mount): **always** allowed without a session user so anonymous and post-logout home/session list loads are not blocked.

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -92,13 +92,13 @@ Check In and Admin share the **same** base visibility on these pages; **Admin** 
 | GET | `/api/stats` | No PII |
 | GET | `/api/sessions`, `/api/sessions/:group/:date` | No volunteer names/emails |
 | GET | `/api/groups`, `/api/groups/:key` | No regulars list (empty array returned) |
-| GET | `/api/projects`, `/api/projects/:key`, `/api/projects/:key/attachments` | Live all-FY totals from linked sessions; document `url` points at app proxy (not SharePoint) |
-| GET | `/projects/:key/files/:itemId` | Public download/view of files in `Projects/{key}/` (no auth) |
+| GET | `/api/projects`, `/api/projects/:key`, `/api/projects/:key/attachments` | Live all-FY totals from linked sessions; attachments returns docs tree with slug URLs |
+| GET | `/projects/:key/docs/*` | Public download/view of files in `Projects/{key}/` (no auth; slug path) |
 | GET | `/api/tags/*` | Tag metadata only; `?profile=` param requires auth |
 | GET | `/api/media/*` | `isPublic` items only; `name` and `webUrl` fields stripped (contain uploader's name in filename) |
 | GET | `/api/docs` | Governance folder tree from SharePoint `Docs/`; file nodes return stable tracker `url` only |
 | GET | `/docs/*.pdf` | Governance PDF byte proxy (app.js); server-side from Documents library |
-| GET | `/projects/:key/files/:itemId` | Project document byte proxy (app.js); server-side from `Projects/{key}/` |
+| GET | `/projects/:key/docs/*` | Project document byte proxy (app.js); slug-resolved from `Projects/{key}/` tree |
 
 All other endpoints require authentication (return 401 from `require-auth.ts`).
 
@@ -180,7 +180,7 @@ Check In can make a session photo non-public via `PATCH /media/:itemId`; permane
 
 1. **Role assignment** ([`routes/auth/dtv.ts`](../routes/auth/dtv.ts)): Microsoft callback requires a Profile **`User`** match; else session is destroyed and redirect **`/login?reason=dtv-not-authorised`**. If matched: `ADMIN_USERS` → **`admin`**, else **`checkin`**. Verify flow set **`selfservice`** when Profile **`Email`** matches; no match → `reason=not-approved`. Role is `req.session.user.role`. Public = no session.
 
-2. **Auth middleware** (`middleware/require-auth.ts`): Whitelist of public GET paths (`/api/stats`, `/api/sessions`, `/api/groups`, `/api/projects`, `/api/tags`, `/api/media`, `/api/docs`). All other paths require a session. Page requests redirect to `/login`; API requests return 401. API key auth bypasses this for `/api/eventbrite/` paths. Document proxies at `/docs/*.pdf` and `/projects/:key/files/:itemId` require no session.
+2. **Auth middleware** (`middleware/require-auth.ts`): Whitelist of public GET paths (`/api/stats`, `/api/sessions`, `/api/groups`, `/api/projects`, `/api/tags`, `/api/media`, `/api/docs`). All other paths require a session. Page requests redirect to `/login`; API requests return 401. API key auth bypasses this for `/api/eventbrite/` paths. Document proxies at `/docs/*.pdf` and `/projects/:key/docs/*` require no session.
 
 3. **Role enforcement** (`middleware/require-admin.ts`): After `requireAuth` on API routes:
    - **Public GETs** (same path set as `require-auth.ts`, resolved with `baseUrl` + `path` inside the `/api` mount): **always** allowed without a session user so anonymous and post-logout home/session list loads are not blocked.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,5 +1,9 @@
 # Development Progress
 
+## Session: 2026-06-09 (File proxy cache TTL unification)
+
+- Shared **6 hr** TTL in `file-proxy-cache-ttl.ts` for session media, project docs, and governance docs (folder listings + proxied bytes + governance tree).
+
 ## Session: 2026-06-09 (Public governance Docs page)
 
 - Public **Docs** page at `/docs` and burger menu link; reads SharePoint `Docs/` from Documents library (`DOCUMENTS_DRIVE_ID`).

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,5 +1,11 @@
 # Development Progress
 
+## Session: 2026-06-10 (Project docs tree + RR prep)
+
+- Project attachments API returns `DocsTreeNode[]`; byte proxy at `/projects/:key/docs/{slug-path}` (recursive `Projects/{key}/` mirror).
+- `ProjectDocsCard` reuses `DocsSection` (same hierarchy/lozenges as governance Docs); admin delete via file `id`.
+- Listing order: files before folders, alphabetical within each level; project card typography aligned with Totals hero + stepped folder headings.
+
 ## Session: 2026-06-09 (File proxy cache TTL unification)
 
 - Shared **6 hr** TTL in `file-proxy-cache-ttl.ts` for session media, project docs, and governance docs (folder listings + proxied bytes + governance tree).
@@ -7,7 +13,7 @@
 ## Session: 2026-06-09 (Public governance Docs page)
 
 - Public **Docs** page at `/docs` and burger menu link; reads SharePoint `Docs/` from Documents library (`DOCUMENTS_DRIVE_ID`).
-- `GET /api/docs` + `GET /docs/*.pdf` byte proxy (project files use `/projects/:key/files/:itemId`).
+- `GET /api/docs` + `GET /docs/*.pdf` byte proxy; project docs tree at `/api/projects/:key/attachments` with `/projects/:key/docs/{slug-path}` proxy.
 - Lozenge file links (`DocLozengeLink.vue`); heading hierarchy H2/H3/bold; slug paths via `nameToSlug`.
 
 ## Session: 2026-05-21 (Project documents via Graph; DOCUMENTS_DRIVE_ID)

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -7,7 +7,7 @@
 ## Session: 2026-06-09 (Public governance Docs page)
 
 - Public **Docs** page at `/docs` and burger menu link; reads SharePoint `Docs/` from Documents library (`DOCUMENTS_DRIVE_ID`).
-- `GET /api/docs` + `GET /docs/*.pdf` byte proxy (same pattern as `/docs/projects/:key/:itemId`).
+- `GET /api/docs` + `GET /docs/*.pdf` byte proxy (project files use `/projects/:key/files/:itemId`).
 - Lozenge file links (`DocLozengeLink.vue`); heading hierarchy H2/H3/bold; slug paths via `nameToSlug`.
 
 ## Session: 2026-05-21 (Project documents via Graph; DOCUMENTS_DRIVE_ID)

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,5 +1,11 @@
 # Development Progress
 
+## Session: 2026-06-09 (Public governance Docs page)
+
+- Public **Docs** page at `/docs` and burger menu link; reads SharePoint `Docs/` from Documents library (`DOCUMENTS_DRIVE_ID`).
+- `GET /api/docs` + `GET /docs/*.pdf` byte proxy (same pattern as `/docs/projects/:key/:itemId`).
+- Lozenge file links (`DocLozengeLink.vue`); heading hierarchy H2/H3/bold; slug paths via `nameToSlug`.
+
 ## Session: 2026-05-21 (Project documents via Graph; DOCUMENTS_DRIVE_ID)
 
 - Project files: `Projects/{slug}/` in Documents library (top level beside `Backups/`), via Graph.

--- a/docs/testing/full-regression.md
+++ b/docs/testing/full-regression.md
@@ -16,6 +16,9 @@ Run with `npm run dev` at http://localhost:3000. Log in via Microsoft Entra ID.
 - [ ] Unauthenticated visit to `/` (homepage) loads without redirect — stats, sessions, groups nav cards visible; volunteers nav card hidden; admin button hidden; header shows "Log in" button
 - [ ] Unauthenticated visit to `/sessions` loads without redirect
 - [ ] Unauthenticated visit to `/groups` loads without redirect; regulars count shows 0
+- [ ] Unauthenticated visit to `/docs` loads without redirect; burger menu shows **Docs** link
+- [ ] `/docs` lists governance folders from SharePoint `Docs/` (H2/H3/bold hierarchy); PDF lozenge opens via tracker URL (`/docs/.../file.pdf`), not SharePoint
+- [ ] `/docs/health-and-safety` scrolls to Health and Safety section (v1: full tree + scroll-to)
 - [ ] Unauthenticated visit to `/groups/:key` loads without redirect; regulars section hidden
 - [ ] Unauthenticated visit to `/sessions/:group/:date` loads; entries section and free parking card hidden
 - [ ] Unauthenticated visit to `/profiles` redirects to `/login` (trusted route)

--- a/docs/testing/full-regression.md
+++ b/docs/testing/full-regression.md
@@ -432,8 +432,12 @@ Run with `npm run dev` at http://localhost:3000. Log in via Microsoft Entra ID.
 
 ### M3b. Project detail
 - [ ] `GET /api/projects/:key` — live all-FY session/hour totals + linked sessions (sessions with `ProjectLookupId` set in SharePoint)
-- [ ] `GET /api/projects/:key/attachments` — `{ id, name, url }` with `url` like `/projects/{key}/files/{itemId}` (not SharePoint `webUrl`)
+- [ ] `GET /api/projects/:key/attachments` — `DocsTreeNode[]` tree; file `url` like `/projects/{key}/docs/{slug-path}` (not SharePoint `webUrl`); subfolders shown as nested sections
+- [ ] Project detail Documents card: root files listed **above** folder headings; files and folders alphabetically sorted at each level
+- [ ] Documents section title matches Totals hero font (dark, not gold); folder headings one step smaller
+- [ ] SharePoint subfolders under `Projects/{key}/` appear nested (e.g. `drafts/`, `sketches/`) with files inside each section
 - [ ] **Public**: open a document `url` while logged out — file loads via app proxy (PDF/images inline); no SharePoint sign-in
+- [ ] Governance PDF under `Docs/Projects/…` opens at `/docs/projects/…/file.pdf` (not caught by project proxy)
 - [ ] Upload/delete project doc — list updates; re-open same `url` shows new file or 404 after delete
 - [ ] Public project detail: Documents card hidden when folder empty
 - [ ] Admin: Upload docs button; files appear as lozenges; × removes file
@@ -442,7 +446,7 @@ Run with `npm run dev` at http://localhost:3000. Log in via Microsoft Entra ID.
 - [ ] Stats card: sessions + hours (all linked sessions, all FYs)
 - [ ] Carousel: cover photos from linked sessions (newest first)
 - [ ] Admin: edit display name/key/description (display name required; Save disabled if empty); renaming key to an existing project key returns 409; delete project
-- [ ] Admin: rename project key when documents exist — `Projects/{old}/` folder moves to `Projects/{new}/`; documents still listed and `/projects/{new}/files/…` URLs work
+- [ ] Admin: rename project key when documents exist — `Projects/{old}/` folder moves to `Projects/{new}/`; documents still listed and `/projects/{new}/docs/…` URLs work
 
 ### M4. Group detail
 - [ ] `GET /api/groups/:key` — stats, regulars, sessions for the group

--- a/docs/testing/full-regression.md
+++ b/docs/testing/full-regression.md
@@ -432,7 +432,7 @@ Run with `npm run dev` at http://localhost:3000. Log in via Microsoft Entra ID.
 
 ### M3b. Project detail
 - [ ] `GET /api/projects/:key` — live all-FY session/hour totals + linked sessions (sessions with `ProjectLookupId` set in SharePoint)
-- [ ] `GET /api/projects/:key/attachments` — `{ id, name, url }` with `url` like `/docs/projects/{key}/{itemId}` (not SharePoint `webUrl`)
+- [ ] `GET /api/projects/:key/attachments` — `{ id, name, url }` with `url` like `/projects/{key}/files/{itemId}` (not SharePoint `webUrl`)
 - [ ] **Public**: open a document `url` while logged out — file loads via app proxy (PDF/images inline); no SharePoint sign-in
 - [ ] Upload/delete project doc — list updates; re-open same `url` shows new file or 404 after delete
 - [ ] Public project detail: Documents card hidden when folder empty
@@ -442,7 +442,7 @@ Run with `npm run dev` at http://localhost:3000. Log in via Microsoft Entra ID.
 - [ ] Stats card: sessions + hours (all linked sessions, all FYs)
 - [ ] Carousel: cover photos from linked sessions (newest first)
 - [ ] Admin: edit display name/key/description (display name required; Save disabled if empty); renaming key to an existing project key returns 409; delete project
-- [ ] Admin: rename project key when documents exist — `Projects/{old}/` folder moves to `Projects/{new}/`; documents still listed and `/docs/projects/{new}/…` URLs work
+- [ ] Admin: rename project key when documents exist — `Projects/{old}/` folder moves to `Projects/{new}/`; documents still listed and `/projects/{new}/files/…` URLs work
 
 ### M4. Group detail
 - [ ] `GET /api/groups/:key` — stats, regulars, sessions for the group

--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -22,6 +22,7 @@
           <RouterLink to="/sessions" @click="open = false" class="text-white font-bold uppercase tracking-wide text-sm py-3 border-b border-white/10 hover:text-dtv-green transition-colors">Sessions</RouterLink>
           <RouterLink to="/groups" @click="open = false" class="text-white font-bold uppercase tracking-wide text-sm py-3 border-b border-white/10 hover:text-dtv-green transition-colors">Groups</RouterLink>
           <RouterLink to="/projects" @click="open = false" class="text-white font-bold uppercase tracking-wide text-sm py-3 border-b border-white/10 hover:text-dtv-green transition-colors">Projects</RouterLink>
+          <RouterLink to="/docs" @click="open = false" class="text-white font-bold uppercase tracking-wide text-sm py-3 border-b border-white/10 hover:text-dtv-green transition-colors">Docs</RouterLink>
           <RouterLink v-if="profile.isTrusted" to="/profiles" @click="open = false" class="text-white font-bold uppercase tracking-wide text-sm py-3 border-b border-white/10 hover:text-dtv-green transition-colors">Profiles</RouterLink>
           <RouterLink v-if="profile.isAdmin" to="/entries" @click="open = false" class="text-white font-bold uppercase tracking-wide text-sm py-3 border-b border-white/10 hover:text-dtv-green transition-colors">Entries</RouterLink>
           <RouterLink v-if="profile.isAdmin" :to="toolsPath()" @click="open = false" class="text-white font-bold uppercase tracking-wide text-sm py-3 border-b border-white/10 hover:text-dtv-green transition-colors">{{ ACCESS_LABEL_ADMIN_TOOLS_PAGE }}</RouterLink>

--- a/frontend/src/components/docs/DocLozengeLink.vue
+++ b/frontend/src/components/docs/DocLozengeLink.vue
@@ -1,0 +1,39 @@
+<template>
+  <span
+    class="pdc-lozenge"
+    :class="{ 'pdc-lozenge-deleting': deleting, 'pdc-lozenge--removable': removable }"
+  >
+    <a
+      :href="url"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="pdc-name"
+      :title="label"
+    >{{ displayLabel }}</a>
+    <button
+      v-if="removable"
+      type="button"
+      class="pdc-remove"
+      aria-label="Remove document"
+      :disabled="deleting"
+      @click="emit('remove')"
+    >
+      <img src="/icons/close.svg" width="10" height="10" alt="" class="svg-black" />
+    </button>
+  </span>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = defineProps<{
+  label: string
+  url: string
+  removable?: boolean
+  deleting?: boolean
+}>()
+
+const emit = defineEmits<{ remove: [] }>()
+
+const displayLabel = computed(() => props.label.replace(/\.pdf$/i, ''))
+</script>

--- a/frontend/src/components/docs/DocLozengeLink.vue
+++ b/frontend/src/components/docs/DocLozengeLink.vue
@@ -35,5 +35,8 @@ const props = defineProps<{
 
 const emit = defineEmits<{ remove: [] }>()
 
-const displayLabel = computed(() => props.label.replace(/\.pdf$/i, ''))
+const displayLabel = computed(() => {
+  const dot = props.label.lastIndexOf('.')
+  return dot > 0 ? props.label.slice(0, dot) : props.label
+})
 </script>

--- a/frontend/src/components/docs/DocsSection.test.ts
+++ b/frontend/src/components/docs/DocsSection.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { createApp } from 'vue'
+import DocsSection from './DocsSection.vue'
+import '../../styles/main.css'
+import type { DocsTreeNode } from '../../../../types/api-responses'
+
+const skiRunTree: DocsTreeNode[] = [
+  { name: 'map.png', slug: 'map.png', type: 'file', url: '/projects/ski-run-27/docs/map.png', id: '1' },
+  {
+    name: 'drafts',
+    slug: 'drafts',
+    type: 'folder',
+    children: [
+      { name: 'Ski Run 2027.pptx', slug: 'ski-run-2027.pptx', type: 'file', url: '/projects/ski-run-27/docs/drafts/ski-run-2027.pptx', id: '2' },
+    ],
+  },
+]
+
+describe('DocsSection', () => {
+  it('renders root and nested file lozenges', () => {
+    const root = document.createElement('div')
+    const app = createApp(DocsSection, { nodes: skiRunTree, depth: 0, subsectionHeadings: true })
+    app.mount(root)
+    expect(root.querySelectorAll('.pdc-lozenge').length).toBe(2)
+    expect(root.querySelectorAll('.pdc-grid').length).toBe(2)
+    app.unmount()
+  })
+})

--- a/frontend/src/components/docs/DocsSection.vue
+++ b/frontend/src/components/docs/DocsSection.vue
@@ -1,0 +1,62 @@
+<template>
+  <section
+    v-for="node in folderNodes"
+    :key="node.slug"
+    :id="sectionId(node)"
+    class="docs-folder"
+  >
+    <h2 v-if="headingLevel === 2" class="text-xl font-bold mb-2 mt-6">{{ node.name }}</h2>
+    <h3 v-else-if="headingLevel === 3" class="text-lg font-bold mb-2 mt-4">{{ node.name }}</h3>
+    <p v-else class="font-bold mb-2 mt-3">{{ node.name }}</p>
+
+    <DocsSection
+      v-if="node.children?.length"
+      :nodes="node.children"
+      :depth="depth + 1"
+      :prefix="sectionId(node)"
+    />
+  </section>
+
+  <div v-if="fileNodes.length" class="pdc-grid docs-file-grid">
+    <DocLozengeLink
+      v-for="file in fileNodes"
+      :key="file.slug"
+      :label="file.name"
+      :url="file.url!"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { DocsTreeNode } from '../../../../types/api-responses'
+import DocLozengeLink from './DocLozengeLink.vue'
+
+defineOptions({ name: 'DocsSection' })
+
+const props = defineProps<{
+  nodes: DocsTreeNode[]
+  depth: number
+  prefix?: string
+}>()
+
+const folderNodes = computed(() => props.nodes.filter(n => n.type === 'folder'))
+const fileNodes = computed(() => props.nodes.filter(n => n.type === 'file' && n.url))
+
+const headingLevel = computed(() => {
+  if (props.depth === 0) return 2
+  if (props.depth === 1) return 3
+  return 0
+})
+
+function sectionId(node: DocsTreeNode): string {
+  const segment = node.slug
+  return props.prefix ? `${props.prefix}/${segment}` : segment
+}
+</script>
+
+<style scoped>
+.docs-file-grid {
+  margin-bottom: 0.75rem;
+}
+</style>

--- a/frontend/src/components/docs/DocsSection.vue
+++ b/frontend/src/components/docs/DocsSection.vue
@@ -1,30 +1,46 @@
 <template>
-  <section
-    v-for="node in folderNodes"
-    :key="node.slug"
-    :id="sectionId(node)"
-    class="docs-folder"
-  >
-    <h2 v-if="headingLevel === 2" class="text-xl font-bold mb-2 mt-6">{{ node.name }}</h2>
-    <h3 v-else-if="headingLevel === 3" class="text-lg font-bold mb-2 mt-4">{{ node.name }}</h3>
-    <p v-else class="font-bold mb-2 mt-3">{{ node.name }}</p>
-
-    <DocsSection
-      v-if="node.children?.length"
-      :nodes="node.children"
-      :depth="depth + 1"
-      :prefix="sectionId(node)"
-    />
-  </section>
-
   <div v-if="fileNodes.length" class="pdc-grid docs-file-grid">
     <DocLozengeLink
       v-for="file in fileNodes"
       :key="file.slug"
       :label="file.name"
       :url="file.url!"
+      :removable="allowManage && !!file.id"
+      :deleting="!!file.id && deletingIds?.has(file.id)"
+      @remove="file.id && emit('delete', file.id)"
     />
   </div>
+
+  <section
+    v-for="node in folderNodes"
+    :key="node.slug"
+    :id="sectionId(node)"
+    class="docs-folder"
+  >
+    <h3
+      v-if="folderHeadingLevel === 3"
+      :class="folderHeadingClass(3)"
+    >{{ node.name }}</h3>
+    <h4
+      v-else-if="folderHeadingLevel === 4"
+      :class="folderHeadingClass(4)"
+    >{{ node.name }}</h4>
+    <p
+      v-else
+      :class="folderHeadingClass(0)"
+    >{{ node.name }}</p>
+
+    <DocsSection
+      v-if="node.children?.length"
+      :nodes="node.children"
+      :depth="depth + 1"
+      :prefix="sectionId(node)"
+      :subsection-headings="subsectionHeadings"
+      :allow-manage="allowManage"
+      :deleting-ids="deletingIds"
+      @delete="emit('delete', $event)"
+    />
+  </section>
 </template>
 
 <script setup lang="ts">
@@ -38,16 +54,40 @@ const props = defineProps<{
   nodes: DocsTreeNode[]
   depth: number
   prefix?: string
+  /** When true (project detail card), folder headings sit below a hero section title. */
+  subsectionHeadings?: boolean
+  allowManage?: boolean
+  deletingIds?: Set<string>
 }>()
 
-const folderNodes = computed(() => props.nodes.filter(n => n.type === 'folder'))
-const fileNodes = computed(() => props.nodes.filter(n => n.type === 'file' && n.url))
+const emit = defineEmits<{ delete: [itemId: string] }>()
 
-const headingLevel = computed(() => {
-  if (props.depth === 0) return 2
-  if (props.depth === 1) return 3
+const byName = (a: DocsTreeNode, b: DocsTreeNode) =>
+  a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
+
+const fileNodes = computed(() =>
+  props.nodes.filter(n => n.type === 'file' && n.url).sort(byName)
+)
+const folderNodes = computed(() =>
+  props.nodes.filter(n => n.type === 'folder').sort(byName)
+)
+
+const folderHeadingLevel = computed(() => {
+  if (props.depth === 0) return 3
+  if (props.depth === 1) return 4
   return 0
 })
+
+function folderHeadingClass(level: 0 | 3 | 4): string {
+  if (props.subsectionHeadings) {
+    if (level === 3) return 'text-base font-bold mb-2 mt-4'
+    if (level === 4) return 'text-sm font-bold mb-2 mt-3'
+    return 'text-sm font-bold mb-2 mt-2'
+  }
+  if (level === 3) return 'text-xl font-bold mb-2 mt-6'
+  if (level === 4) return 'text-lg font-bold mb-2 mt-4'
+  return 'font-bold mb-2 mt-3'
+}
 
 function sectionId(node: DocsTreeNode): string {
   const segment = node.slug

--- a/frontend/src/components/projects/ProjectDocsCard.test.ts
+++ b/frontend/src/components/projects/ProjectDocsCard.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { createApp } from 'vue'
+import ProjectDocsCard from './ProjectDocsCard.vue'
+import '../../styles/main.css'
+import type { DocsTreeNode } from '../../../../types/api-responses'
+
+const tree: DocsTreeNode[] = [
+  { name: 'map.png', slug: 'map.png', type: 'file', url: '/projects/ski-run-27/docs/map.png', id: '1' },
+  {
+    name: 'sketches',
+    slug: 'sketches',
+    type: 'folder',
+    children: [
+      { name: 'sr01.png', slug: 'sr01.png', type: 'file', url: '/projects/ski-run-27/docs/sketches/sr01.png', id: '2' },
+    ],
+  },
+]
+
+describe('ProjectDocsCard', () => {
+  it('renders file lozenges when tree has files', () => {
+    const grid = document.createElement('div')
+    grid.style.display = 'grid'
+    grid.style.gridTemplateColumns = '1fr 2fr'
+    grid.style.alignItems = 'start'
+    const left = document.createElement('div')
+    left.style.height = '120px'
+    left.textContent = 'Totals'
+    const right = document.createElement('div')
+    right.className = 'min-w-0 self-stretch'
+    grid.append(left, right)
+
+    const app = createApp(ProjectDocsCard, {
+      tree,
+      projectKey: 'ski-run-27',
+      loading: false,
+      allowManage: true,
+    })
+    app.mount(right)
+
+    expect(right.querySelectorAll('.pdc-lozenge').length).toBe(2)
+    app.unmount()
+  })
+})

--- a/frontend/src/components/projects/ProjectDocsCard.vue
+++ b/frontend/src/components/projects/ProjectDocsCard.vue
@@ -19,36 +19,22 @@
     <p v-else-if="allowManage && !attachments.length" class="pdc-empty">No documents yet.</p>
 
     <div v-else-if="attachments.length" class="pdc-grid">
-      <span
+      <DocLozengeLink
         v-for="doc in attachments"
         :key="doc.id"
-        class="pdc-lozenge"
-        :class="{ 'pdc-lozenge-deleting': props.deletingIds.has(doc.id) }"
-      >
-        <a
-          :href="doc.url"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="pdc-name"
-          :title="doc.name"
-        >{{ doc.name }}</a>
-        <button
-          v-if="allowManage"
-          type="button"
-          class="pdc-remove"
-          aria-label="Remove document"
-          :disabled="props.deletingIds.has(doc.id)"
-          @click="onDelete(doc.id)"
-        >
-          <img src="/icons/close.svg" width="10" height="10" alt="" class="svg-black" />
-        </button>
-      </span>
+        :label="doc.name"
+        :url="doc.url"
+        :removable="allowManage"
+        :deleting="props.deletingIds.has(doc.id)"
+        @remove="onDelete(doc.id)"
+      />
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import AppButton from '../AppButton.vue'
+import DocLozengeLink from '../docs/DocLozengeLink.vue'
 import LoadingSpinner from '../LoadingSpinner.vue'
 import { projectUploadPath } from '../../router/index'
 import type { ProjectAttachmentResponse } from '../../../../types/api-responses'
@@ -106,61 +92,4 @@ function onDelete(itemId: string) {
   color: var(--color-dtv-dirt);
 }
 
-.pdc-grid {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-}
-
-.pdc-lozenge {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  background: var(--color-dtv-sand);
-  padding: 0.5rem 0.75rem;
-  border: 2px solid transparent;
-  max-width: 100%;
-}
-
-.pdc-lozenge:hover {
-  background: var(--color-dtv-sand-dark);
-}
-
-.pdc-lozenge-deleting {
-  opacity: 0.55;
-}
-
-.pdc-name {
-  font-size: 0.9rem;
-  color: var(--color-text);
-  text-decoration: none;
-  max-width: 14rem;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.pdc-name:hover {
-  text-decoration: underline;
-}
-
-.pdc-remove {
-  background: none;
-  border: none;
-  cursor: pointer;
-  padding: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-}
-
-.pdc-remove:hover img {
-  filter: invert(20%) sepia(95%) saturate(5000%) hue-rotate(0deg) brightness(90%) contrast(90%);
-}
-
-.pdc-remove:disabled {
-  cursor: wait;
-  opacity: 0.5;
-}
 </style>

--- a/frontend/src/components/projects/ProjectDocsCard.vue
+++ b/frontend/src/components/projects/ProjectDocsCard.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="pdc-wrap">
     <div class="pdc-header">
-      <h3 class="pdc-title">Documents</h3>
+      <h2 class="font-hero text-dtv-dark text-xl uppercase leading-none m-0">Documents</h2>
       <AppButton
         v-if="allowManage && projectKey"
         label="Upload docs"
@@ -16,32 +16,33 @@
 
     <p v-else-if="error" class="pdc-error">{{ error }}</p>
 
-    <p v-else-if="allowManage && !attachments.length" class="pdc-empty">No documents yet.</p>
+    <p v-else-if="allowManage && !hasFiles" class="pdc-empty">No documents yet.</p>
 
-    <div v-else-if="attachments.length" class="pdc-grid">
-      <DocLozengeLink
-        v-for="doc in attachments"
-        :key="doc.id"
-        :label="doc.name"
-        :url="doc.url"
-        :removable="allowManage"
-        :deleting="props.deletingIds.has(doc.id)"
-        @remove="onDelete(doc.id)"
+    <div v-else-if="hasFiles" class="pdc-tree">
+      <DocsSection
+        :nodes="tree"
+        :depth="0"
+        subsection-headings
+        :allow-manage="allowManage"
+        :deleting-ids="deletingIds"
+        @delete="onDelete"
       />
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
 import AppButton from '../AppButton.vue'
-import DocLozengeLink from '../docs/DocLozengeLink.vue'
+import DocsSection from '../docs/DocsSection.vue'
 import LoadingSpinner from '../LoadingSpinner.vue'
 import { projectUploadPath } from '../../router/index'
-import type { ProjectAttachmentResponse } from '../../../../types/api-responses'
+import { docsTreeHasFiles } from '../../utils/docsTree'
+import type { DocsTreeNode } from '../../../../types/api-responses'
 
 const props = withDefaults(
   defineProps<{
-    attachments: ProjectAttachmentResponse[]
+    tree: DocsTreeNode[]
     projectKey: string
     loading?: boolean
     error?: string | null
@@ -52,6 +53,8 @@ const props = withDefaults(
 )
 
 const emit = defineEmits<{ delete: [itemId: string] }>()
+
+const hasFiles = computed(() => docsTreeHasFiles(props.tree))
 
 function onDelete(itemId: string) {
   emit('delete', itemId)
@@ -70,14 +73,7 @@ function onDelete(itemId: string) {
   align-items: center;
   justify-content: space-between;
   gap: 0.75rem;
-  margin-bottom: 0.75rem;
-}
-
-.pdc-title {
-  font-size: 1rem;
-  font-weight: 700;
-  margin: 0;
-  color: var(--color-dtv-dark);
+  margin-bottom: 1rem;
 }
 
 .pdc-empty {
@@ -91,5 +87,4 @@ function onDelete(itemId: string) {
   font-size: 0.85rem;
   color: var(--color-dtv-dirt);
 }
-
 </style>

--- a/frontend/src/pages/DocsPage.vue
+++ b/frontend/src/pages/DocsPage.vue
@@ -1,0 +1,63 @@
+<template>
+  <DefaultLayout>
+    <h1 class="sr-only">Docs</h1>
+    <PageHeader>Docs</PageHeader>
+    <div class="px-6 pt-4 pb-8">
+      <p v-if="loading" class="text-sm text-gray-500">Loading documents…</p>
+      <p v-else-if="error" class="text-sm text-red-600">{{ error }}</p>
+      <p v-else-if="!tree.length" class="text-sm text-gray-500">No documents available.</p>
+      <div v-else class="text-black">
+        <DocsSection :nodes="tree" :depth="0" />
+      </div>
+    </div>
+  </DefaultLayout>
+</template>
+
+<script setup lang="ts">
+import { ref, watch, nextTick } from 'vue'
+import { useRoute } from 'vue-router'
+import DefaultLayout from '../layouts/DefaultLayout.vue'
+import PageHeader from '../components/PageHeader.vue'
+import DocsSection from '../components/docs/DocsSection.vue'
+import { usePageTitle } from '../composables/usePageTitle'
+import type { DocsTreeNode } from '../../../types/api-responses'
+
+usePageTitle('Docs')
+
+const route = useRoute()
+const tree = ref<DocsTreeNode[]>([])
+const loading = ref(true)
+const error = ref('')
+
+async function loadTree() {
+  loading.value = true
+  error.value = ''
+  try {
+    const res = await fetch('/api/docs')
+    if (!res.ok) throw new Error(`Failed to load docs (${res.status})`)
+    const json = await res.json()
+    if (!json.success) throw new Error(json.error || 'Failed to load docs')
+    tree.value = json.data ?? []
+  } catch (err) {
+    console.error('Error loading docs:', err)
+    error.value = 'Could not load documents. Please try again later.'
+  } finally {
+    loading.value = false
+  }
+}
+
+function scrollToSection() {
+  const pathParam = route.params.pathMatch
+  const segments = Array.isArray(pathParam) ? pathParam : pathParam ? [pathParam] : []
+  const sectionPath = segments.join('/')
+  if (!sectionPath || sectionPath.startsWith('projects/')) return
+  nextTick(() => {
+    document.getElementById(sectionPath)?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  })
+}
+
+loadTree().then(scrollToSection)
+watch(() => route.params.pathMatch, () => {
+  if (!loading.value) scrollToSection()
+})
+</script>

--- a/frontend/src/pages/DocsPage.vue
+++ b/frontend/src/pages/DocsPage.vue
@@ -50,7 +50,7 @@ function scrollToSection() {
   const pathParam = route.params.pathMatch
   const segments = Array.isArray(pathParam) ? pathParam : pathParam ? [pathParam] : []
   const sectionPath = segments.join('/')
-  if (!sectionPath || sectionPath.startsWith('projects/')) return
+  if (!sectionPath) return
   nextTick(() => {
     document.getElementById(sectionPath)?.scrollIntoView({ behavior: 'smooth', block: 'start' })
   })

--- a/frontend/src/pages/ProjectDetailPage.vue
+++ b/frontend/src/pages/ProjectDetailPage.vue
@@ -62,7 +62,7 @@
         </template>
         <template #right>
           <ProjectDocsCard
-            :attachments="store.attachments"
+            :tree="store.docsTree"
             :project-key="store.project.key"
             :loading="store.attachmentsLoading"
             :error="store.attachmentsError"
@@ -113,6 +113,7 @@ import ProjectDocsCard from '../components/projects/ProjectDocsCard.vue'
 import SessionListResults from '../components/sessions/SessionListResults.vue'
 import SectionHeader from '../components/SectionHeader.vue'
 import { sessionPath, projectPath, projectsPath } from '../router/index'
+import { docsTreeHasFiles } from '../utils/docsTree'
 import type { SessionResponse } from '../../../types/api-responses'
 import type { Session, SessionStats } from '../types/session'
 import type { MediaItem } from '../types/media'
@@ -170,7 +171,7 @@ const linkedSessions = computed<Session[]>(() =>
 
 const showDocumentsCard = computed(() => {
   if (profile.isAdmin) return true
-  return store.attachmentsLoading || store.attachments.length > 0
+  return store.attachmentsLoading || docsTreeHasFiles(store.docsTree)
 })
 
 function onCoverSelect(index: number) {

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -33,7 +33,7 @@ export const projectsPath = () => '/projects'
 export const projectPath = (key: string) => `/projects/${key}`
 export const projectUploadPath = (key: string) => `/projects/${key}/upload`
 export const projectDocPath = (projectKey: string, itemId: string) =>
-  `/docs/projects/${projectKey}/${encodeURIComponent(itemId)}`
+  `/projects/${projectKey}/files/${encodeURIComponent(itemId)}`
 export const sessionsPath = () => '/sessions'
 export const profilesPath = () => '/profiles'
 export const profilePath = (slug: string) => `/profiles/${slug}`

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -32,8 +32,8 @@ export const groupPath = (key: string) => `/groups/${key}`
 export const projectsPath = () => '/projects'
 export const projectPath = (key: string) => `/projects/${key}`
 export const projectUploadPath = (key: string) => `/projects/${key}/upload`
-export const projectDocPath = (projectKey: string, itemId: string) =>
-  `/projects/${projectKey}/files/${encodeURIComponent(itemId)}`
+export const projectDocPath = (projectKey: string, ...slugSegments: string[]) =>
+  `/projects/${projectKey}/docs/${slugSegments.join('/')}`
 export const sessionsPath = () => '/sessions'
 export const profilesPath = () => '/profiles'
 export const profilePath = (slug: string) => `/profiles/${slug}`

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -22,6 +22,7 @@ import ProfileListPage from '../pages/ProfileListPage.vue'
 import ProfileDetailPage from '../pages/ProfileDetailPage.vue'
 import ProjectListPage from '../pages/ProjectListPage.vue'
 import ProjectDetailPage from '../pages/ProjectDetailPage.vue'
+import DocsPage from '../pages/DocsPage.vue'
 
 // Path builders — colocated with route definitions so URL structure has one home.
 // Import these wherever a link to an entity is needed; never construct URLs inline.
@@ -42,6 +43,9 @@ export const entriesPath = () => '/entries'
 export const toolsPath = () => '/tools'
 export const consentPath = (slug: string) => `/profiles/${slug}/consent`
 export const uploadPath  = (entryId: number) => `/upload?entryId=${entryId}`
+export const docsPath = () => '/docs'
+export const docsSectionPath = (...segments: string[]) =>
+  segments.length ? `/docs/${segments.join('/')}` : '/docs'
 
 export const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -61,6 +65,8 @@ export const router = createRouter({
     { path: '/sessions/:groupKey/:date', component: SessionDetailPage },
     { path: '/privacy', component: PrivacyPage },
     { path: '/terms', component: TermsPage },
+    { path: '/docs', component: DocsPage },
+    { path: '/docs/:pathMatch(.*)*', component: DocsPage },
     { path: '/login', component: LoginPage },
     { path: '/entries', component: EntriesPage, meta: { requiresAdmin: true } },
     { path: '/admin', redirect: '/tools' },

--- a/frontend/src/stores/projectDetail.ts
+++ b/frontend/src/stores/projectDetail.ts
@@ -1,10 +1,11 @@
 import { ref } from 'vue'
 import { defineStore } from 'pinia'
-import type { ProjectDetailResponse, ProjectAttachmentResponse } from '../../../types/api-responses'
+import type { ProjectDetailResponse, DocsTreeNode } from '../../../types/api-responses'
+import { removeDocFromTree } from '../utils/docsTree'
 
 export const useProjectDetailStore = defineStore('projectDetail', () => {
   const project = ref<ProjectDetailResponse | null>(null)
-  const attachments = ref<ProjectAttachmentResponse[]>([])
+  const docsTree = ref<DocsTreeNode[]>([])
   const loading = ref(false)
   const attachmentsLoading = ref(false)
   const attachmentsError = ref<string | null>(null)
@@ -41,10 +42,10 @@ export const useProjectDetailStore = defineStore('projectDetail', () => {
         const msg = json.message || json.error || `Failed to load documents (${res.status})`
         throw new Error(msg)
       }
-      attachments.value = json.data as ProjectAttachmentResponse[]
+      docsTree.value = json.data as DocsTreeNode[]
     } catch (e) {
       console.error('[projectDetail store] fetchAttachments', e)
-      attachments.value = []
+      docsTree.value = []
       attachmentsError.value = e instanceof Error ? e.message : 'Failed to load documents'
     } finally {
       attachmentsLoading.value = false
@@ -61,7 +62,7 @@ export const useProjectDetailStore = defineStore('projectDetail', () => {
       if (!res.ok) {
         throw new Error(json.error || json.message || `Delete failed (${res.status})`)
       }
-      attachments.value = attachments.value.filter(a => a.id !== itemId)
+      docsTree.value = removeDocFromTree(docsTree.value, itemId)
       return true
     } catch (e) {
       console.error('[projectDetail store] deleteDocument', e)
@@ -87,7 +88,7 @@ export const useProjectDetailStore = defineStore('projectDetail', () => {
 
   return {
     project,
-    attachments,
+    docsTree,
     loading,
     attachmentsLoading,
     attachmentsError,

--- a/frontend/src/styles/doc-lozenge.css
+++ b/frontend/src/styles/doc-lozenge.css
@@ -1,0 +1,63 @@
+/* Shared document lozenge links — project details + governance docs */
+.pdc-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.pdc-lozenge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  background: var(--color-dtv-sand);
+  padding: 0.5rem 0.75rem;
+  border: 2px solid transparent;
+  max-width: 14rem;
+}
+
+.pdc-lozenge--removable {
+  max-width: calc(14rem + 1.75rem);
+}
+
+.pdc-lozenge:hover {
+  background: var(--color-dtv-sand-dark);
+}
+
+.pdc-name {
+  flex: 1 1 0;
+  min-width: 0;
+  font-size: 0.9rem;
+  color: var(--color-text);
+  text-decoration: none;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pdc-name:hover {
+  text-decoration: underline;
+}
+
+.pdc-lozenge-deleting {
+  opacity: 0.55;
+}
+
+.pdc-remove {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.pdc-remove:hover img {
+  filter: invert(20%) sepia(95%) saturate(5000%) hue-rotate(0deg) brightness(90%) contrast(90%);
+}
+
+.pdc-remove:disabled {
+  cursor: wait;
+  opacity: 0.5;
+}

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -4,6 +4,7 @@
 @import "./admin.css";
 @import "./list.css";
 @import "./modal-form.css";
+@import "./doc-lozenge.css";
 
 @theme {
   /* DTV brand colours — keep in sync with shared/brand.ts (used by email renderer) */

--- a/frontend/src/utils/docsTree.test.ts
+++ b/frontend/src/utils/docsTree.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { docsTreeHasFiles, removeDocFromTree } from './docsTree'
+import type { DocsTreeNode } from '../../../types/api-responses'
+
+const sampleTree: DocsTreeNode[] = [
+  {
+    name: 'Reports',
+    slug: 'reports',
+    type: 'folder',
+    children: [
+      { name: 'Annual.pdf', slug: 'annual.pdf', type: 'file', url: '/projects/foo/docs/reports/annual.pdf', id: 'a1' },
+    ],
+  },
+  { name: 'Overview.pdf', slug: 'overview.pdf', type: 'file', url: '/projects/foo/docs/overview.pdf', id: 'a2' },
+]
+
+describe('docsTreeHasFiles', () => {
+  it('returns true when tree contains files', () => {
+    expect(docsTreeHasFiles(sampleTree)).toBe(true)
+  })
+
+  it('returns false for empty or folder-only trees', () => {
+    expect(docsTreeHasFiles([])).toBe(false)
+    expect(docsTreeHasFiles([{ name: 'Empty', slug: 'empty', type: 'folder', children: [] }])).toBe(false)
+  })
+})
+
+describe('removeDocFromTree', () => {
+  it('removes a file node by id', () => {
+    const result = removeDocFromTree(sampleTree, 'a1')
+    expect(docsTreeHasFiles(result)).toBe(true)
+    expect(result[0].children).toHaveLength(0)
+  })
+})

--- a/frontend/src/utils/docsTree.ts
+++ b/frontend/src/utils/docsTree.ts
@@ -1,0 +1,18 @@
+import type { DocsTreeNode } from '../../../types/api-responses'
+
+export function docsTreeHasFiles(nodes: DocsTreeNode[]): boolean {
+  for (const node of nodes) {
+    if (node.type === 'file') return true
+    if (node.children?.length && docsTreeHasFiles(node.children)) return true
+  }
+  return false
+}
+
+export function removeDocFromTree(nodes: DocsTreeNode[], itemId: string): DocsTreeNode[] {
+  return nodes
+    .filter(n => !(n.type === 'file' && n.id === itemId))
+    .map(n => {
+      if (n.type !== 'folder' || !n.children?.length) return n
+      return { ...n, children: removeDocFromTree(n.children, itemId) }
+    })
+}

--- a/frontend/src/utils/slug.test.ts
+++ b/frontend/src/utils/slug.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import { nameToSlug } from './slug'
+
+describe('nameToSlug', () => {
+  it('lowercases and hyphenates spaces', () => {
+    expect(nameToSlug('Andrew Davies')).toBe('andrew-davies')
+    expect(nameToSlug('Health and Safety')).toBe('health-and-safety')
+  })
+
+  it('strips apostrophes', () => {
+    expect(nameToSlug("O'Brien")).toBe('obrien')
+  })
+
+  it('returns empty string for undefined', () => {
+    expect(nameToSlug(undefined)).toBe('')
+  })
+
+  it('replaces special characters with hyphens', () => {
+    expect(nameToSlug('(#2305774137) Certificate - C&SO Select Renewal Policy from Zurich'))
+      .toBe('2305774137-certificate-c-so-select-renewal-policy-from-zurich')
+  })
+})

--- a/frontend/src/utils/slug.ts
+++ b/frontend/src/utils/slug.ts
@@ -1,0 +1,11 @@
+/**
+ * URL-safe slug — mirrors nameToSlug() in backend/services/data-layer.ts
+ */
+export function nameToSlug(name: string | undefined): string {
+  if (!name) return '';
+  return name
+    .toLowerCase()
+    .replace(/[\u2018\u2019']/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}

--- a/types/api-responses.ts
+++ b/types/api-responses.ts
@@ -349,6 +349,14 @@ export interface TagHoursItem {
 
 export type TagHoursResponse = TagHoursItem[];
 
+export interface DocsTreeNode {
+  name: string;
+  slug: string;
+  type: 'folder' | 'file';
+  url?: string;
+  children?: DocsTreeNode[];
+}
+
 export interface EntryUploadContextResponse {
   entryId: number;
   sessionId: number;

--- a/types/api-responses.ts
+++ b/types/api-responses.ts
@@ -59,7 +59,7 @@ export interface ProjectDetailResponse extends ProjectResponse {
 export interface ProjectAttachmentResponse {
   id: string;
   name: string;
-  /** Stable app URL — served via /docs/projects/:key/:itemId (no SharePoint login). */
+  /** Stable app URL — served via /projects/:key/files/:itemId (no SharePoint login). */
   url: string;
 }
 

--- a/types/api-responses.ts
+++ b/types/api-responses.ts
@@ -59,7 +59,7 @@ export interface ProjectDetailResponse extends ProjectResponse {
 export interface ProjectAttachmentResponse {
   id: string;
   name: string;
-  /** Stable app URL — served via /projects/:key/files/:itemId (no SharePoint login). */
+  /** Stable app URL — served via /projects/:key/docs/{slug-path} (no SharePoint login). */
   url: string;
 }
 
@@ -354,6 +354,8 @@ export interface DocsTreeNode {
   slug: string;
   type: 'folder' | 'file';
   url?: string;
+  /** SharePoint drive item id — present on project file nodes (admin delete). */
+  id?: string;
   children?: DocsTreeNode[];
 }
 


### PR DESCRIPTION
## Summary
- Adds a public **Docs** page at `/docs` and burger menu link, reading the SharePoint `Docs/` folder from the Documents library (`DOCUMENTS_DRIVE_ID`).
- `GET /api/docs` returns the folder tree with stable tracker URLs; `GET /docs/*.pdf` proxies PDF bytes server-side (same pattern as `/docs/projects/:key/:itemId`).
- Shared `DocLozengeLink` component and `doc-lozenge.css` used by governance docs and project document cards.

## Test plan
- [ ] Visit `/docs` unauthenticated — page loads, folder hierarchy renders (H2/H3/bold)
- [ ] Click a PDF lozenge — opens via `/docs/.../file.pdf` (not SharePoint URL)
- [ ] Burger menu shows **Docs** link when logged out
- [ ] Project detail documents still render and download correctly
- [ ] Admin cache clear refreshes docs tree after SharePoint changes