### PR TITLE
Show session Time and Length on detail page and pre-session emails

### DIFF
--- a/backend/routes/sessions.ts
+++ b/backend/routes/sessions.ts
@@ -25,7 +25,8 @@ import {
   parseHours,
   profileSlug,
   extractMetadataTags,
-  parseEmails
+  parseEmails,
+  sessionScheduleFields,
 } from '../services/data-layer';
 import { parseSessionStats } from '../services/data-layer';
 import {
@@ -494,6 +495,7 @@ router.get('/sessions/:group/:date', async (req: Request, res: Response) => {
         displayName: spSession.Name || spSession.Title,
         description: spSession[SESSION_NOTES],
         date: spSession.Date,
+        ...sessionScheduleFields(spSession),
         groupId: groupId,
         groupName: group.displayName,
         groupDescription: group.description,
@@ -626,6 +628,7 @@ router.get('/sessions/:group/:date', async (req: Request, res: Response) => {
       displayName: spSession.Name || spSession.Title,
       description: spSession[SESSION_NOTES],
       date: spSession.Date,
+      ...sessionScheduleFields(spSession),
       groupId: groupId,
       groupName: group.displayName,
       groupDescription: group.description,

--- a/backend/services/data-layer.test.ts
+++ b/backend/services/data-layer.test.ts
@@ -186,6 +186,10 @@ describe('formatSessionTimeRangeProse', () => {
     expect(formatSessionTimeRangeProse('10:00', 2.5)).toBe('10:00 to 12:30 (about 2.5 hours)')
     expect(formatSessionTimeRangeProse('09:00', 1)).toBe('9:00 to 10:00 (about 1 hour)')
   })
+
+  it('rounds fractional-minute end times from floating-point arithmetic', () => {
+    expect(formatSessionTimeRangeProse('09:30', 2.33)).toBe('9:30 to 11:50 (about 2.33 hours)')
+  })
 })
 
 describe('sessionScheduleFields', () => {

--- a/backend/services/data-layer.test.ts
+++ b/backend/services/data-layer.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest'
-import { calculateFinancialYear, calculateCurrentFY, calculateSessionStats, toMatchName, extractMetadataTags, findTitleKeyClash } from './data-layer'
+import { calculateFinancialYear, calculateCurrentFY, calculateSessionStats, toMatchName, extractMetadataTags, findTitleKeyClash, sessionScheduleFields, formatSessionTimeRangeProse } from './data-layer'
+import { SESSION_TIME, SESSION_LENGTH } from './field-names'
 import type { SharePointEntry } from '../../types/sharepoint'
+import type { SharePointSession } from '../../types/session'
 
 describe('findTitleKeyClash', () => {
   const items = [
@@ -172,5 +174,41 @@ describe('calculateSessionStats', () => {
   it('ignores entries with no SessionLookupId', () => {
     const stats = calculateSessionStats([{ ID: 1, Created: '', Modified: '', Hours: 3 } as SharePointEntry])
     expect(stats.size).toBe(0)
+  })
+})
+
+describe('formatSessionTimeRangeProse', () => {
+  it('formats default schedule in email prose', () => {
+    expect(formatSessionTimeRangeProse('09:30', 3)).toBe('9:30 to 12:30 (about 3 hours)')
+  })
+
+  it('supports fractional hours and singular hour', () => {
+    expect(formatSessionTimeRangeProse('10:00', 2.5)).toBe('10:00 to 12:30 (about 2.5 hours)')
+    expect(formatSessionTimeRangeProse('09:00', 1)).toBe('9:00 to 10:00 (about 1 hour)')
+  })
+})
+
+describe('sessionScheduleFields', () => {
+  it('uses SharePoint Time and Length when set', () => {
+    expect(sessionScheduleFields({
+      ID: 1,
+      Date: '2026-06-12',
+      Created: '',
+      Modified: '',
+      [SESSION_TIME]: '10:00',
+      [SESSION_LENGTH]: 2.5,
+    } as SharePointSession)).toEqual({ time: '10:00', length: 2.5 })
+  })
+
+  it('defaults to 09:30 and 3 hours when SharePoint fields are unset', () => {
+    expect(sessionScheduleFields({
+      ID: 1,
+      Date: '2026-06-12',
+      Created: '',
+      Modified: '',
+    } as SharePointSession)).toEqual({
+      time: '09:30',
+      length: 3,
+    })
   })
 })

--- a/backend/services/data-layer.ts
+++ b/backend/services/data-layer.ts
@@ -25,7 +25,7 @@ import {
   GROUP_LOOKUP, GROUP_DISPLAY,
   SESSION_LOOKUP, SESSION_DISPLAY,
   PROFILE_LOOKUP, PROFILE_DISPLAY,
-  SESSION_NOTES, SESSION_LIMITS,
+  SESSION_NOTES, SESSION_LIMITS, SESSION_TIME, SESSION_LENGTH,
 } from './field-names';
 import type { SessionStats } from '../../types/api-responses';
 
@@ -72,6 +72,66 @@ export function parseSessionLimits(spSession: SharePointSession): SessionLimits 
   } catch {
     return {};
   }
+}
+
+/** Normalises SharePoint Time (HH:MM, 24-hour) for API responses. */
+export function parseSessionTime(raw: unknown): string | undefined {
+  if (typeof raw !== 'string' || !raw.trim()) return undefined;
+  const match = raw.trim().match(/^(\d{1,2}):(\d{2})$/);
+  if (!match) return undefined;
+  const hours = parseInt(match[1], 10);
+  const minutes = parseInt(match[2], 10);
+  if (hours > 23 || minutes > 59) return undefined;
+  return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
+}
+
+/** Normalises SharePoint Length (hours) for API responses. */
+export function parseSessionLength(raw: unknown): number | undefined {
+  if (raw === null || raw === undefined || raw === '') return undefined;
+  const value = typeof raw === 'number' ? raw : parseFloat(String(raw));
+  if (!Number.isFinite(value) || value <= 0) return undefined;
+  return value;
+}
+
+export const DEFAULT_SESSION_TIME = '09:30';
+export const DEFAULT_SESSION_LENGTH = 3;
+
+/** Schedule fields for session detail API — SharePoint values with DTV defaults when unset. */
+export function sessionScheduleFields(spSession: SharePointSession): { time: string; length: number } {
+  return {
+    time: parseSessionTime(spSession[SESSION_TIME]) ?? DEFAULT_SESSION_TIME,
+    length: parseSessionLength(spSession[SESSION_LENGTH]) ?? DEFAULT_SESSION_LENGTH,
+  };
+}
+
+function sessionTimeToMinutes(time: string): number | null {
+  const match = time.trim().match(/^(\d{1,2}):(\d{2})$/);
+  if (!match) return null;
+  const hours = parseInt(match[1], 10);
+  const minutes = parseInt(match[2], 10);
+  if (hours > 23 || minutes > 59) return null;
+  return hours * 60 + minutes;
+}
+
+function formatSessionMinutesAsTime(totalMinutes: number): string {
+  const wrapped = ((totalMinutes % (24 * 60)) + 24 * 60) % (24 * 60);
+  const hours = Math.floor(wrapped / 60);
+  const minutes = wrapped % 60;
+  return `${hours}:${String(minutes).padStart(2, '0')}`;
+}
+
+function formatSessionLengthProse(hours: number): string {
+  const value = Number.isInteger(hours) ? String(hours) : String(hours);
+  const unit = hours === 1 ? 'hour' : 'hours';
+  return `about ${value} ${unit}`;
+}
+
+/** Prose time range for emails, e.g. "9:30 to 12:30 (about 3 hours)". */
+export function formatSessionTimeRangeProse(time: string, lengthHours: number): string {
+  const startMinutes = sessionTimeToMinutes(time);
+  if (startMinutes === null) return formatSessionLengthProse(lengthHours);
+  const endMinutes = startMinutes + lengthHours * 60;
+  return `${formatSessionMinutesAsTime(startMinutes)} to ${formatSessionMinutesAsTime(endMinutes)} (${formatSessionLengthProse(lengthHours)})`;
 }
 
 /**

--- a/backend/services/data-layer.ts
+++ b/backend/services/data-layer.ts
@@ -114,7 +114,8 @@ function sessionTimeToMinutes(time: string): number | null {
 }
 
 function formatSessionMinutesAsTime(totalMinutes: number): string {
-  const wrapped = ((totalMinutes % (24 * 60)) + 24 * 60) % (24 * 60);
+  const rounded = Math.round(totalMinutes);
+  const wrapped = ((rounded % (24 * 60)) + 24 * 60) % (24 * 60);
   const hours = Math.floor(wrapped / 60);
   const minutes = wrapped % 60;
   return `${hours}:${String(minutes).padStart(2, '0')}`;

--- a/backend/services/email-renderer.test.ts
+++ b/backend/services/email-renderer.test.ts
@@ -6,6 +6,7 @@ const PRE_SESSION_VARS = {
   groupName:         'Trail Crew',
   formattedDateLong: 'Saturday 3 May 2025',
   formattedDateShort:'3 May',
+  formattedTime:     '9:30 to 12:30 (about 3 hours)',
   sessionUrl:        'https://example.com/sessions/trail-crew/2025-05-03',
   loginUrl:          'https://example.com/login',
 }
@@ -50,6 +51,15 @@ describe('pre-session email', () => {
   it('renders non-empty text', async () => {
     const { text } = await renderEmail('pre-session', PRE_SESSION_VARS)
     expect(text.length).toBeGreaterThan(0)
+  })
+
+  it('renders session time from template vars', async () => {
+    const { html, text } = await renderEmail('pre-session', {
+      ...PRE_SESSION_VARS,
+      formattedTime: '10:00 to 12:30 (about 2.5 hours)',
+    })
+    expect(html).toContain('10:00 to 12:30 (about 2.5 hours)')
+    expect(text).toContain('Time: 10:00 to 12:30 (about 2.5 hours)')
   })
 
   it('omits isRegular block when not set', async () => {

--- a/backend/services/email-vars.test.ts
+++ b/backend/services/email-vars.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { buildPreSessionVars } from './email-vars'
+import { SESSION_TIME, SESSION_LENGTH } from './field-names'
+import type { SharePointEntry, SharePointProfile } from '../../types/sharepoint'
+import type { SharePointSession } from '../../types/session'
+import type { SharePointGroup } from '../../types/group'
+
+const baseEntry = {
+  ID: 1,
+  Created: '',
+  Modified: '',
+  ProfileLookupId: 10,
+  Profile: 'Alice',
+} as SharePointEntry
+
+const baseProfile = {
+  ID: 10,
+  Created: '',
+  Modified: '',
+} as SharePointProfile
+
+const baseGroup = {
+  ID: 5,
+  Title: 'Trail Crew',
+  Name: 'Trail Crew',
+  Created: '',
+  Modified: '',
+} as SharePointGroup
+
+describe('buildPreSessionVars', () => {
+  it('includes formattedTime from session schedule with defaults', () => {
+    const session = {
+      ID: 100,
+      Date: '2026-04-23',
+      Created: '',
+      Modified: '',
+    } as SharePointSession
+
+    const vars = buildPreSessionVars(baseEntry, session, baseProfile, baseGroup, [], 'https://example.com')
+
+    expect(vars.formattedTime).toBe('9:30 to 12:30 (about 3 hours)')
+  })
+
+  it('includes formattedTime from SharePoint Time and Length', () => {
+    const session = {
+      ID: 100,
+      Date: '2026-04-23',
+      Created: '',
+      Modified: '',
+      [SESSION_TIME]: '10:00',
+      [SESSION_LENGTH]: 2,
+    } as SharePointSession
+
+    const vars = buildPreSessionVars(baseEntry, session, baseProfile, baseGroup, [], 'https://example.com')
+
+    expect(vars.formattedTime).toBe('10:00 to 12:00 (about 2 hours)')
+  })
+})

--- a/backend/services/email-vars.ts
+++ b/backend/services/email-vars.ts
@@ -1,7 +1,7 @@
 import { SharePointEntry, SharePointProfile } from '../../types/sharepoint';
 import { SharePointSession } from '../../types/session';
 import { SharePointGroup } from '../../types/group';
-import { extractMetadataTags, safeParseLookupId, parseHours } from './data-layer';
+import { extractMetadataTags, safeParseLookupId, parseHours, sessionScheduleFields, formatSessionTimeRangeProse } from './data-layer';
 import {
   SESSION_NOTES, SESSION_METADATA, SESSION_STATS, SESSION_COVER_MEDIA,
   GROUP_LOOKUP, PROFILE_DISPLAY, ENTRY_CANCELLED,
@@ -58,6 +58,7 @@ export interface PreSessionVars extends Record<string, unknown> {
   sessionTitle: string | null;
   formattedDateShort: string;
   formattedDateLong: string;
+  formattedTime: string;
   description: string;
   sessionUrl: string;
   loginUrl: string;
@@ -79,6 +80,8 @@ export function buildPreSessionVars(
   const groupKey = (group.Title || '').toLowerCase();
   const dateParam = session.Date;
   const { formattedDateShort, formattedDateLong } = formatDate(dateParam);
+  const { time, length } = sessionScheduleFields(session);
+  const formattedTime = formatSessionTimeRangeProse(time, length);
 
   const myChildEntries = findChildEntries(sessionEntries, profileId);
   const myChildNames = myChildEntries
@@ -96,6 +99,7 @@ export function buildPreSessionVars(
     sessionTitle: session.Name || null,
     formattedDateShort,
     formattedDateLong,
+    formattedTime,
     description: (session[SESSION_NOTES] as string | undefined) || '',
     sessionUrl: `${baseUrl}/sessions/${groupKey}/${dateParam}`,
     loginUrl: `${baseUrl}/login?returnTo=${encodeURIComponent(`/sessions/${groupKey}/${dateParam}`)}`,

--- a/backend/services/field-names.ts
+++ b/backend/services/field-names.ts
@@ -28,6 +28,8 @@ export const PROJECT_METADATA    = 'Metadata';
 export const SESSION_COVER_MEDIA = 'CoverMediaLookupId'; // Lookup to Media library (ID field, consistent with GROUP_LOOKUP pattern)
 export const SESSION_STATS       = 'Stats';  // Pre-computed JSON stats stored on Session items (avoid full entries scan on listing views)
 export const SESSION_LIMITS      = 'Limits'; // Per-session capacity limits JSON: {"new": 4, "total": 16}
+export const SESSION_TIME        = 'Time';   // Start time HH:MM (24-hour clock)
+export const SESSION_LENGTH      = 'Length'; // Session duration in hours
 export const PROFILE_STATS       = 'Stats';  // Same field name on Profiles list
 export const ENTRY_CANCELLED             = 'Cancelled';         // Date/time when entry was cancelled; null = active booking
 export const ENTRY_LABELS                = 'Labels';            // Multi-select choice: Regular | CSR | Late | FirstAider | DigLead

--- a/backend/services/repositories/sessions-repository.ts
+++ b/backend/services/repositories/sessions-repository.ts
@@ -6,7 +6,7 @@
 
 import { SharePointSession } from '../../../types/session';
 import { sharePointClient, CACHE_TTL } from '../sharepoint-client';
-import { GROUP_LOOKUP, GROUP_DISPLAY, PROJECT_LOOKUP, PROJECT_DISPLAY, SESSION_NOTES, SESSION_METADATA, SESSION_COVER_MEDIA, SESSION_STATS, SESSION_LIMITS } from '../field-names';
+import { GROUP_LOOKUP, GROUP_DISPLAY, PROJECT_LOOKUP, PROJECT_DISPLAY, SESSION_NOTES, SESSION_METADATA, SESSION_COVER_MEDIA, SESSION_STATS, SESSION_LIMITS, SESSION_TIME, SESSION_LENGTH } from '../field-names';
 
 
 class SessionsRepository {
@@ -17,7 +17,7 @@ class SessionsRepository {
   }
 
   private get selectFields(): string {
-    return `ID,Title,Name,Date,${SESSION_NOTES},${SESSION_METADATA},EventbriteEventID,${GROUP_DISPLAY},${GROUP_LOOKUP},${PROJECT_DISPLAY},${PROJECT_LOOKUP},${SESSION_COVER_MEDIA},${SESSION_STATS},${SESSION_LIMITS},Created,Modified`;
+    return `ID,Title,Name,Date,${SESSION_TIME},${SESSION_LENGTH},${SESSION_NOTES},${SESSION_METADATA},EventbriteEventID,${GROUP_DISPLAY},${GROUP_LOOKUP},${PROJECT_DISPLAY},${PROJECT_LOOKUP},${SESSION_COVER_MEDIA},${SESSION_STATS},${SESSION_LIMITS},Created,Modified`;
   }
 
   private readonly dateOnlyFields = ['Date'];

--- a/frontend/src/components/sessions/SessionDetailHeader.vue
+++ b/frontend/src/components/sessions/SessionDetailHeader.vue
@@ -10,7 +10,7 @@
         </div>
         <div class="flex gap-3">
           <dt class="text-gray-400 w-20 shrink-0">Time</dt>
-          <dd>9:30 to 12:30 (3h)</dd><!-- TODO: add time field to API -->
+          <dd>{{ timeLabel }}</dd>
         </div>
         <div class="flex gap-3">
           <dt class="text-gray-400 w-20 shrink-0">Location</dt>
@@ -28,9 +28,13 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
 import type { SessionDetailResponse } from '../../../../types/api-responses'
+import { formatSessionTimeRange } from '../../utils/sessionTime'
 
 const props = defineProps<{ session: SessionDetailResponse }>()
+
+const timeLabel = computed(() => formatSessionTimeRange(props.session.time, props.session.length))
 
 function formatDate(dateStr: string): string {
   return new Date(dateStr).toLocaleDateString('en-GB', {

--- a/frontend/src/pages/sandbox/SandboxActionBars.vue
+++ b/frontend/src/pages/sandbox/SandboxActionBars.vue
@@ -161,6 +161,8 @@ const mockProjects = [
 const mockSession: SessionDetailResponse = {
   id: 1,
   date: '2025-03-01',
+  time: '09:30',
+  length: 3,
   displayName: 'Sheepskull Morning Session',
   groupId: 1,
   groupName: 'Sheepskull',

--- a/frontend/src/pages/sandbox/SandboxEmailPreSession.vue
+++ b/frontend/src/pages/sandbox/SandboxEmailPreSession.vue
@@ -41,6 +41,7 @@ const FIXTURE: Record<string, unknown> = {
   sessionTitle: 'Spring Conservation Day',
   formattedDateShort: '23 April',
   formattedDateLong: 'Wednesday, 23 April 2026',
+  formattedTime: '9:30 to 12:30 (about 3 hours)',
   description: 'Meet at the usual car park.<br>Bring waterproofs.',
   sessionUrl: 'http://localhost:3000/sessions/sheepskull/2026-04-23',
   loginUrl: 'http://localhost:3000/login?returnTo=/sessions/sheepskull/2026-04-23',

--- a/frontend/src/pages/sandbox/SandboxModals.vue
+++ b/frontend/src/pages/sandbox/SandboxModals.vue
@@ -290,6 +290,7 @@ import type { MediaItem } from '../../types/media'
 import type { EntryItem } from '../../types/entry'
 import type { PickerProfile } from '../../components/ProfilePicker.vue'
 import type { SessionSaveData } from '../modals/SessionEditModal.vue'
+import type { SessionDetailResponse } from '../../../../types/api-responses'
 
 usePageTitle('Sandbox')
 
@@ -412,18 +413,18 @@ const mockProjects = [
   { id: 11, name: 'Hedge planting', key: 'hedge-planting' },
 ]
 
-const mockSession = {
+const mockSession: SessionDetailResponse = {
   id: 1,
   displayName: 'Morning Session',
   description: 'A description of the session.',
   date: '2026-04-03',
+  time: '09:30',
+  length: 3,
   groupId: 1,
   eventbriteEventId: '',
   limits: { new: 4, total: 20 },
   storedLimits: { new: 4, total: 20 },
   stats: { count: 3, hours: 9 },
-  registrations: 3,
-  hours: 9,
   financialYear: '2025/26',
   isBookable: false,
   coverMediaId: null,

--- a/frontend/src/utils/sessionTime.test.ts
+++ b/frontend/src/utils/sessionTime.test.ts
@@ -10,6 +10,10 @@ describe('formatSessionTimeRange', () => {
     expect(formatSessionTimeRange('10:00', 2.5)).toBe('10:00 to 12:30 (2.5h)')
   })
 
+  it('rounds fractional-minute end times from floating-point arithmetic', () => {
+    expect(formatSessionTimeRange('09:30', 2.33)).toBe('9:30 to 11:50 (2.33h)')
+  })
+
   it('shows start time only when length is missing', () => {
     expect(formatSessionTimeRange('09:30')).toBe('9:30')
   })

--- a/frontend/src/utils/sessionTime.test.ts
+++ b/frontend/src/utils/sessionTime.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { formatSessionTimeRange } from './sessionTime'
+
+describe('formatSessionTimeRange', () => {
+  it('formats start time, end time, and duration', () => {
+    expect(formatSessionTimeRange('09:30', 3)).toBe('9:30 to 12:30 (3h)')
+  })
+
+  it('supports fractional hours', () => {
+    expect(formatSessionTimeRange('10:00', 2.5)).toBe('10:00 to 12:30 (2.5h)')
+  })
+
+  it('shows start time only when length is missing', () => {
+    expect(formatSessionTimeRange('09:30')).toBe('9:30')
+  })
+
+  it('shows duration only when start time is missing', () => {
+    expect(formatSessionTimeRange(undefined, 3)).toBe('3h')
+  })
+
+  it('returns null when both values are missing', () => {
+    expect(formatSessionTimeRange()).toBeNull()
+  })
+})

--- a/frontend/src/utils/sessionTime.ts
+++ b/frontend/src/utils/sessionTime.ts
@@ -8,7 +8,8 @@ function parseTimeToMinutes(time: string): number | null {
 }
 
 function formatMinutesAsTime(totalMinutes: number): string {
-  const wrapped = ((totalMinutes % (24 * 60)) + 24 * 60) % (24 * 60)
+  const rounded = Math.round(totalMinutes)
+  const wrapped = ((rounded % (24 * 60)) + 24 * 60) % (24 * 60)
   const hours = Math.floor(wrapped / 60)
   const minutes = wrapped % 60
   return `${hours}:${String(minutes).padStart(2, '0')}`

--- a/frontend/src/utils/sessionTime.ts
+++ b/frontend/src/utils/sessionTime.ts
@@ -1,0 +1,36 @@
+function parseTimeToMinutes(time: string): number | null {
+  const match = time.trim().match(/^(\d{1,2}):(\d{2})$/)
+  if (!match) return null
+  const hours = parseInt(match[1], 10)
+  const minutes = parseInt(match[2], 10)
+  if (hours > 23 || minutes > 59) return null
+  return hours * 60 + minutes
+}
+
+function formatMinutesAsTime(totalMinutes: number): string {
+  const wrapped = ((totalMinutes % (24 * 60)) + 24 * 60) % (24 * 60)
+  const hours = Math.floor(wrapped / 60)
+  const minutes = wrapped % 60
+  return `${hours}:${String(minutes).padStart(2, '0')}`
+}
+
+function formatLengthHours(hours: number): string {
+  const label = Number.isInteger(hours) ? String(hours) : String(hours)
+  return `${label}h`
+}
+
+/** Formats session start time and duration for display, e.g. "9:30 to 12:30 (3h)". */
+export function formatSessionTimeRange(time?: string, lengthHours?: number): string | null {
+  if (!time && lengthHours === undefined) return null
+
+  const startMinutes = time ? parseTimeToMinutes(time) : null
+  const lengthLabel = lengthHours !== undefined ? formatLengthHours(lengthHours) : null
+
+  if (startMinutes !== null && lengthHours !== undefined && lengthHours > 0) {
+    const endMinutes = startMinutes + lengthHours * 60
+    return `${formatMinutesAsTime(startMinutes)} to ${formatMinutesAsTime(endMinutes)} (${lengthLabel})`
+  }
+  if (startMinutes !== null) return formatMinutesAsTime(startMinutes)
+  if (lengthLabel) return lengthLabel
+  return null
+}

--- a/templates/email/pre-session/html.hbs
+++ b/templates/email/pre-session/html.hbs
@@ -4,7 +4,7 @@
 
 {{#section style="sand"}}
   <strong>Date:</strong> {{formattedDateLong}}<br>
-  <strong>Time:</strong> 9:30 to 12:30 (about 3 hours)<br>
+  <strong>Time:</strong> {{formattedTime}}<br>
   <strong>Location:</strong> By the DTV containers, Forest of Dean Cycle Centre
 {{/section}}
 

--- a/templates/email/pre-session/text.hbs
+++ b/templates/email/pre-session/text.hbs
@@ -1,7 +1,7 @@
 Hi {{volunteerName}}, you're booked onto the next {{groupName}}.
 
 Date: {{formattedDateLong}}
-Time: 9:30 to 12:30 (about 3 hours)
+Time: {{formattedTime}}
 Location: By the DTV containers, Forest of Dean Cycle Centre
 {{#if sessionTitle}}
 

--- a/types/api-responses.ts
+++ b/types/api-responses.ts
@@ -218,6 +218,10 @@ export interface SessionDetailResponse {
   displayName?: string;
   description?: string;
   date: string;
+  /** Start time HH:MM (24-hour clock); defaults to 09:30 when SharePoint Time is unset */
+  time: string;
+  /** Session duration in hours; defaults to 3 when SharePoint Length is unset */
+  length: number;
   groupId?: number;
   groupName?: string;
   groupDescription?: string;


### PR DESCRIPTION
## Summary
- Read SharePoint `Time` (HH:MM) and `Length` (hours) on sessions and expose them on `SessionDetailResponse` with API defaults of 09:30 and 3 hours when unset.
- Display the schedule on the session detail header and in pre-session notification emails via a new `formattedTime` template variable.

## Test plan
- [ ] Open a session detail page without SharePoint Time/Length set — header shows **9:30 to 12:30 (3h)**
- [ ] Set Time and Length on a session in SharePoint — header reflects the stored values
- [ ] Visit `/sandbox/email-pre-session` — time line renders from `formattedTime`
- [ ] Send a pre-session email (or preview via notify) — time matches the session schedule
- [ ] `npm run build` and `npm test` / `cd frontend && npm test` pass

Made with [Cursor](https://cursor.com)