### PR TITLE
Sessions list photos filter, bulk make public, and image-only media stats

### DIFF
--- a/backend/routes/entries.ts
+++ b/backend/routes/entries.ts
@@ -1049,7 +1049,8 @@ router.get('/entries/:id/upload-context', async (req: Request, res: Response) =>
       date: spSession.Date,
       groupKey: group?.lookupKeyName || '',
       groupName: group?.displayName || group?.lookupKeyName || '',
-      profileName: profile?.Title || rawEntry[PROFILE_DISPLAY] || 'Volunteer'
+      profileName: profile?.Title || rawEntry[PROFILE_DISPLAY] || 'Volunteer',
+      uploadsPublicDefault: req.session.user?.role === 'admin' || req.session.user?.role === 'checkin',
     };
 
     res.json({ success: true, data } as ApiResponse<EntryUploadContextResponse>);
@@ -1121,6 +1122,8 @@ router.post('/entries/:id/photos', upload.array('photos', 10), async (req: Reque
 
     const groupKey = (group?.lookupKeyName || '').toLowerCase();
     const date = spSession.Date;
+    const role = req.session.user?.role;
+    const uploadsPublicDefault = role === 'admin' || role === 'checkin';
     const folderPath = `${groupKey}/${date}`;
     let uploaded = 0;
 
@@ -1132,7 +1135,7 @@ router.post('/entries/:id/photos', upload.array('photos', 10), async (req: Reque
       const takenAt = exifDate(file.buffer) ?? new Date();
       const filename = mediaFilename(file.originalname, profileName, takenAt);
       const uploadedItem = await sharePointClient.uploadFile(driveId, `${folderPath}/${filename}`, file.buffer, file.mimetype);
-      await sharePointClient.updateMediaItemFields(driveId, uploadedItem.id, { IsPublic: false });
+      await sharePointClient.updateMediaItemFields(driveId, uploadedItem.id, { IsPublic: uploadsPublicDefault });
       uploaded++;
     }
 

--- a/backend/routes/entries.ts
+++ b/backend/routes/entries.ts
@@ -38,11 +38,12 @@ import { renderEmail } from '../services/email-renderer';
 import { buildPreSessionVars, buildPostSessionVars } from '../services/email-vars';
 
 import { computeAndSaveProfileStats } from '../services/profile-stats';
+import { refreshSessionMediaStats } from '../services/session-stats';
 import multer from 'multer';
 import { sharePointClient } from '../services/sharepoint-client';
 import { mediaDriveId, exifDate, mediaFilename } from '../services/media-upload';
 
-import type { EntryDetailResponse, EntryListItemResponse, RecentSignupResponse, EntryUploadContextResponse } from '../../types/api-responses';
+import type { MediaStatus, EntryDetailResponse, EntryListItemResponse, RecentSignupResponse, EntryUploadContextResponse } from '../../types/api-responses';
 import { trackerAccessForProfileUser } from '../services/tracker-access';
 import type { ApiResponse } from '../../types/sharepoint';
 
@@ -50,8 +51,11 @@ const router: Router = express.Router();
 
 // Recomputes and saves the Stats field for a single session after an entry change.
 // Called as fire-and-forget after entry writes so the response isn't delayed.
-// existingMedia is extracted from the cached session Stats before the write clears the cache.
-async function computeAndSaveSessionStats(sessionId: number, existingMedia: number = 0): Promise<void> {
+// preservedMedia is extracted from cached session Stats before the write clears the cache.
+async function computeAndSaveSessionStats(
+  sessionId: number,
+  preservedMedia: { media?: number; mediaStatus?: MediaStatus } = {},
+): Promise<void> {
   const start = Date.now();
   const [sessionEntries, profilesRaw] = await Promise.all([
     entriesRepository.getBySessionIds([sessionId]),
@@ -70,17 +74,30 @@ async function computeAndSaveSessionStats(sessionId: number, existingMedia: numb
   const statsMap = calculateSessionStats(sessionEntries, profileFirstSessionMap);
   const entryStats = statsMap.get(String(sessionId));
   const cancelledRegular = sessionEntries.filter(e => e[ENTRY_CANCELLED] && e.Labels?.includes('Regular')).length;
-  await sessionsRepository.updateStats(sessionId, {
+  const statsPayload: Record<string, number | MediaStatus | undefined> = {
     count: entryStats?.registrations || 0,
     hours: entryStats ? Math.round(entryStats.hours * 10) / 10 : 0,
-    media: existingMedia,
+    media: preservedMedia.media ?? 0,
     new: entryStats?.newCount || 0,
     child: entryStats?.childCount || 0,
     regular: entryStats?.regularCount || 0,
     cancelledRegular,
-    eventbrite: entryStats?.eventbriteCount || 0
-  });
+    eventbrite: entryStats?.eventbriteCount || 0,
+  };
+  if (preservedMedia.mediaStatus !== undefined) {
+    statsPayload.mediaStatus = preservedMedia.mediaStatus;
+  }
+  await sessionsRepository.updateStats(sessionId, statsPayload);
   console.log(`[Stats] Session ${sessionId} targeted stats update in ${Date.now() - start}ms`);
+}
+
+function preservedMediaFromStats(raw: string | undefined): { media?: number; mediaStatus?: MediaStatus } {
+  try {
+    const p = JSON.parse(raw || '{}');
+    return { media: p.media, mediaStatus: p.mediaStatus };
+  } catch {
+    return {};
+  }
 }
 
 const upload = multer({
@@ -459,7 +476,7 @@ router.patch('/entries/:id', async (req: Request, res: Response) => {
       }
 
       const sessionIdSelf = safeParseLookupId(spEntrySelf[SESSION_LOOKUP]);
-      let existingMediaSelf = 0;
+      let preservedMediaSelf: { media?: number; mediaStatus?: MediaStatus } = {};
       if (sessionIdSelf !== undefined) {
         const spSessionSelf = await sessionsRepository.getById(sessionIdSelf);
         if (!spSessionSelf) {
@@ -471,7 +488,7 @@ router.patch('/entries/:id', async (req: Request, res: Response) => {
           res.status(400).json({ success: false, error: 'Session has already passed' });
           return;
         }
-        try { existingMediaSelf = JSON.parse(spSessionSelf?.[SESSION_STATS] || '{}').media || 0; } catch { /* ignore */ }
+        preservedMediaSelf = preservedMediaFromStats(spSessionSelf[SESSION_STATS]);
       } else {
         res.status(404).json({ success: false, error: 'Session not found' });
         return;
@@ -482,7 +499,7 @@ router.patch('/entries/:id', async (req: Request, res: Response) => {
       }
 
       if (sessionIdSelf !== undefined) {
-        computeAndSaveSessionStats(sessionIdSelf, existingMediaSelf).catch(err =>
+        computeAndSaveSessionStats(sessionIdSelf, preservedMediaSelf).catch(err =>
           console.error(`[Stats] Failed session stats for entry ${entryId}:`, err)
         );
       }
@@ -568,10 +585,10 @@ router.patch('/entries/:id', async (req: Request, res: Response) => {
     // Read session ID + existing media count — direct Graph calls, bypass cache entirely
     const spEntry = await entriesRepository.getById(entryId);
     const sessionId = spEntry ? safeParseLookupId(spEntry[SESSION_LOOKUP]) : undefined;
-    let existingMedia = 0;
+    let preservedMedia: { media?: number; mediaStatus?: MediaStatus } = {};
     if (sessionId !== undefined) {
       const spSession = await sessionsRepository.getById(sessionId);
-      try { existingMedia = JSON.parse(spSession?.[SESSION_STATS] || '{}').media || 0; } catch { /* ignore */ }
+      preservedMedia = preservedMediaFromStats(spSession?.[SESSION_STATS]);
     }
 
     const profileId = spEntry ? safeParseLookupId(spEntry[PROFILE_LOOKUP]) : undefined;
@@ -585,7 +602,7 @@ router.patch('/entries/:id', async (req: Request, res: Response) => {
     }
 
     if (sessionId !== undefined) {
-      computeAndSaveSessionStats(sessionId, existingMedia).catch(err =>
+      computeAndSaveSessionStats(sessionId, preservedMedia).catch(err =>
         console.error(`[Stats] Failed session stats for entry ${entryId}:`, err)
       );
     }
@@ -635,10 +652,10 @@ router.delete('/entries/:id', async (req: Request, res: Response) => {
 
     // Read existing media count before delete clears the cache
     const sessionId = safeParseLookupId(entry[SESSION_LOOKUP]);
-    let existingMedia = 0;
+    let preservedMedia: { media?: number; mediaStatus?: MediaStatus } = {};
     if (sessionId !== undefined) {
       const spSession = await sessionsRepository.getById(sessionId);
-      try { existingMedia = JSON.parse(spSession?.[SESSION_STATS] || '{}').media || 0; } catch { /* ignore */ }
+      preservedMedia = preservedMediaFromStats(spSession?.[SESSION_STATS]);
     }
 
     const profileId = safeParseLookupId(entry[PROFILE_LOOKUP]);
@@ -646,7 +663,7 @@ router.delete('/entries/:id', async (req: Request, res: Response) => {
     await entriesRepository.delete(entryId);
 
     if (sessionId !== undefined) {
-      computeAndSaveSessionStats(sessionId, existingMedia).catch(err =>
+      computeAndSaveSessionStats(sessionId, preservedMedia).catch(err =>
         console.error(`[Stats] Failed targeted update for session ${sessionId}:`, err)
       );
     }
@@ -732,12 +749,11 @@ router.post('/sessions/:group/:date/entries', async (req: Request, res: Response
     const entryNotes = typeof notes === 'string' && notes.trim() ? notes : undefined;
     if (entryNotes) fields.Notes = entryNotes;
 
-    let existingMedia = 0;
-    try { existingMedia = JSON.parse(spSession[SESSION_STATS] || '{}').media || 0; } catch { /* ignore */ }
+    const preservedMedia = preservedMediaFromStats(spSession[SESSION_STATS]);
 
     const id = await entriesRepository.create(fields);
 
-    computeAndSaveSessionStats(spSession.ID, existingMedia).catch(err =>
+    computeAndSaveSessionStats(spSession.ID, preservedMedia).catch(err =>
       console.error(`[Stats] Failed session stats for entry ${id}:`, err)
     );
     computeAndSaveProfileStats(volunteerId).catch(err =>
@@ -863,8 +879,7 @@ router.post('/sessions/:group/:date/refresh', async (req: Request, res: Response
     }
 
     // Update stats in dependency order: Profile → Session
-    let existingMedia = 0;
-    try { existingMedia = JSON.parse(spSession[SESSION_STATS] || '{}').media || 0; } catch { /* ignore */ }
+    const preservedMedia = preservedMediaFromStats(spSession[SESSION_STATS]);
 
     await Promise.all([...existingVolunteerIds].map(vid =>
       computeAndSaveProfileStats(vid).catch(err =>
@@ -872,7 +887,7 @@ router.post('/sessions/:group/:date/refresh', async (req: Request, res: Response
       )
     ));
 
-    await computeAndSaveSessionStats(spSession.ID, existingMedia).catch(err =>
+    await computeAndSaveSessionStats(spSession.ID, preservedMedia).catch(err =>
       console.error(`[Stats] Failed session stats after refresh:`, err)
     );
 
@@ -913,10 +928,9 @@ router.post('/sessions/:group/:date/stats', async (req: Request, res: Response) 
       return;
     }
 
-    let existingMedia = 0;
-    try { existingMedia = JSON.parse(spSession[SESSION_STATS] || '{}').media || 0; } catch { /* ignore */ }
+    const preservedMedia = preservedMediaFromStats(spSession[SESSION_STATS]);
 
-    await computeAndSaveSessionStats(spSession.ID, existingMedia);
+    await computeAndSaveSessionStats(spSession.ID, preservedMedia);
     res.json({ success: true });
   } catch (error: any) {
     console.error('Error updating session stats:', error);
@@ -950,8 +964,7 @@ router.delete('/sessions/:group/:date/unchecked-entries', async (req: Request, r
     const sessionEntries = rawEntries.filter(e => safeParseLookupId(e[SESSION_LOOKUP]) === spSession.ID);
     const unchecked = sessionEntries.filter(e => !e.Checked);
 
-    let existingMedia = 0;
-    try { existingMedia = JSON.parse(spSession[SESSION_STATS] || '{}').media || 0; } catch { /* ignore */ }
+    const preservedMedia = preservedMediaFromStats(spSession[SESSION_STATS]);
 
     const uncheckedProfileIds = unchecked
       .map(e => safeParseLookupId(e[PROFILE_LOOKUP]))
@@ -960,7 +973,7 @@ router.delete('/sessions/:group/:date/unchecked-entries', async (req: Request, r
     await Promise.all(unchecked.map(e => entriesRepository.delete(e.ID)));
 
     if (unchecked.length > 0) {
-      computeAndSaveSessionStats(spSession.ID, existingMedia).catch(err =>
+      computeAndSaveSessionStats(spSession.ID, preservedMedia).catch(err =>
         console.error(`[Stats] Failed targeted update after removing no-shows for session ${spSession.ID}:`, err)
       );
       for (const vid of uncheckedProfileIds) {
@@ -1128,14 +1141,9 @@ router.post('/entries/:id/photos', upload.array('photos', 10), async (req: Reque
       sharePointClient.clearCacheByPrefix(`media-counts-${groupKey}`);
       // Update session Stats with fresh media count (fire-and-forget)
       if (sessionId !== undefined) {
-        (async () => {
-          try {
-            const mediaCount = await sharePointClient.getSessionMediaCount(driveId, groupKey, date);
-            await computeAndSaveSessionStats(sessionId, mediaCount);
-          } catch (err) {
-            console.error(`[Stats] Failed targeted update after upload for session ${sessionId}:`, err);
-          }
-        })();
+        refreshSessionMediaStats(sessionId, groupKey, date).catch(err => {
+          console.error(`[Stats] Failed targeted update after upload for session ${sessionId}:`, err);
+        });
       }
     }
 

--- a/backend/routes/media.ts
+++ b/backend/routes/media.ts
@@ -159,9 +159,11 @@ router.patch('/media/:itemId', requireAdmin, async (req: Request, res: Response)
     if (groupKey && date) {
       sharePointClient.clearMediaFolderCache(`${groupKey}/${date}`);
       sharePointClient.clearCacheKey(`media-counts-${groupKey}`);
-      refreshMediaStatsForSession(groupKey, date).catch(err =>
-        console.error(`[Stats] Failed media stats refresh after PATCH for ${groupKey}/${date}:`, err)
-      );
+      try {
+        await refreshMediaStatsForSession(groupKey, date);
+      } catch (err) {
+        console.error(`[Stats] Failed media stats refresh after PATCH for ${groupKey}/${date}:`, err);
+      }
     }
     res.json({ success: true });
   } catch (error: any) {
@@ -180,9 +182,11 @@ router.delete('/media/:itemId', requireAdmin, async (req: Request, res: Response
     if (groupKey && date) {
       sharePointClient.clearMediaFolderCache(`${groupKey}/${date}`);
       sharePointClient.clearCacheKey(`media-counts-${groupKey}`);
-      refreshMediaStatsForSession(groupKey, date).catch(err =>
-        console.error(`[Stats] Failed media stats refresh after DELETE for ${groupKey}/${date}:`, err)
-      );
+      try {
+        await refreshMediaStatsForSession(groupKey, date);
+      } catch (err) {
+        console.error(`[Stats] Failed media stats refresh after DELETE for ${groupKey}/${date}:`, err);
+      }
     }
     res.json({ success: true });
   } catch (error: any) {

--- a/backend/routes/media.ts
+++ b/backend/routes/media.ts
@@ -4,8 +4,21 @@ import { Readable } from 'stream';
 import { sharePointClient } from '../services/sharepoint-client';
 import { mediaDriveId } from '../services/media-upload';
 import { requireAdmin } from '../middleware/require-admin';
+import { sessionsRepository } from '../services/repositories/sessions-repository';
+import { refreshSessionMediaStats } from '../services/session-stats';
 
 const router: Router = express.Router();
+
+function sanitisePathSegment(value: string, pattern: RegExp): string {
+  return (value || '').replace(pattern, '');
+}
+
+async function refreshMediaStatsForSession(groupKey: string, date: string): Promise<void> {
+  if (!groupKey || !date) return;
+  const spSession = await sessionsRepository.getBySlug(groupKey, date);
+  if (!spSession) return;
+  await refreshSessionMediaStats(spSession.ID, groupKey, date);
+}
 
 // Batch media count by session folder. Accepts comma-separated groupKey/date paths;
 // returns non-zero counts keyed by path. Makes one Graph call per unique group key.
@@ -141,6 +154,14 @@ router.patch('/media/:itemId', requireAdmin, async (req: Request, res: Response)
   try {
     const driveId = mediaDriveId();
     await sharePointClient.updateMediaItemFields(driveId, String(req.params.itemId), fields);
+    const groupKey = sanitisePathSegment(req.query.groupKey as string, /[^a-zA-Z0-9-]/g);
+    const date = sanitisePathSegment(req.query.date as string, /[^0-9-]/g);
+    if (groupKey && date) {
+      sharePointClient.clearMediaFolderCache(`${groupKey}/${date}`);
+      refreshMediaStatsForSession(groupKey, date).catch(err =>
+        console.error(`[Stats] Failed media stats refresh after PATCH for ${groupKey}/${date}:`, err)
+      );
+    }
     res.json({ success: true });
   } catch (error: any) {
     console.error('Error updating media item:', error);
@@ -155,7 +176,12 @@ router.delete('/media/:itemId', requireAdmin, async (req: Request, res: Response
   try {
     const driveId = mediaDriveId();
     await sharePointClient.deleteMediaItem(driveId, String(req.params.itemId));
-    if (groupKey && date) sharePointClient.clearMediaFolderCache(`${groupKey}/${date}`);
+    if (groupKey && date) {
+      sharePointClient.clearMediaFolderCache(`${groupKey}/${date}`);
+      refreshMediaStatsForSession(groupKey, date).catch(err =>
+        console.error(`[Stats] Failed media stats refresh after DELETE for ${groupKey}/${date}:`, err)
+      );
+    }
     res.json({ success: true });
   } catch (error: any) {
     console.error('Error deleting media item:', error);

--- a/backend/routes/media.ts
+++ b/backend/routes/media.ts
@@ -158,6 +158,7 @@ router.patch('/media/:itemId', requireAdmin, async (req: Request, res: Response)
     const date = sanitisePathSegment(req.query.date as string, /[^0-9-]/g);
     if (groupKey && date) {
       sharePointClient.clearMediaFolderCache(`${groupKey}/${date}`);
+      sharePointClient.clearCacheKey(`media-counts-${groupKey}`);
       refreshMediaStatsForSession(groupKey, date).catch(err =>
         console.error(`[Stats] Failed media stats refresh after PATCH for ${groupKey}/${date}:`, err)
       );
@@ -178,6 +179,7 @@ router.delete('/media/:itemId', requireAdmin, async (req: Request, res: Response
     await sharePointClient.deleteMediaItem(driveId, String(req.params.itemId));
     if (groupKey && date) {
       sharePointClient.clearMediaFolderCache(`${groupKey}/${date}`);
+      sharePointClient.clearCacheKey(`media-counts-${groupKey}`);
       refreshMediaStatsForSession(groupKey, date).catch(err =>
         console.error(`[Stats] Failed media stats refresh after DELETE for ${groupKey}/${date}:`, err)
       );

--- a/backend/routes/sessions.ts
+++ b/backend/routes/sessions.ts
@@ -39,7 +39,7 @@ import type { ApiResponse } from '../../types/sharepoint';
 import { sharePointClient } from '../services/sharepoint-client';
 import { trackerAccessForProfileUser } from '../services/tracker-access';
 import { taxonomyClient } from '../services/taxonomy-client';
-import { runSessionStatsRefresh } from '../services/session-stats';
+import { runSessionStatsRefresh, refreshSessionMediaStats } from '../services/session-stats';
 
 const router: Router = express.Router();
 
@@ -757,6 +757,9 @@ router.patch('/sessions/:group/:date', async (req: Request, res: Response) => {
     // Cover image changed — bust sessions listing cache so coverUrl updates immediately
     if (SESSION_COVER_MEDIA in fields) {
       sharePointClient.clearCacheByPrefix('sessions_FY');
+      refreshSessionMediaStats(spSession.ID, groupKey, dateParam).catch(err =>
+        console.error(`[Stats] Failed media stats refresh after cover change for session ${spSession.ID}:`, err)
+      );
     }
 
     const newDate = fields.Date || dateParam;

--- a/backend/routes/sessions.ts
+++ b/backend/routes/sessions.ts
@@ -830,12 +830,13 @@ router.patch('/sessions/:group/:date', async (req: Request, res: Response) => {
         process.env.SESSIONS_LIST_GUID!, spSession.ID, SESSION_METADATA, metadataTags
       );
     }
-    // Cover image changed — bust sessions listing cache so coverUrl updates immediately
+    // Cover image changed — recompute media stats before responding so list filters stay in sync
     if (SESSION_COVER_MEDIA in fields) {
-      sharePointClient.clearCacheByPrefix('sessions_FY');
-      refreshSessionMediaStats(spSession.ID, groupKey, dateParam).catch(err =>
-        console.error(`[Stats] Failed media stats refresh after cover change for session ${spSession.ID}:`, err)
-      );
+      try {
+        await refreshSessionMediaStats(spSession.ID, groupKey, dateParam);
+      } catch (err) {
+        console.error(`[Stats] Failed media stats refresh after cover change for session ${spSession.ID}:`, err);
+      }
     }
 
     const newDate = fields.Date || dateParam;

--- a/backend/routes/sessions.ts
+++ b/backend/routes/sessions.ts
@@ -40,6 +40,7 @@ import { sharePointClient } from '../services/sharepoint-client';
 import { trackerAccessForProfileUser } from '../services/tracker-access';
 import { taxonomyClient } from '../services/taxonomy-client';
 import { runSessionStatsRefresh, refreshSessionMediaStats } from '../services/session-stats';
+import { mediaDriveId } from '../services/media-upload';
 
 const router: Router = express.Router();
 
@@ -438,6 +439,81 @@ router.post('/sessions/bulk-project', async (req: Request, res: Response) => {
     res.status(500).json({
       success: false,
       error: 'Failed to bulk update session projects',
+      message: error.message
+    });
+  }
+});
+
+router.post('/sessions/bulk-media-public', async (req: Request, res: Response) => {
+  try {
+    const { sessionIds } = req.body;
+
+    if (!Array.isArray(sessionIds) || sessionIds.length === 0) {
+      res.status(400).json({ success: false, error: 'sessionIds array is required' });
+      return;
+    }
+
+    let driveId: string;
+    try {
+      driveId = mediaDriveId();
+    } catch {
+      res.status(400).json({ success: false, error: 'Media library not configured' });
+      return;
+    }
+
+    const [rawSessions, rawGroups] = await Promise.all([
+      sessionsRepository.getAll(),
+      groupsRepository.getAll(),
+    ]);
+    const groupKeyMap = new Map(rawGroups.map(g => [g.ID, (g.Title || '').toLowerCase()]));
+
+    let sessionsUpdated = 0;
+    let itemsUpdated = 0;
+    const errors: string[] = [];
+
+    for (const rawId of sessionIds) {
+      const id = parseInt(String(rawId), 10);
+      if (isNaN(id)) continue;
+
+      const spSession = rawSessions.find(s => s.ID === id);
+      if (!spSession?.Date) continue;
+
+      const gid = safeParseLookupId(spSession[GROUP_LOOKUP]);
+      const groupKey = gid !== undefined ? groupKeyMap.get(gid) : undefined;
+      if (!groupKey) continue;
+
+      try {
+        const folderPath = `${groupKey}/${spSession.Date}`;
+        const photos = await sharePointClient.listFolderPhotos(driveId, folderPath);
+        const privateItems = photos.filter(p => !p.isPublic);
+
+        for (const item of privateItems) {
+          await sharePointClient.updateMediaItemFields(driveId, item.id, { IsPublic: true });
+          itemsUpdated++;
+        }
+
+        if (privateItems.length > 0) {
+          sharePointClient.clearMediaFolderCache(folderPath);
+        }
+
+        await refreshSessionMediaStats(id, groupKey, spSession.Date);
+        sessionsUpdated++;
+      } catch (err: any) {
+        const msg = `Session ${id}: ${err.message}`;
+        console.error(`[Bulk media public] ${msg}`);
+        errors.push(msg);
+      }
+    }
+
+    res.json({
+      success: true,
+      data: { sessionsUpdated, itemsUpdated, errors },
+    } as ApiResponse<{ sessionsUpdated: number; itemsUpdated: number; errors: string[] }>);
+  } catch (error: any) {
+    console.error('Error bulk making session media public:', error);
+    res.status(500).json({
+      success: false,
+      error: 'Failed to bulk make session media public',
       message: error.message
     });
   }

--- a/backend/services/data-layer.test.ts
+++ b/backend/services/data-layer.test.ts
@@ -230,21 +230,36 @@ describe('deriveMediaStatus', () => {
     expect(deriveMediaStatus(2, 1, 10, true)).toBe('public')
   })
 
-  it('returns noCover when public files exist but cover is unset or not public', () => {
+  it('returns noCover only when public files exist and no cover is selected', () => {
     expect(deriveMediaStatus(2, 1, null, false)).toBe('noCover')
-    expect(deriveMediaStatus(2, 1, 10, false)).toBe('noCover')
+    expect(deriveMediaStatus(0, 0, null, false)).toBe('none')
+  })
+
+  it('returns coverPrivate when public files exist but cover is set and not public', () => {
+    expect(deriveMediaStatus(2, 1, 10, false)).toBe('coverPrivate')
   })
 })
 
 describe('mediaStatsFromFolderItems', () => {
   const items = [
-    { listItemId: 1, isPublic: false },
-    { listItemId: 2, isPublic: true },
+    { listItemId: 1, isPublic: false, mimeType: 'image/jpeg' },
+    { listItemId: 2, isPublic: true, mimeType: 'image/jpeg' },
   ]
 
   it('classifies from folder items and cover lookup', () => {
     expect(mediaStatsFromFolderItems(items, 2)).toEqual({ media: 2, mediaStatus: 'public' })
     expect(mediaStatsFromFolderItems(items, null)).toEqual({ media: 2, mediaStatus: 'noCover' })
-    expect(mediaStatsFromFolderItems(items, 1)).toEqual({ media: 2, mediaStatus: 'noCover' })
+    expect(mediaStatsFromFolderItems(items, 1)).toEqual({ media: 2, mediaStatus: 'coverPrivate' })
+  })
+
+  it('counts videos in media but not in mediaStatus (cover is photo-only)', () => {
+    const videoOnly = [{ listItemId: 9, isPublic: true, mimeType: 'video/mp4' }]
+    expect(mediaStatsFromFolderItems(videoOnly, null)).toEqual({ media: 0, mediaStatus: 'none' })
+
+    const mixed = [
+      { listItemId: 1, isPublic: true, mimeType: 'video/mp4' },
+      { listItemId: 2, isPublic: true, mimeType: 'image/jpeg' },
+    ]
+    expect(mediaStatsFromFolderItems(mixed, null)).toEqual({ media: 1, mediaStatus: 'noCover' })
   })
 })

--- a/backend/services/data-layer.test.ts
+++ b/backend/services/data-layer.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { calculateFinancialYear, calculateCurrentFY, calculateSessionStats, toMatchName, extractMetadataTags, findTitleKeyClash, sessionScheduleFields, formatSessionTimeRangeProse } from './data-layer'
+import { calculateFinancialYear, calculateCurrentFY, calculateSessionStats, toMatchName, extractMetadataTags, findTitleKeyClash, sessionScheduleFields, formatSessionTimeRangeProse, deriveMediaStatus, mediaStatsFromFolderItems } from './data-layer'
 import { SESSION_TIME, SESSION_LENGTH } from './field-names'
 import type { SharePointEntry } from '../../types/sharepoint'
 import type { SharePointSession } from '../../types/session'
@@ -214,5 +214,37 @@ describe('sessionScheduleFields', () => {
       time: '09:30',
       length: 3,
     })
+  })
+})
+
+describe('deriveMediaStatus', () => {
+  it('returns none when folder is empty', () => {
+    expect(deriveMediaStatus(0, 0, null, false)).toBe('none')
+  })
+
+  it('returns allPrivate when files exist but none are public', () => {
+    expect(deriveMediaStatus(3, 0, 42, false)).toBe('allPrivate')
+  })
+
+  it('returns public when cover is set and public', () => {
+    expect(deriveMediaStatus(2, 1, 10, true)).toBe('public')
+  })
+
+  it('returns noCover when public files exist but cover is unset or not public', () => {
+    expect(deriveMediaStatus(2, 1, null, false)).toBe('noCover')
+    expect(deriveMediaStatus(2, 1, 10, false)).toBe('noCover')
+  })
+})
+
+describe('mediaStatsFromFolderItems', () => {
+  const items = [
+    { listItemId: 1, isPublic: false },
+    { listItemId: 2, isPublic: true },
+  ]
+
+  it('classifies from folder items and cover lookup', () => {
+    expect(mediaStatsFromFolderItems(items, 2)).toEqual({ media: 2, mediaStatus: 'public' })
+    expect(mediaStatsFromFolderItems(items, null)).toEqual({ media: 2, mediaStatus: 'noCover' })
+    expect(mediaStatsFromFolderItems(items, 1)).toEqual({ media: 2, mediaStatus: 'noCover' })
   })
 })

--- a/backend/services/data-layer.ts
+++ b/backend/services/data-layer.ts
@@ -29,7 +29,7 @@ import {
 } from './field-names';
 import type { MediaStatus, SessionStats } from '../../types/api-responses';
 
-const MEDIA_STATUS_VALUES = new Set<MediaStatus>(['none', 'allPrivate', 'noCover', 'public']);
+const MEDIA_STATUS_VALUES = new Set<MediaStatus>(['none', 'allPrivate', 'noCover', 'coverPrivate', 'public']);
 
 function parseMediaStatus(raw: unknown): MediaStatus | undefined {
   return typeof raw === 'string' && MEDIA_STATUS_VALUES.has(raw as MediaStatus)
@@ -47,20 +47,23 @@ export function deriveMediaStatus(
   if (mediaCount === 0) return 'none';
   if (publicMediaCount === 0) return 'allPrivate';
   if (coverMediaId != null && coverIsPublic) return 'public';
-  return 'noCover';
+  if (publicMediaCount > 0 && coverMediaId == null) return 'noCover';
+  return 'coverPrivate';
 }
 
 export function mediaStatsFromFolderItems(
-  items: { listItemId: number; isPublic: boolean }[],
+  items: { listItemId: number; isPublic: boolean; mimeType: string }[],
   coverMediaId: number | null | undefined,
 ): { media: number; mediaStatus: MediaStatus } {
-  const mediaCount = items.length;
-  const publicMediaCount = items.filter(p => p.isPublic).length;
+  // Photos only — videos in the folder are ignored until session carousel supports them (#244).
+  const images = items.filter(i => i.mimeType.startsWith('image/'));
+  const imageCount = images.length;
+  const publicImageCount = images.filter(p => p.isPublic).length;
   const coverIsPublic = coverMediaId != null
-    && items.some(p => p.listItemId === coverMediaId && p.isPublic);
+    && images.some(p => p.listItemId === coverMediaId && p.isPublic);
   return {
-    media: mediaCount,
-    mediaStatus: deriveMediaStatus(mediaCount, publicMediaCount, coverMediaId, coverIsPublic),
+    media: imageCount,
+    mediaStatus: deriveMediaStatus(imageCount, publicImageCount, coverMediaId, coverIsPublic),
   };
 }
 

--- a/backend/services/data-layer.ts
+++ b/backend/services/data-layer.ts
@@ -27,7 +27,42 @@ import {
   PROFILE_LOOKUP, PROFILE_DISPLAY,
   SESSION_NOTES, SESSION_LIMITS, SESSION_TIME, SESSION_LENGTH,
 } from './field-names';
-import type { SessionStats } from '../../types/api-responses';
+import type { MediaStatus, SessionStats } from '../../types/api-responses';
+
+const MEDIA_STATUS_VALUES = new Set<MediaStatus>(['none', 'allPrivate', 'noCover', 'public']);
+
+function parseMediaStatus(raw: unknown): MediaStatus | undefined {
+  return typeof raw === 'string' && MEDIA_STATUS_VALUES.has(raw as MediaStatus)
+    ? raw as MediaStatus
+    : undefined;
+}
+
+/** Classifies session media for the sessions list filter (mutually exclusive states). */
+export function deriveMediaStatus(
+  mediaCount: number,
+  publicMediaCount: number,
+  coverMediaId: number | null | undefined,
+  coverIsPublic: boolean,
+): MediaStatus {
+  if (mediaCount === 0) return 'none';
+  if (publicMediaCount === 0) return 'allPrivate';
+  if (coverMediaId != null && coverIsPublic) return 'public';
+  return 'noCover';
+}
+
+export function mediaStatsFromFolderItems(
+  items: { listItemId: number; isPublic: boolean }[],
+  coverMediaId: number | null | undefined,
+): { media: number; mediaStatus: MediaStatus } {
+  const mediaCount = items.length;
+  const publicMediaCount = items.filter(p => p.isPublic).length;
+  const coverIsPublic = coverMediaId != null
+    && items.some(p => p.listItemId === coverMediaId && p.isPublic);
+  return {
+    media: mediaCount,
+    mediaStatus: deriveMediaStatus(mediaCount, publicMediaCount, coverMediaId, coverIsPublic),
+  };
+}
 
 /** Parses the session Stats JSON field into a typed SessionStats object. */
 export function parseSessionStats(raw: string | undefined | null): SessionStats {
@@ -42,6 +77,7 @@ export function parseSessionStats(raw: string | undefined | null): SessionStats 
       cancelledRegular: p.cancelledRegular || undefined,
       eventbrite: p.eventbrite || undefined,
       media: p.media || undefined,
+      mediaStatus: parseMediaStatus(p.mediaStatus),
     };
   } catch {
     return { count: 0, hours: 0 };

--- a/backend/services/session-stats.ts
+++ b/backend/services/session-stats.ts
@@ -7,14 +7,60 @@ import { entriesRepository } from './repositories/entries-repository';
 import { groupsRepository } from './repositories/groups-repository';
 import { profilesRepository } from './repositories/profiles-repository';
 import { sharePointClient } from './sharepoint-client';
-import { calculateSessionStats, safeParseLookupId, parseSessionLimits } from './data-layer';
-import { GROUP_LOOKUP, SESSION_LOOKUP, SESSION_STATS, ENTRY_CANCELLED, PROFILE_LOOKUP } from './field-names';
+import {
+  calculateSessionStats,
+  safeParseLookupId,
+  mediaStatsFromFolderItems,
+} from './data-layer';
+import { GROUP_LOOKUP, SESSION_LOOKUP, SESSION_STATS, SESSION_COVER_MEDIA, ENTRY_CANCELLED, PROFILE_LOOKUP } from './field-names';
+import type { MediaStatus } from '../../types/api-responses';
 
 export interface SessionStatsRefreshResult {
   total: number;
   updated: number;
   updatedIds: number[];
   errors: string[];
+}
+
+function storedStatsMatch(
+  existing: Record<string, unknown>,
+  newStats: Record<string, unknown>,
+): boolean {
+  const keys = [
+    'count', 'hours', 'media', 'mediaStatus', 'new', 'child',
+    'regular', 'cancelledRegular', 'eventbrite',
+  ] as const;
+  return keys.every(k => existing[k] === newStats[k]);
+}
+
+/** Recomputes media count + mediaStatus for one session and merges into stored Stats. */
+export async function refreshSessionMediaStats(
+  sessionId: number,
+  groupKey: string,
+  date: string,
+): Promise<void> {
+  const mediaDriveId = process.env.MEDIA_LIBRARY_DRIVE_ID;
+  if (!mediaDriveId) return;
+
+  const spSession = await sessionsRepository.getById(sessionId);
+  if (!spSession) return;
+
+  sharePointClient.clearMediaFolderCache(`${groupKey}/${date}`);
+
+  let existingStats: Record<string, unknown> = {};
+  try {
+    existingStats = JSON.parse(spSession[SESSION_STATS] || '{}');
+  } catch { /* malformed — overwrite with fresh entry fields on next entry write */ }
+
+  const coverMediaId = safeParseLookupId(spSession[SESSION_COVER_MEDIA] as unknown as string) ?? null;
+  const photos = await sharePointClient.listFolderPhotos(mediaDriveId, `${groupKey}/${date}`);
+  const { media, mediaStatus } = mediaStatsFromFolderItems(photos, coverMediaId);
+
+  await sessionsRepository.updateStats(sessionId, {
+    ...existingStats,
+    media,
+    mediaStatus,
+  });
 }
 
 export async function runSessionStatsRefresh(): Promise<SessionStatsRefreshResult> {
@@ -90,11 +136,24 @@ export async function runSessionStatsRefresh(): Promise<SessionStatsRefreshResul
           mediaCount = mediaCountsByGroup.get(groupKey)!.get(date) || 0;
         }
 
+        let media = mediaCount;
+        let mediaStatus: MediaStatus = 'none';
+        if (mediaCount === 0) {
+          mediaStatus = 'none';
+        } else if (mediaDriveId && groupKey && date) {
+          const coverMediaId = safeParseLookupId(spSession[SESSION_COVER_MEDIA] as unknown as string) ?? null;
+          const photos = await sharePointClient.listFolderPhotos(mediaDriveId, `${groupKey}/${date}`);
+          const computed = mediaStatsFromFolderItems(photos, coverMediaId);
+          media = computed.media;
+          mediaStatus = computed.mediaStatus;
+        }
+
         const cancelledRegular = cancelledRegularMap.get(String(spSession.ID)) ?? 0;
         const newStats = {
           count: entryStats?.registrations || 0,
           hours: entryStats ? Math.round(entryStats.hours * 10) / 10 : 0,
-          media: mediaCount,
+          media,
+          mediaStatus,
           new: entryStats?.newCount || 0,
           child: entryStats?.childCount || 0,
           regular: entryStats?.regularCount || 0,
@@ -107,16 +166,7 @@ export async function runSessionStatsRefresh(): Promise<SessionStatsRefreshResul
         if (stored) {
           try {
             const existing = JSON.parse(stored);
-            if (
-              existing.count            === newStats.count &&
-              existing.hours            === newStats.hours &&
-              existing.media            === newStats.media &&
-              existing.new              === newStats.new &&
-              existing.child            === newStats.child &&
-              existing.regular          === newStats.regular &&
-              existing.cancelledRegular === newStats.cancelledRegular &&
-              existing.eventbrite       === newStats.eventbrite
-            ) {
+            if (storedStatsMatch(existing, newStats)) {
               return; // unchanged — skip write
             }
           } catch { /* malformed JSON — fall through to write */ }

--- a/backend/services/session-stats.ts
+++ b/backend/services/session-stats.ts
@@ -1,5 +1,11 @@
 /**
  * Session stats refresh — shared logic used by the admin endpoint and the nightly Eventbrite sync.
+ *
+ * Always computes from live SharePoint/list data. Stored Stats are only used to skip
+ * unchanged Graph writes — never to decide what to fetch or how to classify media.
+ *
+ * Callers that need accurate session "new" counts should run profile stats refresh first
+ * (session new-count uses profile.sessionIds). This module does not run profile stats itself.
  */
 
 import { sessionsRepository } from './repositories/sessions-repository';
@@ -7,12 +13,8 @@ import { entriesRepository } from './repositories/entries-repository';
 import { groupsRepository } from './repositories/groups-repository';
 import { profilesRepository } from './repositories/profiles-repository';
 import { sharePointClient } from './sharepoint-client';
-import {
-  calculateSessionStats,
-  safeParseLookupId,
-  mediaStatsFromFolderItems,
-} from './data-layer';
-import { GROUP_LOOKUP, SESSION_LOOKUP, SESSION_STATS, SESSION_COVER_MEDIA, ENTRY_CANCELLED, PROFILE_LOOKUP } from './field-names';
+import { calculateSessionStats, safeParseLookupId, mediaStatsFromFolderItems } from './data-layer';
+import { GROUP_LOOKUP, SESSION_LOOKUP, SESSION_STATS, SESSION_COVER_MEDIA, ENTRY_CANCELLED } from './field-names';
 import type { MediaStatus } from '../../types/api-responses';
 
 export interface SessionStatsRefreshResult {
@@ -33,7 +35,29 @@ function storedStatsMatch(
   return keys.every(k => existing[k] === newStats[k]);
 }
 
-/** Recomputes media count + mediaStatus for one session and merges into stored Stats. */
+function buildProfileFirstSessionMap(profilesRaw: Awaited<ReturnType<typeof profilesRepository.getAll>>): Map<number, number> {
+  const profileFirstSessionMap = new Map<number, number>();
+  for (const p of profilesRaw) {
+    try {
+      const ps = JSON.parse(p.Stats || '{}');
+      if (Array.isArray(ps.sessionIds) && ps.sessionIds.length > 0)
+        profileFirstSessionMap.set(p.ID, ps.sessionIds[0]);
+    } catch { /* malformed */ }
+  }
+  return profileFirstSessionMap;
+}
+
+async function liveMediaStats(
+  mediaDriveId: string,
+  groupKey: string,
+  date: string,
+  coverMediaId: number | null,
+): Promise<{ media: number; mediaStatus: MediaStatus }> {
+  const photos = await sharePointClient.listFolderPhotos(mediaDriveId, `${groupKey}/${date}`);
+  return mediaStatsFromFolderItems(photos, coverMediaId);
+}
+
+/** Recomputes media count + mediaStatus for one session from the live media folder. */
 export async function refreshSessionMediaStats(
   sessionId: number,
   groupKey: string,
@@ -47,14 +71,13 @@ export async function refreshSessionMediaStats(
 
   sharePointClient.clearMediaFolderCache(`${groupKey}/${date}`);
 
+  const coverMediaId = safeParseLookupId(spSession[SESSION_COVER_MEDIA] as unknown as string) ?? null;
+  const { media, mediaStatus } = await liveMediaStats(mediaDriveId, groupKey, date, coverMediaId);
+
   let existingStats: Record<string, unknown> = {};
   try {
     existingStats = JSON.parse(spSession[SESSION_STATS] || '{}');
-  } catch { /* malformed — overwrite with fresh entry fields on next entry write */ }
-
-  const coverMediaId = safeParseLookupId(spSession[SESSION_COVER_MEDIA] as unknown as string) ?? null;
-  const photos = await sharePointClient.listFolderPhotos(mediaDriveId, `${groupKey}/${date}`);
-  const { media, mediaStatus } = mediaStatsFromFolderItems(photos, coverMediaId);
+  } catch { /* malformed */ }
 
   await sessionsRepository.updateStats(sessionId, {
     ...existingStats,
@@ -67,29 +90,23 @@ export async function runSessionStatsRefresh(): Promise<SessionStatsRefreshResul
   const start = Date.now();
   console.log('[Stats] Starting session stats refresh');
 
+  // Bust cached media listings so every session reads the live folder.
+  sharePointClient.clearCacheByPrefix('media_folder_');
+  sharePointClient.clearCacheByPrefix('media-counts-');
+
   const [sessionsRaw, entriesRaw, groupsRaw, profilesRaw] = await Promise.all([
     sessionsRepository.getAll(),
     entriesRepository.getAll(),
     groupsRepository.getAll(),
-    profilesRepository.getAll()
+    profilesRepository.getAll(),
   ]);
 
   console.log(`[Stats] Fetched ${sessionsRaw.length} sessions, ${entriesRaw.length} entries in ${Date.now() - start}ms`);
 
-  // Build profileId → first sessionId from profile.stats.sessionIds[0]
-  const profileFirstSessionMap = new Map<number, number>();
-  for (const p of profilesRaw) {
-    try {
-      const ps = JSON.parse(p.Stats || '{}');
-      if (Array.isArray(ps.sessionIds) && ps.sessionIds.length > 0)
-        profileFirstSessionMap.set(p.ID, ps.sessionIds[0]);
-    } catch { /* malformed */ }
-  }
-
+  const profileFirstSessionMap = buildProfileFirstSessionMap(profilesRaw);
   const groupKeyMap = new Map(groupsRaw.map(g => [g.ID, (g.Title || '').toLowerCase()]));
   const statsMap = calculateSessionStats(entriesRaw, profileFirstSessionMap);
 
-  // Build per-session cancelled regular counts
   const cancelledRegularMap = new Map<string, number>();
   for (const e of entriesRaw) {
     if (!e[ENTRY_CANCELLED]) continue;
@@ -99,24 +116,6 @@ export async function runSessionStatsRefresh(): Promise<SessionStatsRefreshResul
   }
 
   const mediaDriveId = process.env.MEDIA_LIBRARY_DRIVE_ID;
-  const mediaCountsByGroup = new Map<string, Map<string, number>>();
-  if (mediaDriveId) {
-    const uniqueGroupKeys = [...new Set(
-      sessionsRaw
-        .map(s => {
-          const gid = safeParseLookupId(s[GROUP_LOOKUP]);
-          return gid !== undefined ? groupKeyMap.get(gid) : undefined;
-        })
-        .filter((k): k is string => !!k)
-    )];
-    const mediaStart = Date.now();
-    await Promise.all(uniqueGroupKeys.map(async (groupKey) => {
-      const counts = await sharePointClient.listGroupDateCounts(mediaDriveId, groupKey);
-      mediaCountsByGroup.set(groupKey, counts);
-    }));
-    console.log(`[Stats] Media counts fetched for ${uniqueGroupKeys.length} groups in ${Date.now() - mediaStart}ms`);
-  }
-
   const total = sessionsRaw.length;
   let updated = 0;
   const updatedIds: number[] = [];
@@ -131,19 +130,11 @@ export async function runSessionStatsRefresh(): Promise<SessionStatsRefreshResul
         const groupKey = gid !== undefined ? groupKeyMap.get(gid) : undefined;
         const date = spSession.Date;
 
-        let mediaCount = 0;
-        if (groupKey && date && mediaCountsByGroup.has(groupKey)) {
-          mediaCount = mediaCountsByGroup.get(groupKey)!.get(date) || 0;
-        }
-
-        let media = mediaCount;
+        let media = 0;
         let mediaStatus: MediaStatus = 'none';
-        if (mediaCount === 0) {
-          mediaStatus = 'none';
-        } else if (mediaDriveId && groupKey && date) {
+        if (mediaDriveId && groupKey && date) {
           const coverMediaId = safeParseLookupId(spSession[SESSION_COVER_MEDIA] as unknown as string) ?? null;
-          const photos = await sharePointClient.listFolderPhotos(mediaDriveId, `${groupKey}/${date}`);
-          const computed = mediaStatsFromFolderItems(photos, coverMediaId);
+          const computed = await liveMediaStats(mediaDriveId, groupKey, date, coverMediaId);
           media = computed.media;
           mediaStatus = computed.mediaStatus;
         }
@@ -161,13 +152,12 @@ export async function runSessionStatsRefresh(): Promise<SessionStatsRefreshResul
           eventbrite: entryStats?.eventbriteCount || 0,
         };
 
-        // Skip if stored stats already match — avoids unnecessary Graph writes
         const stored = spSession[SESSION_STATS];
         if (stored) {
           try {
             const existing = JSON.parse(stored);
             if (storedStatsMatch(existing, newStats)) {
-              return; // unchanged — skip write
+              return;
             }
           } catch { /* malformed JSON — fall through to write */ }
         }

--- a/backend/services/sharepoint-client.ts
+++ b/backend/services/sharepoint-client.ts
@@ -870,13 +870,20 @@ export class SharePointClient {
       const token = await this.getAccessToken();
       const encodedPath = folderPath.split('/').map(encodeURIComponent).join('/');
       // Include listItem to get SharePoint list item ID (for CoverMedia lookup) and custom columns
-      const url = `https://graph.microsoft.com/v1.0/drives/${driveId}/root:/${encodedPath}:/children?$select=id,name,webUrl,file&$expand=thumbnails,listItem($select=id;$expand=fields($select=Title,IsPublic))`;
+      let url: string | undefined =
+        `https://graph.microsoft.com/v1.0/drives/${driveId}/root:/${encodedPath}:/children?$select=id,name,webUrl,file&$expand=thumbnails,listItem($select=id;$expand=fields($select=Title,IsPublic))&$top=999`;
 
-      const response = await axios.get(url, {
-        headers: { 'Authorization': `Bearer ${token}` }
-      });
+      const rawItems: any[] = [];
 
-      const result = (response.data.value as any[])
+      while (url) {
+        const response = await axios.get(url, {
+          headers: { 'Authorization': `Bearer ${token}` }
+        });
+        rawItems.push(...(response.data.value as any[]));
+        url = response.data['@odata.nextLink'] as string | undefined;
+      }
+
+      const result = rawItems
         .filter(item => item.file?.mimeType?.startsWith('image/') || item.file?.mimeType?.startsWith('video/'))
         .map(item => ({
           id: item.id as string,

--- a/docs/api.md
+++ b/docs/api.md
@@ -48,6 +48,7 @@ Self-service users get the **Public** GET allowlist plus their own profile (`/pr
 | `/api/sessions/refresh-stats` | POST | Admin / API key | Bulk refresh pre-computed stats for all sessions |
 | `/api/sessions/bulk-tag` | POST | Admin | Apply taxonomy terms to multiple sessions |
 | `/api/sessions/bulk-project` | POST | Admin | Set project lookup on multiple sessions (`projectId: number \| null`) |
+| `/api/sessions/bulk-media-public` | POST | Admin | Mark all media in selected session folders as public |
 | `/api/sessions/:group/:date` | GET | Public | Session detail with entries |
 | `/api/sessions/:group/:date` | PATCH | Check In+ | Update session (name, description, date, cover) |
 | `/api/sessions/:group/:date` | DELETE | Admin | Delete session |

--- a/docs/features/media.md
+++ b/docs/features/media.md
@@ -26,6 +26,8 @@ Path derived from the session's group key and date — browsable directly in Sha
 
 Upload page at `/upload?entryId=:id`. Requires authentication — self-service users can upload to their own entries; Admin and Check In can upload to any entry.
 
+**Default visibility:** self-service uploads are saved **private** (`IsPublic: false`); admin and check-in uploads default to **public** (`IsPublic: true`). Set in `POST /api/entries/:id/photos` from session role.
+
 Accepted formats: photos (JPG, PNG, WebP, HEIC) and short videos (MP4, MOV). Up to 10 files, 10 MB each.
 
 Capture date is extracted server-side from EXIF data (images) or MP4/MOV container metadata (videos) and used when writing the file to SharePoint. Implementation: `media-upload.ts`.
@@ -34,9 +36,11 @@ Completion screen shows file count and links to the session gallery.
 
 ## Gallery
 
-Session detail page shows a photo/video gallery with an inline lightbox. Rendered from `GET /api/media?groupKey=&date=`, which lists files from the session's folder in the Media library.
+Session detail page shows a photo gallery with an inline lightbox. Rendered from `GET /api/media?groupKey=&date=`, which lists files from the session's folder in the Media library.
 
-Videos play inline in the lightbox via `GET /api/media/:itemId/stream` (Graph API `/content` redirect).
+**Photos-only in the app today:** session stats, list filters, and the detail carousel all ignore videos. Videos can be uploaded and stored in SharePoint but are invisible in the UI until [#244](https://github.com/gothandy/dtv-tracker-app/issues/244) (carousel + playback).
+
+Videos play inline in the lightbox via `GET /api/media/:itemId/stream` (Graph API `/content` redirect) — planned when #244 is implemented.
 
 Public users see only items marked `IsPublic`. The `name` and `webUrl` fields (which contain the uploader's name in the filename) are stripped from public API responses.
 

--- a/docs/features/session-stats.md
+++ b/docs/features/session-stats.md
@@ -17,7 +17,8 @@ Profile Stats are a parallel system — stored on Profile items — and feed int
   "regular": 8,
   "cancelledRegular": 1,
   "eventbrite": 3,
-  "media": 5
+  "media": 5,
+  "mediaStatus": "public"
 }
 ```
 
@@ -34,7 +35,8 @@ All counts exclude cancelled entries, except `cancelledRegular` which counts onl
 | `regular` | non-cancelled entries with `Labels.includes('Regular')` | |
 | `cancelledRegular` | **cancelled** entries with `Labels.includes('Regular')` | used to warn when regular didn't show |
 | `eventbrite` | non-cancelled entries with `EventbriteAttendeeID` set | |
-| `media` | public photo/video count from SharePoint media library | not derived from entries; used by homepage carousel to find sessions with photos |
+| `media` | total photo/video count in session media folder | not derived from entries; used by homepage carousel |
+| `mediaStatus` | `listFolderPhotos` + `CoverMediaLookupId` | `none` / `allPrivate` / `noCover` / `public` — sessions list Media filter |
 
 ### Entry classification
 

--- a/docs/features/session-stats.md
+++ b/docs/features/session-stats.md
@@ -35,8 +35,8 @@ All counts exclude cancelled entries, except `cancelledRegular` which counts onl
 | `regular` | non-cancelled entries with `Labels.includes('Regular')` | |
 | `cancelledRegular` | **cancelled** entries with `Labels.includes('Regular')` | used to warn when regular didn't show |
 | `eventbrite` | non-cancelled entries with `EventbriteAttendeeID` set | |
-| `media` | total photo/video count in session media folder | not derived from entries; used by homepage carousel |
-| `mediaStatus` | `listFolderPhotos` + `CoverMediaLookupId` | `none` / `allPrivate` / `noCover` / `public` — sessions list Media filter |
+| `media` | photo count in session media folder | images only — videos in the folder are ignored until carousel support (#244) |
+| `mediaStatus` | cover/public classification for sessions list Photos filter | derived from images only; `none` = no photos (empty folder or video-only) |
 
 ### Entry classification
 
@@ -62,7 +62,7 @@ Session stats are written in three different contexts. All use the same field de
 
 **When:** Fire-and-forget after any entry write (PATCH, POST create, POST refresh, DELETE).
 
-**How:** Fetches only that session's entries + all profiles (to build `profileFirstSessionMap` for `new` count). Reads the existing `media` count from the cached session Stats so it isn't wiped on every entry change.
+**How:** Fetches only that session's entries + all profiles (to build `profileFirstSessionMap` for `new` count). Preserves existing `media` / `mediaStatus` in Stats so entry-only writes do not wipe media fields (media is refreshed separately via `refreshSessionMediaStats` on upload/delete/cover change).
 
 ### 2. Full bulk refresh
 
@@ -70,7 +70,7 @@ Session stats are written in three different contexts. All use the same field de
 
 **When:** `POST /sessions/refresh-stats` (admin UI) or triggered by the nightly Eventbrite sync.
 
-**How:** Fetches all sessions, entries, groups, and profiles in one pass. Re-fetches media counts from SharePoint for each group. Skips sessions where stored stats already match to minimise Graph API writes. Clears the sessions cache after the bulk update.
+**How:** Clears cached media folder listings, then fetches all sessions, entries, groups, and profiles. For each session with a media library folder, reads the live folder via `listFolderPhotos` and derives `media` + `mediaStatus`. Entry aggregates come from live entries and whatever profile Stats are currently stored (run profile stats refresh first when accurate `new` counts matter — nightly Eventbrite sync does profile then session). Stored Stats are compared only to skip unchanged Graph writes — never used to decide what to fetch. Clears the sessions cache after the bulk update.
 
 ### 3. Session detail live computation
 

--- a/docs/features/session-stats.md
+++ b/docs/features/session-stats.md
@@ -70,7 +70,7 @@ Session stats are written in three different contexts. All use the same field de
 
 **When:** `POST /sessions/refresh-stats` (admin UI) or triggered by the nightly Eventbrite sync.
 
-**How:** Clears cached media folder listings, then fetches all sessions, entries, groups, and profiles. For each session with a media library folder, reads the live folder via `listFolderPhotos` and derives `media` + `mediaStatus`. Entry aggregates come from live entries and whatever profile Stats are currently stored (run profile stats refresh first when accurate `new` counts matter — nightly Eventbrite sync does profile then session). Stored Stats are compared only to skip unchanged Graph writes — never used to decide what to fetch. Clears the sessions cache after the bulk update.
+**How:** Clears cached media folder listings, then fetches all sessions, entries, groups, and profiles. For each session with a media library folder, reads the live folder via `listFolderPhotos` (pages through Graph `@odata.nextLink` so large folders are fully counted) and derives `media` + `mediaStatus`. Entry aggregates come from live entries and whatever profile Stats are currently stored (run profile stats refresh first when accurate `new` counts matter — nightly Eventbrite sync does profile then session). Stored Stats are compared only to skip unchanged Graph writes — never used to decide what to fetch. Clears the sessions cache after the bulk update.
 
 ### 3. Session detail live computation
 

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,5 +1,11 @@
 # Development Progress
 
+## Session: 2026-06-19 (Sessions list Media filter)
+
+- `mediaStatus` on session Stats JSON (`none` / `allPrivate` / `noCover` / `public`) computed in bulk refresh and on media/cover writes.
+- Sessions list Media filter dropdown — Public for all users; operational states for check-in/admin.
+- Run **Refresh Session Stats** after deploy to backfill existing sessions.
+
 ## Session: 2026-06-10 (docs.dtv.org.uk redirect)
 
 - Early middleware in `app.js` 301-redirects `docs.dtv.org.uk` to `FRONTEND_URL` + `/docs` (path and query preserved); legacy privacy-notice path mapped to canonical slug.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -4,6 +4,7 @@
 
 - `mediaStatus` on session Stats JSON (`none` / `allPrivate` / `noCover` / `public`) computed in bulk refresh and on media/cover writes.
 - Sessions list Media filter dropdown — Public for all users; operational states for check-in/admin.
+- `listFolderPhotos` follows Graph `@odata.nextLink` so media stats include all folder pages (not just the first page).
 - Run **Refresh Session Stats** after deploy to backfill existing sessions.
 
 ## Session: 2026-06-10 (docs.dtv.org.uk redirect)

--- a/docs/testing/full-regression.md
+++ b/docs/testing/full-regression.md
@@ -568,7 +568,7 @@ Run with `npm run dev` at http://localhost:3000. Log in via Microsoft Entra ID.
 - [ ] Media filter only matches sessions with stored `stats.mediaStatus` (run session stats refresh after deploy to backfill)
 - [ ] If the active tag is not present in the newly selected group, tag is auto-cleared
 - [ ] "Select all" / "Deselect all" respects current visible sessions
-- [ ] "Add Tags" and "Update Project" enabled only when ≥1 session checked
+- [ ] "Media Public" enabled when ≥1 session checked; confirm modal → `POST /api/sessions/bulk-media-public` with `{ sessionIds }` → private media in those folders marked public; sessions list refreshes
 - [ ] Closing Advanced clears selection and hides checkboxes
 
 ### L4. Sort

--- a/docs/testing/full-regression.md
+++ b/docs/testing/full-regression.md
@@ -563,6 +563,9 @@ Run with `npm run dev` at http://localhost:3000. Log in via Microsoft Entra ID.
 - [ ] Tag dropdown (tree picker): shows only tags present in sessions matching current FY + search + group + project
 - [ ] Selecting a group, project, or tag narrows the other dropdown options; clearing one filter re-expands the others
 - [ ] Project filter in URL as `?project=` (`__none__` or project key); cleared when that project has no sessions under the current FY/filters
+- [ ] Media filter: **All sessions** (default); **Public** visible to everyone; **No media**, **All private**, **No cover** visible to check-in/admin only
+- [ ] Media filter URL param `?media=` (`none`, `allPrivate`, `noCover`, `public`); trusted-only values ignored for public users
+- [ ] Media filter only matches sessions with stored `stats.mediaStatus` (run session stats refresh after deploy to backfill)
 - [ ] If the active tag is not present in the newly selected group, tag is auto-cleared
 - [ ] "Select all" / "Deselect all" respects current visible sessions
 - [ ] "Add Tags" and "Update Project" enabled only when ≥1 session checked

--- a/docs/testing/full-regression.md
+++ b/docs/testing/full-regression.md
@@ -567,7 +567,8 @@ Run with `npm run dev` at http://localhost:3000. Log in via Microsoft Entra ID.
 - [ ] Tag dropdown (tree picker): shows only tags present in sessions matching current FY + search + group + project
 - [ ] Selecting a group, project, or tag narrows the other dropdown options; clearing one filter re-expands the others
 - [ ] Project filter in URL as `?project=` (`__none__` or project key); cleared when that project has no sessions under the current FY/filters
-- [ ] Photos filter: **All sessions** (default); **Public cover** visible to everyone; **No photos**, **All photos private**, **No cover photo** visible to check-in/admin only
+- [ ] Photos filter: **All sessions** (default); **Public photos** visible to everyone; **No photos**, **All photos private**, **No cover photo** visible to check-in/admin only
+- [ ] **Public photos** filter (`media=public`): each session card shows cover image above the card (4:3 crop); filter still requires public cover selected in stats
 - [ ] Photos filter URL param `?media=` (`none`, `allPrivate`, `noCover`, `public`); trusted-only values ignored for public users
 - [ ] Photos filter only matches stored `stats.mediaStatus` (run session stats refresh after deploy to backfill)
 - [ ] **No photos** (`media=none`): no images in folder — includes empty folders and video-only sessions (videos ignored in stats until #244)

--- a/docs/testing/full-regression.md
+++ b/docs/testing/full-regression.md
@@ -575,7 +575,7 @@ Run with `npm run dev` at http://localhost:3000. Log in via Microsoft Entra ID.
 - [ ] **No cover photo**: at least one public image, no cover lookup (`mediaStatus=noCover`, no `coverUrl`)
 - [ ] If the active tag is not present in the newly selected group, tag is auto-cleared
 - [ ] "Select all" / "Deselect all" respects current visible sessions
-- [ ] "Media Public" enabled when ≥1 session checked; confirm modal → `POST /api/sessions/bulk-media-public` with `{ sessionIds }` → private media in those folders marked public; sessions list refreshes
+- [ ] "Make Public" enabled when ≥1 session checked; confirm modal → `POST /api/sessions/bulk-media-public` with `{ sessionIds }` → private media in those folders marked public; sessions list refreshes
 - [ ] Closing Advanced clears selection and hides checkboxes
 
 ### L4. Sort

--- a/docs/testing/full-regression.md
+++ b/docs/testing/full-regression.md
@@ -352,6 +352,10 @@ Run with `npm run dev` at http://localhost:3000. Log in via Microsoft Entra ID.
 - [ ] Upload → each file shows "✓ Uploaded" status; non-supported file (e.g. PDF) shows "✗ Failed"
 - [ ] Files appear in SharePoint Media Library at `{groupKey}/{date}/`
 - [ ] Completion step shows file count ("N files uploaded") and "View session gallery" link
+- [ ] Self-service completion note mentions photos stay private until marked public; check-in/admin note says photos are added to the gallery
+- [ ] Selecting a video file shows info banner (video stored but not yet viewable in Tracker); photos-only selection does not
+- [ ] Self-service upload → SharePoint media item `IsPublic` false
+- [ ] Check-in/admin upload → SharePoint media item `IsPublic` true
 - [ ] "View session gallery" link navigates to the correct session detail page
 - [ ] `POST /api/entries/:id/photos` — self-service for another volunteer's entry returns 403
 
@@ -563,9 +567,11 @@ Run with `npm run dev` at http://localhost:3000. Log in via Microsoft Entra ID.
 - [ ] Tag dropdown (tree picker): shows only tags present in sessions matching current FY + search + group + project
 - [ ] Selecting a group, project, or tag narrows the other dropdown options; clearing one filter re-expands the others
 - [ ] Project filter in URL as `?project=` (`__none__` or project key); cleared when that project has no sessions under the current FY/filters
-- [ ] Media filter: **All sessions** (default); **Public** visible to everyone; **No media**, **All private**, **No cover** visible to check-in/admin only
-- [ ] Media filter URL param `?media=` (`none`, `allPrivate`, `noCover`, `public`); trusted-only values ignored for public users
-- [ ] Media filter only matches sessions with stored `stats.mediaStatus` (run session stats refresh after deploy to backfill)
+- [ ] Photos filter: **All sessions** (default); **Public cover** visible to everyone; **No photos**, **All photos private**, **No cover photo** visible to check-in/admin only
+- [ ] Photos filter URL param `?media=` (`none`, `allPrivate`, `noCover`, `public`); trusted-only values ignored for public users
+- [ ] Photos filter only matches stored `stats.mediaStatus` (run session stats refresh after deploy to backfill)
+- [ ] **No photos** (`media=none`): no images in folder — includes empty folders and video-only sessions (videos ignored in stats until #244)
+- [ ] **No cover photo**: at least one public image, no cover lookup (`mediaStatus=noCover`, no `coverUrl`)
 - [ ] If the active tag is not present in the newly selected group, tag is auto-cleared
 - [ ] "Select all" / "Deselect all" respects current visible sessions
 - [ ] "Media Public" enabled when ≥1 session checked; confirm modal → `POST /api/sessions/bulk-media-public` with `{ sessionIds }` → private media in those folders marked public; sessions list refreshes

--- a/frontend/src/components/FileUploadPicker.vue
+++ b/frontend/src/components/FileUploadPicker.vue
@@ -79,7 +79,7 @@ const props = withDefaults(
   }
 )
 
-const emit = defineEmits<{ done: [uploadedCount: number] }>()
+const emit = defineEmits<{ done: [uploadedCount: number]; selectionChange: [files: File[]] }>()
 
 const fileInput = ref<HTMLInputElement | null>(null)
 const dragOver = ref(false)
@@ -97,6 +97,10 @@ function statusLabel(status: FileUploadItemStatus) {
   return 'Failed'
 }
 
+function emitSelection() {
+  emit('selectionChange', files.value.map(f => f.file))
+}
+
 function addFiles(incoming: FileList | null) {
   if (!incoming || uploading.value) return
   for (const file of Array.from(incoming)) {
@@ -104,6 +108,7 @@ function addFiles(incoming: FileList | null) {
       files.value.push({ file, name: file.name, status: 'pending' })
     }
   }
+  emitSelection()
 }
 
 function onDrop(e: DragEvent) {

--- a/frontend/src/components/sessions/SessionListActions.vue
+++ b/frontend/src/components/sessions/SessionListActions.vue
@@ -7,7 +7,7 @@
     <div class="list-actions-buttons">
       <AppButton label="Add Tags" icon="add" mode="icon-responsive" :disabled="!selectedSessions.length" @click="emit('add-tags')" />
       <AppButton label="Update Project" icon="save" mode="icon-responsive" :disabled="!selectedSessions.length" @click="emit('update-project')" />
-      <AppButton label="Media Public" icon="uploadphoto" mode="icon-responsive" :disabled="!selectedSessions.length" :working="mediaPublicWorking" @click="emit('media-public')" />
+      <AppButton label="Make Public" icon="uploadphoto" mode="icon-responsive" :disabled="!selectedSessions.length" :working="mediaPublicWorking" @click="emit('media-public')" />
       <AppButton label="Download CSV" icon="download" mode="icon-only" :disabled="!selectedSessions.length" @click="onDownload" />
       <AppButton label="Share" icon="share" mode="icon-only" @click="onShare" />
       <AppButton label="Add session" icon="add" mode="icon-only" @click="emit('add-session')" />

--- a/frontend/src/components/sessions/SessionListActions.vue
+++ b/frontend/src/components/sessions/SessionListActions.vue
@@ -7,6 +7,7 @@
     <div class="list-actions-buttons">
       <AppButton label="Add Tags" icon="add" mode="icon-responsive" :disabled="!selectedSessions.length" @click="emit('add-tags')" />
       <AppButton label="Update Project" icon="save" mode="icon-responsive" :disabled="!selectedSessions.length" @click="emit('update-project')" />
+      <AppButton label="Media Public" icon="uploadphoto" mode="icon-responsive" :disabled="!selectedSessions.length" :working="mediaPublicWorking" @click="emit('media-public')" />
       <AppButton label="Download CSV" icon="download" mode="icon-only" :disabled="!selectedSessions.length" @click="onDownload" />
       <AppButton label="Share" icon="share" mode="icon-only" @click="onShare" />
       <AppButton label="Add session" icon="add" mode="icon-only" @click="emit('add-session')" />
@@ -25,12 +26,14 @@ const props = defineProps<{
   sessions: Session[]
   selected: number[]
   canBulkTag: boolean
+  mediaPublicWorking?: boolean
 }>()
 
 const emit = defineEmits<{
   'update:selected': [ids: number[]]
   'add-tags': []
   'update-project': []
+  'media-public': []
   'add-session': []
 }>()
 

--- a/frontend/src/components/sessions/SessionListFilter.vue
+++ b/frontend/src/components/sessions/SessionListFilter.vue
@@ -17,6 +17,13 @@
       <option value="__none__">No project</option>
       <option v-for="p in projectOptions" :key="p.key" :value="p.key">{{ p.title }}</option>
     </select>
+    <select v-model="mediaStatus" class="list-filter-select">
+      <option value="">All sessions</option>
+      <option v-if="profile?.hasCheckInAccess" value="none">No media</option>
+      <option v-if="profile?.hasCheckInAccess" value="allPrivate">All private</option>
+      <option v-if="profile?.hasCheckInAccess" value="noCover">No cover</option>
+      <option value="public">Public</option>
+    </select>
     <TermPicker
       v-model="tagLabel"
       :tree="taxonomyTree"
@@ -33,9 +40,13 @@ import { useRoute, useRouter } from 'vue-router'
 import FyFilter from '../FyFilter.vue'
 import TermPicker from '../TermPicker.vue'
 import { useTaxonomy } from '../../composables/useTaxonomy'
+import type { RoleContext } from '../../composables/useViewer'
+import type { MediaStatus } from '../../types/session'
 import type { Session } from '../../types/session'
 
-const props = defineProps<{ sessions: Session[] }>()
+const TRUSTED_MEDIA_FILTERS = new Set<MediaStatus>(['none', 'allPrivate', 'noCover'])
+
+const props = defineProps<{ sessions: Session[]; profile?: RoleContext }>()
 const emit = defineEmits<{ filtered: [sessions: Session[]] }>()
 
 const { tree: taxonomyTree, loading: taxonomyLoading } = useTaxonomy()
@@ -47,6 +58,16 @@ const search   = ref((route.query.search as string) || '')
 const groupKey = ref((route.query.group as string) || '')
 const projectKey = ref((route.query.project as string) || '')
 const tagLabel = ref((route.query.tag as string) || '')
+
+function initialMediaFilter(): string {
+  const raw = (route.query.media as string) || ''
+  if (!raw) return ''
+  if (raw === 'public') return 'public'
+  if (props.profile?.hasCheckInAccess && TRUSTED_MEDIA_FILTERS.has(raw as MediaStatus)) return raw
+  return ''
+}
+
+const mediaStatus = ref(initialMediaFilter())
 
 function rollingStart(): string {
   const d = new Date()
@@ -93,12 +114,17 @@ function applyTag(list: Session[]): Session[] {
   )
 }
 
+function applyMedia(list: Session[]): Session[] {
+  if (!mediaStatus.value) return list
+  return list.filter(s => s.stats.mediaStatus === mediaStatus.value)
+}
+
 // Cascading: each dropdown only shows options present in sessions matching all other filters
 const base = computed(() => applyBase(props.sessions))
 
 const groupOptions = computed(() => {
   const map = new Map<string, string>()
-  for (const s of applyProject(applyTag(base.value))) {
+  for (const s of applyMedia(applyProject(applyTag(base.value)))) {
     if (s.groupKey && s.groupName) map.set(s.groupKey, s.groupName)
   }
   return [...map.entries()].map(([key, name]) => ({ key, name })).sort((a, b) => a.name.localeCompare(b.name))
@@ -106,7 +132,7 @@ const groupOptions = computed(() => {
 
 const projectOptions = computed(() => {
   const map = new Map<string, { key: string; title: string }>()
-  for (const s of applyTag(applyGroup(base.value))) {
+  for (const s of applyMedia(applyTag(applyGroup(base.value)))) {
     if (!s.projectId) continue
     const key = s.projectKey ?? String(s.projectId)
     const title = s.projectTitle ?? s.projectKey ?? String(s.projectId)
@@ -117,12 +143,12 @@ const projectOptions = computed(() => {
 
 const availableTagLabels = computed(() => {
   const labels = new Set<string>()
-  for (const s of applyProject(applyGroup(base.value))) s.metadata?.forEach(t => labels.add(t.label))
+  for (const s of applyMedia(applyProject(applyGroup(base.value)))) s.metadata?.forEach(t => labels.add(t.label))
   return labels
 })
 
 const filtered = computed(() => {
-  const list = applyProject(applyTag(applyGroup(base.value)))
+  const list = applyMedia(applyProject(applyTag(applyGroup(base.value))))
   return fy.value === 'future'
     ? [...list].sort((a, b) => a.date.localeCompare(b.date))
     : list
@@ -135,13 +161,23 @@ watch(projectOptions, opts => {
   if (!opts.some(p => p.key === projectKey.value)) projectKey.value = ''
 }, { immediate: true })
 
-watch([fy, search, groupKey, projectKey, tagLabel], ([newFy, newSearch, newGroup, newProject, newTag]) => {
+watch(
+  () => props.profile?.hasCheckInAccess,
+  hasAccess => {
+    if (!hasAccess && TRUSTED_MEDIA_FILTERS.has(mediaStatus.value as MediaStatus)) {
+      mediaStatus.value = ''
+    }
+  },
+)
+
+watch([fy, search, groupKey, projectKey, tagLabel, mediaStatus], ([newFy, newSearch, newGroup, newProject, newTag, newMedia]) => {
   const query: Record<string, string> = {}
   if (newFy)     query.fy     = newFy
   if (newSearch) query.search = newSearch
   if (newGroup)  query.group  = newGroup
   if (newProject) query.project = newProject
   if (newTag)    query.tag    = newTag
+  if (newMedia)  query.media  = newMedia
   router.replace({ query })
 })
 </script>

--- a/frontend/src/components/sessions/SessionListFilter.vue
+++ b/frontend/src/components/sessions/SessionListFilter.vue
@@ -17,12 +17,12 @@
       <option value="__none__">No project</option>
       <option v-for="p in projectOptions" :key="p.key" :value="p.key">{{ p.title }}</option>
     </select>
-    <select v-model="mediaStatus" class="list-filter-select">
+    <select v-model="mediaStatus" class="list-filter-select" aria-label="Photos filter">
       <option value="">All sessions</option>
-      <option v-if="profile?.hasCheckInAccess" value="none">No media</option>
-      <option v-if="profile?.hasCheckInAccess" value="allPrivate">All private</option>
-      <option v-if="profile?.hasCheckInAccess" value="noCover">No cover</option>
-      <option value="public">Public</option>
+      <option v-if="profile?.hasCheckInAccess" value="none">No photos</option>
+      <option v-if="profile?.hasCheckInAccess" value="allPrivate">All photos private</option>
+      <option v-if="profile?.hasCheckInAccess" value="noCover">No cover photo</option>
+      <option value="public">Public cover</option>
     </select>
     <TermPicker
       v-model="tagLabel"
@@ -59,15 +59,31 @@ const groupKey = ref((route.query.group as string) || '')
 const projectKey = ref((route.query.project as string) || '')
 const tagLabel = ref((route.query.tag as string) || '')
 
-function initialMediaFilter(): string {
+function mediaFromRouteQuery(): string {
   const raw = (route.query.media as string) || ''
-  if (!raw) return ''
   if (raw === 'public') return 'public'
-  if (props.profile?.hasCheckInAccess && TRUSTED_MEDIA_FILTERS.has(raw as MediaStatus)) return raw
+  if (TRUSTED_MEDIA_FILTERS.has(raw as MediaStatus)) return raw
   return ''
 }
 
-const mediaStatus = ref(initialMediaFilter())
+const mediaStatus = ref(mediaFromRouteQuery())
+
+// Trusted media filters require check-in access — but auth loads after first paint on refresh.
+// Keep the URL value until we know the viewer is not check-in/admin.
+watch(
+  () => [props.profile?.isPublic, props.profile?.isAuthenticated, props.profile?.hasCheckInAccess] as const,
+  ([isPublic, isAuthenticated, hasAccess]) => {
+    const raw = mediaFromRouteQuery()
+    if (!raw) return
+    if (raw === 'public') {
+      mediaStatus.value = 'public'
+      return
+    }
+    if (!isPublic && !isAuthenticated && !hasAccess) return
+    mediaStatus.value = hasAccess ? raw : ''
+  },
+  { immediate: true },
+)
 
 function rollingStart(): string {
   const d = new Date()
@@ -116,6 +132,15 @@ function applyTag(list: Session[]): Session[] {
 
 function applyMedia(list: Session[]): Session[] {
   if (!mediaStatus.value) return list
+  if (mediaStatus.value === 'none') {
+    return list.filter(s => s.stats.mediaStatus === 'none')
+  }
+  if (mediaStatus.value === 'noCover') {
+    return list.filter(s =>
+      s.stats.mediaStatus === 'noCover'
+      && !s.coverUrl,
+    )
+  }
   return list.filter(s => s.stats.mediaStatus === mediaStatus.value)
 }
 
@@ -160,15 +185,6 @@ watch(projectOptions, opts => {
   if (!projectKey.value || projectKey.value === '__none__') return
   if (!opts.some(p => p.key === projectKey.value)) projectKey.value = ''
 }, { immediate: true })
-
-watch(
-  () => props.profile?.hasCheckInAccess,
-  hasAccess => {
-    if (!hasAccess && TRUSTED_MEDIA_FILTERS.has(mediaStatus.value as MediaStatus)) {
-      mediaStatus.value = ''
-    }
-  },
-)
 
 watch([fy, search, groupKey, projectKey, tagLabel, mediaStatus], ([newFy, newSearch, newGroup, newProject, newTag, newMedia]) => {
   const query: Record<string, string> = {}

--- a/frontend/src/components/sessions/SessionListFilter.vue
+++ b/frontend/src/components/sessions/SessionListFilter.vue
@@ -22,7 +22,7 @@
       <option v-if="profile?.hasCheckInAccess" value="none">No photos</option>
       <option v-if="profile?.hasCheckInAccess" value="allPrivate">All photos private</option>
       <option v-if="profile?.hasCheckInAccess" value="noCover">No cover photo</option>
-      <option value="public">Public cover</option>
+      <option value="public">Public photos</option>
     </select>
     <TermPicker
       v-model="tagLabel"

--- a/frontend/src/components/sessions/SessionListResults.vue
+++ b/frontend/src/components/sessions/SessionListResults.vue
@@ -12,14 +12,22 @@
 
       <div class="list-card-grid">
         <div v-for="s in sessions" :key="s.id" class="list-card-item">
-          <input
-            v-if="profile.isAdmin && selected"
-            type="checkbox"
-            class="list-card-checkbox"
-            :checked="selected.includes(s.id)"
-            @change="toggle(s.id)"
+          <img
+            v-if="showCoverPhotos && s.coverUrl"
+            :src="s.coverUrl"
+            :alt="coverAlt(s)"
+            class="session-list-cover"
           />
-          <SessionCard :session="s" :profile="profile.context" />
+          <div class="list-card-entry">
+            <input
+              v-if="profile.isAdmin && selected"
+              type="checkbox"
+              class="list-card-checkbox"
+              :checked="selected.includes(s.id)"
+              @change="toggle(s.id)"
+            />
+            <SessionCard :session="s" :profile="profile.context" />
+          </div>
         </div>
       </div>
     </template>
@@ -37,6 +45,8 @@ const props = defineProps<{
   sessions: Session[]
   loading?: boolean
   selected?: number[]
+  /** When Photos filter is Public photos — show cover image above each card. */
+  showCoverPhotos?: boolean
 }>()
 
 const emit = defineEmits<{ 'update:selected': [ids: number[]] }>()
@@ -58,6 +68,12 @@ function toggle(id: number) {
     : [...props.selected, id]
   emit('update:selected', next)
 }
+
+function coverAlt(s: Session): string {
+  const date = new Date(s.date).toLocaleDateString('en-GB', { day: 'numeric', month: 'short' })
+  const name = s.displayName || s.groupName || s.groupKey || 'Session'
+  return `${name}, ${date}`
+}
 </script>
 
 <style scoped>
@@ -67,5 +83,22 @@ function toggle(id: number) {
   padding: 1.25rem 1.5rem 1.5rem;
   color: var(--color-text-muted);
   font-size: 0.9rem;
+}
+
+.session-list-cover {
+  display: block;
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+  background: var(--color-dtv-dark);
+}
+
+.list-card-entry {
+  position: relative;
+}
+
+.list-card-entry > .list-card-checkbox {
+  top: 1rem;
+  right: 1.5rem;
 }
 </style>

--- a/frontend/src/pages/SessionDetailPage.vue
+++ b/frontend/src/pages/SessionDetailPage.vue
@@ -751,7 +751,7 @@ async function onMediaSave(item: MediaItem, data: { title: string; isPublic: boo
   mediaSaveWorking.value = true
   mediaSaveError.value = undefined
   try {
-    const res = await fetch(`/api/media/${item.id}`, {
+    const res = await fetch(`/api/media/${item.id}?groupKey=${groupKey}&date=${date}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ title: data.title, isPublic: data.isPublic }),

--- a/frontend/src/pages/SessionListPage.vue
+++ b/frontend/src/pages/SessionListPage.vue
@@ -13,7 +13,12 @@
       @media-public="showMediaPublicModal = true"
       @add-session="showAddSession = true"
     />
-    <SessionListResults :sessions="filtered" :loading="store.loading" v-model:selected="selected" />
+    <SessionListResults
+      :sessions="filtered"
+      :loading="store.loading"
+      :show-cover-photos="showCoverPhotos"
+      v-model:selected="selected"
+    />
 
     <SessionAddTagsModal
       v-if="showTagModal"
@@ -57,6 +62,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import DefaultLayout from '../layouts/DefaultLayout.vue'
 import { usePageTitle } from '../composables/usePageTitle'
 import PageHeader from '../components/PageHeader.vue'
@@ -73,18 +79,19 @@ import { useGroupListStore } from '../stores/groupList'
 import { useProjectListStore } from '../stores/projectList'
 import type { ProjectItem } from './modals/SessionEditModal.vue'
 import { useViewer } from '../composables/useViewer'
-import { useRouter } from 'vue-router'
 import { sessionPath } from '../router'
 import type { Session } from '../types/session'
 import { pruneSelectionToVisible, visibleSelected } from '../utils/listSelection'
 
 usePageTitle('Sessions')
 
+const route = useRoute()
 const store = useSessionListStore()
 const groupsStore = useGroupListStore()
 const projectsStore = useProjectListStore()
 const profile = useViewer()
 const router = useRouter()
+const showCoverPhotos = computed(() => route.query.media === 'public')
 const filtered = ref<Session[]>([])
 const selected = ref<number[]>([])
 const showTagModal = ref(false)

--- a/frontend/src/pages/SessionListPage.vue
+++ b/frontend/src/pages/SessionListPage.vue
@@ -6,9 +6,11 @@
     <SessionListActions
       :sessions="filtered"
       :can-bulk-tag="profile.isAdmin"
+      :media-public-working="mediaPublicWorking"
       v-model:selected="selected"
       @add-tags="showTagModal = true"
       @update-project="openProjectModal"
+      @media-public="showMediaPublicModal = true"
       @add-session="showAddSession = true"
     />
     <SessionListResults :sessions="filtered" :loading="store.loading" v-model:selected="selected" />
@@ -30,6 +32,15 @@
       :error="projectError"
       @close="showProjectModal = false"
       @save="onApplyProject"
+    />
+
+    <SessionBulkMediaPublicModal
+      v-if="showMediaPublicModal"
+      :count="visibleSelectedCount"
+      :working="mediaPublicWorking"
+      :error="mediaPublicError"
+      @close="showMediaPublicModal = false"
+      @confirm="onApplyMediaPublic"
     />
 
     <GroupAddSessionModal
@@ -54,6 +65,7 @@ import SessionListActions from '../components/sessions/SessionListActions.vue'
 import SessionListResults from '../components/sessions/SessionListResults.vue'
 import SessionAddTagsModal from './modals/SessionAddTagsModal.vue'
 import SessionBulkProjectModal from './modals/SessionBulkProjectModal.vue'
+import SessionBulkMediaPublicModal from './modals/SessionBulkMediaPublicModal.vue'
 import GroupAddSessionModal from './modals/GroupAddSessionModal.vue'
 import type { AddSessionPayload } from './modals/GroupAddSessionModal.vue'
 import { useSessionListStore } from '../stores/sessionList'
@@ -81,6 +93,9 @@ const tagError = ref('')
 const showProjectModal = ref(false)
 const projectWorking = ref(false)
 const projectError = ref('')
+const showMediaPublicModal = ref(false)
+const mediaPublicWorking = ref(false)
+const mediaPublicError = ref('')
 const showAddSession = ref(false)
 const addSessionWorking = ref(false)
 const addSessionError = ref('')
@@ -177,6 +192,35 @@ async function onApplyProject(projectId: number | null) {
   projectWorking.value = false
   projectError.value = ''
   selected.value = []
+}
+
+async function onApplyMediaPublic() {
+  mediaPublicWorking.value = true
+  mediaPublicError.value = ''
+  const sessionIds = visibleSelected(selected.value, filtered.value).map(s => s.id)
+  try {
+    const res = await fetch('/api/sessions/bulk-media-public', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sessionIds }),
+    })
+    if (!res.ok) {
+      const json = await res.json().catch(() => ({})) as { error?: string }
+      throw new Error(json.error || 'Make media public failed — please try again')
+    }
+    const json = await res.json() as { data?: { errors?: string[] } }
+    if (json.data?.errors?.length) {
+      console.error('[SessionListPage] bulk-media-public partial errors', json.data.errors)
+    }
+    showMediaPublicModal.value = false
+    selected.value = []
+    await store.fetch()
+  } catch (e) {
+    mediaPublicError.value = e instanceof Error ? e.message : 'An error occurred'
+    console.error('[SessionListPage] bulk-media-public failed', e)
+  } finally {
+    mediaPublicWorking.value = false
+  }
 }
 
 async function onAddSession(data: AddSessionPayload) {

--- a/frontend/src/pages/SessionListPage.vue
+++ b/frontend/src/pages/SessionListPage.vue
@@ -2,7 +2,7 @@
   <DefaultLayout>
     <h1 class="sr-only">Sessions</h1>
     <PageHeader>Sessions</PageHeader>
-    <SessionListFilter :sessions="store.sessions" @filtered="filtered = $event" />
+    <SessionListFilter :sessions="store.sessions" :profile="profile.context" @filtered="filtered = $event" />
     <SessionListActions
       :sessions="filtered"
       :can-bulk-tag="profile.isAdmin"

--- a/frontend/src/pages/UploadPage.vue
+++ b/frontend/src/pages/UploadPage.vue
@@ -18,7 +18,7 @@
         <p class="status-text">
           <strong>{{ uploadedTotal }}</strong> {{ uploadedTotal === 1 ? 'file' : 'files' }} uploaded successfully.
         </p>
-        <p class="status-note">Photos are reviewed before appearing publicly.</p>
+        <p class="status-note">{{ completionNote }}</p>
         <FormSubmitRow>
           <AppButton usage="task" label="View session gallery" @click="router.push(galleryHref)" />
         </FormSubmitRow>
@@ -29,12 +29,18 @@
         :title="`Upload for ${ctx.profileName}`"
         :subtitle="sessionSubtitle"
       >
+        <AlertBanner
+          v-if="hasVideoSelection"
+          type="info"
+          message="Tracker currently doesn't support viewing video. Your video will be uploaded and will be available to users once this feature is available."
+        />
         <FileUploadPicker
           ref="pickerRef"
           accept=".jpg,.jpeg,.png,.webp,.heic,.mp4,.mov"
           empty-label="Tap or drag to add photos &amp; videos"
           hint="JPG, PNG, WebP, HEIC, MP4, MOV · max 15 MB each · up to 10 files"
           :upload-file="uploadPhoto"
+          @selection-change="onSelectionChange"
           @done="onUploadDone"
         />
       </FormCard>
@@ -51,7 +57,9 @@ import FormCard from '../components/forms/FormCard.vue'
 import FormSubmitRow from '../components/forms/FormSubmitRow.vue'
 import AppButton from '../components/AppButton.vue'
 import FileUploadPicker from '../components/FileUploadPicker.vue'
+import AlertBanner from '../components/forms/AlertBanner.vue'
 import { sessionPath } from '../router/index'
+import { isVideoFile } from '../utils/mediaFiles'
 
 usePageTitle('Upload Photos')
 
@@ -67,6 +75,7 @@ interface UploadContext {
   groupKey: string
   groupName: string
   profileName: string
+  uploadsPublicDefault: boolean
 }
 
 interface LoadError {
@@ -87,13 +96,20 @@ const ctx = ref<UploadContext>({
   groupKey: '',
   groupName: '',
   profileName: '',
+  uploadsPublicDefault: false,
 })
 
 const done = ref(false)
 const uploadedTotal = ref(0)
+const hasVideoSelection = ref(false)
 
 const galleryHref = computed(() => sessionPath(ctx.value.groupKey, ctx.value.date))
 const sessionSubtitle = computed(() => `${formatDateShort(ctx.value.date)}, ${ctx.value.groupName}`)
+const completionNote = computed(() =>
+  ctx.value.uploadsPublicDefault
+    ? 'Photos are added to the session gallery.'
+    : 'Photos are private until a volunteer coordinator marks them public.',
+)
 
 function formatDateShort(dateStr: string): string {
   return new Date(dateStr).toLocaleDateString('en-GB', { day: 'numeric', month: 'short' })
@@ -112,6 +128,10 @@ async function uploadPhoto(file: File): Promise<boolean> {
     return false
   }
   return res.ok
+}
+
+function onSelectionChange(files: File[]) {
+  hasVideoSelection.value = files.some(isVideoFile)
 }
 
 function onUploadDone(count: number) {
@@ -166,6 +186,10 @@ onMounted(async () => {
   display: flex;
   flex-direction: column;
   gap: 1rem;
+}
+
+.upload-stack :deep(.alert-banner) {
+  margin-bottom: 0.75rem;
 }
 
 .status-text {

--- a/frontend/src/pages/modals/SessionBulkMediaPublicModal.vue
+++ b/frontend/src/pages/modals/SessionBulkMediaPublicModal.vue
@@ -1,0 +1,45 @@
+<template>
+  <ModalLayout
+    title="Make media public"
+    action="Apply"
+    action-icon="uploadphoto"
+    :working="working"
+    :error="error"
+    @close="emit('close')"
+    @action="emit('confirm')"
+  >
+    <p class="sbmp-count">{{ count }} session{{ count === 1 ? '' : 's' }} selected</p>
+    <p class="sbmp-body">
+      All private photos and videos in the selected session folders will be marked public.
+    </p>
+  </ModalLayout>
+</template>
+
+<script setup lang="ts">
+import ModalLayout from '../../components/ModalLayout.vue'
+
+defineProps<{
+  count: number
+  working?: boolean
+  error?: string
+}>()
+
+const emit = defineEmits<{
+  close: []
+  confirm: []
+}>()
+</script>
+
+<style scoped>
+.sbmp-count {
+  font-size: 0.9rem;
+  color: var(--color-text-muted);
+  margin: 0 0 0.5rem;
+}
+
+.sbmp-body {
+  font-size: 0.9rem;
+  margin: 0;
+  line-height: 1.45;
+}
+</style>

--- a/frontend/src/types/session.ts
+++ b/frontend/src/types/session.ts
@@ -2,9 +2,9 @@
 // Mapped from SessionResponse (types/api-responses.ts) in the sessions store.
 // To add a field: add it here, then map it in src/stores/sessions.ts.
 
-import type { SessionStats } from '../../../types/api-responses'
+import type { SessionStats, MediaStatus } from '../../../types/api-responses'
 
-export type { SessionStats }
+export type { SessionStats, MediaStatus }
 
 export interface SessionLimits {
   new?: number

--- a/frontend/src/utils/mediaFiles.ts
+++ b/frontend/src/utils/mediaFiles.ts
@@ -1,0 +1,8 @@
+const VIDEO_EXTENSIONS = new Set(['.mp4', '.mov', '.m4v'])
+
+/** True when the file is a video (MIME or extension fallback for mobile browsers). */
+export function isVideoFile(file: File): boolean {
+  if (file.type.startsWith('video/')) return true
+  const ext = file.name.includes('.') ? file.name.slice(file.name.lastIndexOf('.')).toLowerCase() : ''
+  return VIDEO_EXTENSIONS.has(ext)
+}

--- a/types/api-responses.ts
+++ b/types/api-responses.ts
@@ -7,7 +7,7 @@
 
 import type { SessionLimits } from '../backend/services/data-layer';
 
-export type MediaStatus = 'none' | 'allPrivate' | 'noCover' | 'public'
+export type MediaStatus = 'none' | 'allPrivate' | 'noCover' | 'coverPrivate' | 'public'
 
 export interface SessionStats {
   count: number
@@ -375,4 +375,6 @@ export interface EntryUploadContextResponse {
   groupKey: string;
   groupName: string;
   profileName: string;
+  /** True when this uploader's files are saved as public (admin/check-in). */
+  uploadsPublicDefault: boolean;
 }

--- a/types/api-responses.ts
+++ b/types/api-responses.ts
@@ -7,6 +7,8 @@
 
 import type { SessionLimits } from '../backend/services/data-layer';
 
+export type MediaStatus = 'none' | 'allPrivate' | 'noCover' | 'public'
+
 export interface SessionStats {
   count: number
   hours: number
@@ -16,6 +18,8 @@ export interface SessionStats {
   cancelledRegular?: number
   eventbrite?: number
   media?: number
+  /** Pre-computed from media folder privacy and cover selection — used by sessions list Media filter. */
+  mediaStatus?: MediaStatus
 }
 
 export interface GroupRegularResponse {


### PR DESCRIPTION
## Summary

- Add a **Photos** filter on the sessions list driven by stored `stats.mediaStatus` (`none`, `allPrivate`, `noCover`, `public`), with URL param `?media=`. Public users see **Public photos** only; check-in/admin see all filter options.
- When **Public photos** is active, show a 4:3 cover thumbnail above each session card.
- Add bulk **Make Public** action (admin) to mark all private media in selected session folders public via `POST /api/sessions/bulk-media-public`.
- Compute session photo stats from **images only** (videos stored but ignored in stats/filters until #244); simplify session stats refresh to always read live folder data.
- **Upload UX**: info banner when a video is selected (not yet viewable in carousel); admin/check-in uploads default to public, self-service stays private.
- **Fix**: await `refreshSessionMediaStats` on cover change and media PATCH/DELETE so sessions list filters and `coverUrl` stay in sync after carousel edits.

## Test plan

- [ ] Run session stats refresh (Tools) after deploy to backfill `mediaStatus` on existing sessions
- [ ] Sessions list: each Photos filter option (`?media=none|allPrivate|noCover|public`) matches expected sessions; public users cannot use trusted-only filters
- [ ] `?media=public`: cover thumbnails appear above cards; only sessions with public cover in stats
- [ ] Set/change cover on session detail → return to sessions list with Public photos filter → session appears with correct cover
- [ ] Bulk **Make Public**: select sessions with private photos → confirm → photos public; list refreshes
- [ ] Upload page: select video → info banner shown; trusted upload defaults public, self-service private
- [ ] Video-only session folder: appears under **No photos**, not **No cover photo**; gallery empty (images only)
- [ ] `npm run build` and `cd frontend && npm test` pass
