### PR TITLE
Redirect docs.dtv.org.uk to tracker /docs

### DIFF
--- a/app.js
+++ b/app.js
@@ -44,6 +44,17 @@ const app = express();
 // Trust Azure App Service reverse proxy (for correct req.protocol)
 app.set('trust proxy', 1);
 
+// docs.dtv.org.uk is bound to the same App Service; send visitors to governance Docs on the canonical host.
+const DOCS_REDIRECT_HOST = (process.env.DOCS_REDIRECT_HOST || 'docs.dtv.org.uk').toLowerCase();
+const TRACKER_CANONICAL_ORIGIN = (process.env.FRONTEND_URL || 'https://tracker.dtv.org.uk').replace(/\/$/, '');
+
+app.use((req, res, next) => {
+    if ((req.hostname || '').toLowerCase() !== DOCS_REDIRECT_HOST) return next();
+    const suffix = req.path === '/' ? '/docs' : `/docs${req.path}`;
+    const query = req.originalUrl.includes('?') ? req.originalUrl.slice(req.originalUrl.indexOf('?')) : '';
+    res.redirect(301, `${TRACKER_CANONICAL_ORIGIN}${suffix}${query}`);
+});
+
 app.use(express.json());
 app.use(cookieParser());
 

--- a/app.js
+++ b/app.js
@@ -47,11 +47,18 @@ app.set('trust proxy', 1);
 // docs.dtv.org.uk is bound to the same App Service; send visitors to governance Docs on the canonical host.
 const DOCS_REDIRECT_HOST = (process.env.DOCS_REDIRECT_HOST || 'docs.dtv.org.uk').toLowerCase();
 const TRACKER_CANONICAL_ORIGIN = (process.env.FRONTEND_URL || 'https://tracker.dtv.org.uk').replace(/\/$/, '');
+const DOCS_LEGACY_PATH_REDIRECTS = {
+    '/it-and-data/data-protection/2025-08-01-dtv-privacy-notice.pdf': '/docs/data-protection/dtv-privacy-notice.pdf',
+};
 
 app.use((req, res, next) => {
     if ((req.hostname || '').toLowerCase() !== DOCS_REDIRECT_HOST) return next();
-    const suffix = req.path === '/' ? '/docs' : `/docs${req.path}`;
     const query = req.originalUrl.includes('?') ? req.originalUrl.slice(req.originalUrl.indexOf('?')) : '';
+    const legacyTarget = DOCS_LEGACY_PATH_REDIRECTS[req.path.toLowerCase()];
+    if (legacyTarget) {
+        return res.redirect(301, `${TRACKER_CANONICAL_ORIGIN}${legacyTarget}${query}`);
+    }
+    const suffix = req.path === '/' ? '/docs' : `/docs${req.path}`;
     res.redirect(301, `${TRACKER_CANONICAL_ORIGIN}${suffix}${query}`);
 });
 

--- a/docs/azure-app-service.md
+++ b/docs/azure-app-service.md
@@ -4,6 +4,27 @@ The app is hosted on **Azure App Service** (Node.js, UK South).
 
 All `.env` variables must be configured in Azure App Service → Configuration → Application settings.
 
+## Custom domains
+
+| Host | Purpose |
+|------|---------|
+| `tracker.dtv.org.uk` | Primary app URL (`FRONTEND_URL`) |
+| `docs.dtv.org.uk` | Legacy docs hostname — 301 redirect to `/docs` on the canonical host (see `app.js`) |
+
+**Azure setup for `docs.dtv.org.uk`:**
+
+1. DNS: CNAME `docs` → `<app-name>.azurewebsites.net`
+2. App Service → **Custom domains** → add `docs.dtv.org.uk`
+3. Bind a free **App Service Managed Certificate** for that hostname
+4. Ensure `FRONTEND_URL=https://tracker.dtv.org.uk` is set in Application settings
+
+Path-preserving redirect examples:
+
+- `https://docs.dtv.org.uk/` → `https://tracker.dtv.org.uk/docs`
+- `https://docs.dtv.org.uk/it-and-data/foo.pdf` → `https://tracker.dtv.org.uk/docs/it-and-data/foo.pdf`
+
+Optional override for non-production: `DOCS_REDIRECT_HOST` (hostname that triggers the redirect).
+
 ## CI/CD — GitHub Actions
 
 Deployments are automated via `.github/workflows/main_dtvtrackerapp.yml` on every push to `main`.

--- a/docs/azure-app-service.md
+++ b/docs/azure-app-service.md
@@ -18,10 +18,11 @@ All `.env` variables must be configured in Azure App Service → Configuration �
 3. Bind a free **App Service Managed Certificate** for that hostname
 4. Ensure `FRONTEND_URL=https://tracker.dtv.org.uk` is set in Application settings
 
-Path-preserving redirect examples:
+Redirect examples:
 
 - `https://docs.dtv.org.uk/` → `https://tracker.dtv.org.uk/docs`
-- `https://docs.dtv.org.uk/it-and-data/foo.pdf` → `https://tracker.dtv.org.uk/docs/it-and-data/foo.pdf`
+- `https://docs.dtv.org.uk/it-and-data/data-protection/2025-08-01-dtv-privacy-notice.pdf` → `https://tracker.dtv.org.uk/docs/data-protection/dtv-privacy-notice.pdf` (legacy path mapping in `app.js`)
+- Other paths: prefix preserved — `https://docs.dtv.org.uk/foo.pdf` → `https://tracker.dtv.org.uk/docs/foo.pdf`
 
 Optional override for non-production: `DOCS_REDIRECT_HOST` (hostname that triggers the redirect).
 

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,5 +1,10 @@
 # Development Progress
 
+## Session: 2026-06-10 (docs.dtv.org.uk redirect)
+
+- Early middleware in `app.js` 301-redirects `docs.dtv.org.uk` to `FRONTEND_URL` + `/docs` (path and query preserved).
+- `docs/azure-app-service.md` — custom domain setup for the legacy docs hostname.
+
 ## Session: 2026-06-10 (Project docs tree + RR prep)
 
 - Project attachments API returns `DocsTreeNode[]`; byte proxy at `/projects/:key/docs/{slug-path}` (recursive `Projects/{key}/` mirror).

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -2,7 +2,7 @@
 
 ## Session: 2026-06-10 (docs.dtv.org.uk redirect)
 
-- Early middleware in `app.js` 301-redirects `docs.dtv.org.uk` to `FRONTEND_URL` + `/docs` (path and query preserved).
+- Early middleware in `app.js` 301-redirects `docs.dtv.org.uk` to `FRONTEND_URL` + `/docs` (path and query preserved); legacy privacy-notice path mapped to canonical slug.
 - `docs/azure-app-service.md` — custom domain setup for the legacy docs hostname.
 
 ## Session: 2026-06-10 (Project docs tree + RR prep)

--- a/docs/testing/full-regression.md
+++ b/docs/testing/full-regression.md
@@ -19,7 +19,8 @@ Run with `npm run dev` at http://localhost:3000. Log in via Microsoft Entra ID.
 - [ ] Unauthenticated visit to `/docs` loads without redirect; burger menu shows **Docs** link
 - [ ] `/docs` lists governance folders from SharePoint `Docs/` (H2/H3/bold hierarchy); PDF lozenge opens via tracker URL (`/docs/.../file.pdf`), not SharePoint
 - [ ] `/docs/health-and-safety` scrolls to Health and Safety section (v1: full tree + scroll-to)
-- [ ] `https://docs.dtv.org.uk/` returns 301 to `https://tracker.dtv.org.uk/docs`; deep path (e.g. `/it-and-data/.../file.pdf`) preserves path under `/docs/...`
+- [ ] `https://docs.dtv.org.uk/` returns 301 to `https://tracker.dtv.org.uk/docs`
+- [ ] Legacy privacy notice URL `https://docs.dtv.org.uk/it-and-data/data-protection/2025-08-01-dtv-privacy-notice.pdf` returns 301 to `https://tracker.dtv.org.uk/docs/data-protection/dtv-privacy-notice.pdf` (not `/docs/it-and-data/...`)
 - [ ] Unauthenticated visit to `/groups/:key` loads without redirect; regulars section hidden
 - [ ] Unauthenticated visit to `/sessions/:group/:date` loads; entries section and free parking card hidden
 - [ ] Unauthenticated visit to `/profiles` redirects to `/login` (trusted route)

--- a/docs/testing/full-regression.md
+++ b/docs/testing/full-regression.md
@@ -19,6 +19,7 @@ Run with `npm run dev` at http://localhost:3000. Log in via Microsoft Entra ID.
 - [ ] Unauthenticated visit to `/docs` loads without redirect; burger menu shows **Docs** link
 - [ ] `/docs` lists governance folders from SharePoint `Docs/` (H2/H3/bold hierarchy); PDF lozenge opens via tracker URL (`/docs/.../file.pdf`), not SharePoint
 - [ ] `/docs/health-and-safety` scrolls to Health and Safety section (v1: full tree + scroll-to)
+- [ ] `https://docs.dtv.org.uk/` returns 301 to `https://tracker.dtv.org.uk/docs`; deep path (e.g. `/it-and-data/.../file.pdf`) preserves path under `/docs/...`
 - [ ] Unauthenticated visit to `/groups/:key` loads without redirect; regulars section hidden
 - [ ] Unauthenticated visit to `/sessions/:group/:date` loads; entries section and free parking card hidden
 - [ ] Unauthenticated visit to `/profiles` redirects to `/login` (trusted route)

--- a/frontend/src/pages/PrivacyPage.vue
+++ b/frontend/src/pages/PrivacyPage.vue
@@ -6,7 +6,7 @@
     <p class="text-sm text-gray-500 mb-8">Dean Trail Volunteers &mdash; Registered Charity 1208988<br>Last updated: March 2026</p>
 
     <div class="prose max-w-none text-black space-y-6">
-      <p>This privacy policy explains how the DTV Tracker application (<strong>tracker.dtv.org.uk</strong>) collects, uses, and stores your personal data. It applies specifically to this application. For the full Dean Trail Volunteers privacy notice, see our <a href="https://docs.dtv.org.uk/it-and-data/data-protection/2025-08-01-dtv-privacy-notice.pdf" target="_blank" rel="noopener" class="text-dtv-green hover:underline">DTV Privacy Notice (PDF)</a>.</p>
+      <p>This privacy policy explains how the DTV Tracker application (<strong>tracker.dtv.org.uk</strong>) collects, uses, and stores your personal data. It applies specifically to this application. For the full Dean Trail Volunteers privacy notice, see our <a href="https://tracker.dtv.org.uk/docs/data-protection/dtv-privacy-notice.pdf" target="_blank" rel="noopener" class="text-dtv-green hover:underline">DTV Privacy Notice (PDF)</a>.</p>
 
       <section>
         <h2 class="text-xl font-bold mb-2">Who we are</h2>
@@ -54,12 +54,12 @@
 
       <section>
         <h2 class="text-xl font-bold mb-2">How long we keep your data</h2>
-        <p>Volunteer records are retained for as long as you are an active volunteer, and for a reasonable period thereafter in line with our <a href="https://docs.dtv.org.uk/it-and-data/data-protection/2025-08-01-dtv-privacy-notice.pdf" target="_blank" rel="noopener" class="text-dtv-green hover:underline">full privacy notice</a>. You may request deletion of your data by contacting us.</p>
+        <p>Volunteer records are retained for as long as you are an active volunteer, and for a reasonable period thereafter in line with our <a href="https://tracker.dtv.org.uk/docs/data-protection/dtv-privacy-notice.pdf" target="_blank" rel="noopener" class="text-dtv-green hover:underline">full privacy notice</a>. You may request deletion of your data by contacting us.</p>
       </section>
 
       <section>
         <h2 class="text-xl font-bold mb-2">Your rights</h2>
-        <p>Under UK GDPR you have the right to access, correct, or request deletion of your personal data. To exercise these rights, contact the DTV data controller as described in our <a href="https://docs.dtv.org.uk/it-and-data/data-protection/2025-08-01-dtv-privacy-notice.pdf" target="_blank" rel="noopener" class="text-dtv-green hover:underline">full privacy notice</a>.</p>
+        <p>Under UK GDPR you have the right to access, correct, or request deletion of your personal data. To exercise these rights, contact the DTV data controller as described in our <a href="https://tracker.dtv.org.uk/docs/data-protection/dtv-privacy-notice.pdf" target="_blank" rel="noopener" class="text-dtv-green hover:underline">full privacy notice</a>.</p>
       </section>
 
       <section>
@@ -69,7 +69,7 @@
 
       <section>
         <h2 class="text-xl font-bold mb-2">Contact</h2>
-        <p>For questions about this privacy policy or your data, contact Dean Trail Volunteers via the details in our <a href="https://docs.dtv.org.uk/it-and-data/data-protection/2025-08-01-dtv-privacy-notice.pdf" target="_blank" rel="noopener" class="text-dtv-green hover:underline">full privacy notice</a>.</p>
+        <p>For questions about this privacy policy or your data, contact Dean Trail Volunteers via the details in our <a href="https://tracker.dtv.org.uk/docs/data-protection/dtv-privacy-notice.pdf" target="_blank" rel="noopener" class="text-dtv-green hover:underline">full privacy notice</a>.</p>
       </section>
     </div>
     </div>

--- a/frontend/src/pages/TermsPage.vue
+++ b/frontend/src/pages/TermsPage.vue
@@ -61,7 +61,7 @@
 
       <section>
         <h2 class="text-xl font-bold mb-2">Contact</h2>
-        <p>For questions about these terms, contact Dean Trail Volunteers via the details in our <a href="https://docs.dtv.org.uk/it-and-data/data-protection/2025-08-01-dtv-privacy-notice.pdf" target="_blank" rel="noopener" class="text-dtv-green hover:underline">Privacy Notice (PDF)</a>.</p>
+        <p>For questions about these terms, contact Dean Trail Volunteers via the details in our <a href="https://tracker.dtv.org.uk/docs/data-protection/dtv-privacy-notice.pdf" target="_blank" rel="noopener" class="text-dtv-green hover:underline">Privacy Notice (PDF)</a>.</p>
       </section>
     </div>
     </div>


### PR DESCRIPTION
## Summary

- Add early Express middleware to 301-redirect `docs.dtv.org.uk` to `FRONTEND_URL` + `/docs`, preserving path and query string for legacy deep links.
- Document Azure custom domain setup (CNAME, managed cert, `FRONTEND_URL`) in `docs/azure-app-service.md`.
- Update privacy/terms pages to link directly to `tracker.dtv.org.uk/docs/data-protection/dtv-privacy-notice.pdf`.

## Test plan

- [ ] Merge and deploy to DTVTrackerApp
- [ ] Azure: CNAME `docs` → `dtvtrackerapp.azurewebsites.net`, add custom domain + managed certificate
- [ ] Confirm `FRONTEND_URL=https://tracker.dtv.org.uk` in App Service settings
- [ ] `https://docs.dtv.org.uk/` → 301 → `https://tracker.dtv.org.uk/docs`
- [ ] Deep path redirect works (e.g. old bookmarked PDF paths under `/docs/...`)
- [ ] Privacy and terms pages open the privacy notice PDF at the new URL

Made with [Cursor](https://cursor.com)