### PR TITLE
Fix homepage calendar date query and FY bar chart navigation

### DIFF
--- a/docs/testing/full-regression.md
+++ b/docs/testing/full-regression.md
@@ -529,6 +529,11 @@ Run with `npm run dev` at http://localhost:3000. Log in via Microsoft Entra ID.
 **As a public or read-only user:**
 - [ ] Calendar, Next/Last, and session cards behave exactly as before — no personalisation applied
 
+**Calendar date query (`/?date=YYYY-MM-DD`):**
+- [ ] Valid date with sessions opens that month with the date selected and sessions listed
+- [ ] Valid date without sessions opens that month with the date highlighted (green); session panel empty; empty dates still not clickable
+- [ ] Invalid or missing `date` query falls back to default next/last session selection
+
 **Word cloud:**
 - [ ] Homepage loads with top 5 tags visible by default (cloud still shows, just limited)
 - [ ] Clicking Show History expands the full word cloud alongside the FY bar chart
@@ -583,6 +588,7 @@ Run with `npm run dev` at http://localhost:3000. Log in via Microsoft Entra ID.
 
 ### L20. Taxonomy tag word cloud
 - [ ] **Homepage**: Word cloud card appears below FY stats (requires sessions tagged with taxonomy tags); font sizes vary by hours; selecting a different FY from the bar chart updates the cloud
+- [ ] **Homepage**: Clicking the already-selected FY bar navigates to `/sessions?fy=FY20XX&media=public` for that year (cover photos visible)
 - [ ] **Group detail**: Word cloud card appears between FY bar chart and sessions list; selecting a different FY updates the cloud; selecting "All" hides the FY param (shows all-time for that group)
 - [ ] **Profile detail**: Word cloud card appears between Groups card and Records card; FY filter change updates the cloud; selecting a group from the group dropdown updates the cloud (scoped to that group)
 - [ ] **Hierarchy**: A parent tag (e.g. "DH") appears larger/darker than its children (e.g. "Sheepskull"), which appear larger than grandchildren — depth shown via colour and size

--- a/frontend/src/components/CalendarWidget.vue
+++ b/frontend/src/components/CalendarWidget.vue
@@ -201,6 +201,16 @@ function dateKey(day: number): string {
   return `${currentYear.value}-${m}-${d}`
 }
 
+function isValidDateKey(key: string): boolean {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(key)
+  if (!match) return false
+  const y = Number(match[1])
+  const m = Number(match[2])
+  const d = Number(match[3])
+  const date = new Date(y, m - 1, d)
+  return date.getFullYear() === y && date.getMonth() === m - 1 && date.getDate() === d
+}
+
 function cellClasses(day: number): string[] {
   const key = dateKey(day)
   const hasSession = sessionIndex.value.has(key)
@@ -212,8 +222,10 @@ function cellClasses(day: number): string[] {
     'relative aspect-square w-full flex flex-col items-center justify-center text-sm select-none',
     isToday ? 'font-bold' : '',
     hasSession && !isSelected ? 'bg-dtv-gold text-white cursor-pointer hover:brightness-110' : '',
-    isSelected ? '!bg-dtv-green !text-white cursor-pointer' : '',
-    !hasSession ? 'bg-white text-dtv-dark/40 cursor-default' : '',
+    isSelected ? '!bg-dtv-green !text-white' : '',
+    isSelected && hasSession ? 'cursor-pointer' : '',
+    !hasSession && !isSelected ? 'bg-white text-dtv-dark/40 cursor-default' : '',
+    !hasSession && isSelected ? 'cursor-default' : '',
     hasDot ? 'pb-2' : '',
   ].filter(Boolean)
 }
@@ -230,14 +242,19 @@ function handleDayClick(day: number) {
   if (belowBreakpointMd()) el.value?.scrollIntoView({ behavior: 'smooth', block: 'start' })
 }
 
-function selectDate(key: string) {
-  if (!sessionIndex.value.has(key)) return
+function setSelectedDate(key: string) {
+  if (!isValidDateKey(key)) return
   selectedKey.value = key
   const [y, m] = key.split('-').map(Number)
   currentYear.value = y
   currentMonth.value = m - 1
   emit('update:modelValue', key)
-  emit('select', sessionIndex.value.get(key)!)
+  emit('select', sessionIndex.value.get(key) ?? [])
+}
+
+function selectDate(key: string) {
+  if (!sessionIndex.value.has(key)) return
+  setSelectedDate(key)
 }
 
 function navigateMonth(delta: number) {
@@ -273,17 +290,19 @@ function findDefaultKey(): string | null {
 }
 
 watch(() => props.modelValue, (val) => {
-  if (val && val !== selectedKey.value) selectDate(val)
+  if (val && val !== selectedKey.value && isValidDateKey(val)) setSelectedDate(val)
   else if (!val) selectedKey.value = null
 })
 
 // Re-run selection when sessions load (store fetch completes after mount)
 watch(() => props.sessions, () => {
+  if (props.modelValue && isValidDateKey(props.modelValue)) {
+    setSelectedDate(props.modelValue)
+    return
+  }
   if (selectedKey.value && sessionIndex.value.has(selectedKey.value)) {
-    // Sessions just arrived — re-emit for the already-selected key (e.g. from URL)
-    selectDate(selectedKey.value)
+    setSelectedDate(selectedKey.value)
   } else {
-    // No valid selection — pick the best default for these sessions
     selectedKey.value = null
     const key = findDefaultKey()
     if (key) selectDate(key)
@@ -291,14 +310,13 @@ watch(() => props.sessions, () => {
 })
 
 onMounted(() => {
+  if (props.modelValue && isValidDateKey(props.modelValue)) {
+    setSelectedDate(props.modelValue)
+    return
+  }
   if (!selectedKey.value) {
     const key = findDefaultKey()
     if (key) selectDate(key)
-  } else {
-    const [y, m] = selectedKey.value.split('-').map(Number)
-    currentYear.value = y
-    currentMonth.value = m - 1
-    emit('select', sessionIndex.value.get(selectedKey.value) ?? [])
   }
 })
 </script>

--- a/frontend/src/pages/GroupDetailPage.vue
+++ b/frontend/src/pages/GroupDetailPage.vue
@@ -259,10 +259,10 @@ watchEffect(async () => {
   }
 })
 
-function onSelectedBarClick() {
+function onSelectedBarClick(fy: string) {
   const key = store.group?.key
   if (!key) return
-  router.push({ path: '/sessions', query: { fy: 'all', group: key } })
+  router.push({ path: '/sessions', query: { fy, group: key, media: 'public' } })
 }
 
 function onTagClick(_termGuid: string, label: string) {

--- a/frontend/src/pages/HomePage.vue
+++ b/frontend/src/pages/HomePage.vue
@@ -317,8 +317,8 @@ watchEffect(async () => {
   }
 })
 
-function onSelectedBarClick() {
-  router.push({ path: '/sessions', query: { fy: 'all' } })
+function onSelectedBarClick(fy: string) {
+  router.push({ path: '/sessions', query: { fy, media: 'public' } })
 }
 
 function onTagClick(_termGuid: string, label: string) {


### PR DESCRIPTION
## Summary

- Honour a valid `?date=YYYY-MM-DD` on the homepage calendar even when that day has no sessions — the month and date stay selected; empty dates remain unclickable
- Fix FY bar chart click-through on homepage and group detail: navigate with the selected FY (was hardcoded to `fy=all`) and include `media=public` so cover photos show on the sessions list

## Test plan

- [ ] Open `/?date=2026-06-25` with no session on that date — calendar shows June 2026 with 25th highlighted; session panel empty
- [ ] Open `/?date=` on a date with sessions — sessions listed as before
- [ ] Homepage: select an FY bar, click it again — navigates to `/sessions?fy=FY20XX&media=public` with cover photos visible
- [ ] Group detail: same bar click-through includes `group=` and `media=public`

Made with [Cursor](https://cursor.com)