### PR TITLE
Profile bulk email, Add Entries, and past-session admin tools

### DIFF
--- a/backend/routes/entries.ts
+++ b/backend/routes/entries.ts
@@ -324,6 +324,85 @@ router.get('/entries', async (req: Request, res: Response) => {
   }
 });
 
+router.post('/entries/bulk', async (req: Request, res: Response) => {
+  try {
+    const { profileIds, sessionId } = req.body;
+    if (!Array.isArray(profileIds) || profileIds.length === 0) {
+      res.status(400).json({ success: false, error: 'profileIds array is required' });
+      return;
+    }
+    const sid = parseInt(String(sessionId), 10);
+    if (isNaN(sid)) {
+      res.status(400).json({ success: false, error: 'sessionId is required and must be a number' });
+      return;
+    }
+
+    const today = new Date().toISOString().slice(0, 10);
+    const [rawSessions, rawProfiles] = await Promise.all([
+      sessionsRepository.getAll(),
+      profilesRepository.getAll(),
+    ]);
+
+    const sessions = validateArray(rawSessions, validateSession, 'Session');
+    const spSession = sessions.find(s => s.ID === sid);
+    if (!spSession?.Date) {
+      res.status(404).json({ success: false, error: 'Session not found' });
+      return;
+    }
+    if (spSession.Date < today) {
+      res.status(400).json({ success: false, error: 'Session has already passed' });
+      return;
+    }
+
+    const profiles = validateArray(rawProfiles, validateProfile, 'Profile');
+    const profileMap = new Map(profiles.map(p => [p.ID, p]));
+    const requestedIds = profileIds
+      .map((id: unknown) => parseInt(String(id), 10))
+      .filter((id: number) => !isNaN(id));
+
+    const sessionEntries = await entriesRepository.getBySessionIds([sid]);
+    const existingProfileIds = new Set(
+      sessionEntries
+        .map(e => safeParseLookupId(e[PROFILE_LOOKUP]))
+        .filter((id): id is number => id !== undefined)
+    );
+
+    const preservedMedia = preservedMediaFromStats(spSession[SESSION_STATS]);
+    let created = 0;
+    let skipped = 0;
+
+    for (const profileId of requestedIds) {
+      const profile = profileMap.get(profileId);
+      if (!profile?.ID || profile.IsGroup) {
+        skipped++;
+        continue;
+      }
+      if (existingProfileIds.has(profileId)) {
+        skipped++;
+        continue;
+      }
+      await entriesRepository.create({
+        [SESSION_LOOKUP]: String(sid),
+        [PROFILE_LOOKUP]: String(profileId),
+      });
+      existingProfileIds.add(profileId);
+      created++;
+      computeAndSaveProfileStats(profileId).catch(err =>
+        console.error(`[Stats] Failed targeted profile update for profile ${profileId}:`, err)
+      );
+    }
+
+    computeAndSaveSessionStats(sid, preservedMedia).catch(err =>
+      console.error(`[Stats] Failed session stats for bulk entries on session ${sid}:`, err)
+    );
+
+    res.json({ success: true, data: { created, skipped } } as ApiResponse<{ created: number; skipped: number }>);
+  } catch (error: any) {
+    console.error('Error bulk creating entries:', error);
+    res.status(500).json({ success: false, error: 'Failed to bulk create entries', message: error.message });
+  }
+});
+
 // GET /entries/:id — entry detail by SharePoint ID
 router.get('/entries/:id', async (req: Request, res: Response) => {
   try {

--- a/backend/routes/entries.ts
+++ b/backend/routes/entries.ts
@@ -35,7 +35,7 @@ import {
 import { getAttendees, getCancelledAttendees } from '../services/eventbrite-client';
 import { sendEmail } from '../services/graph-mail';
 import { renderEmail } from '../services/email-renderer';
-import { buildPreSessionVars, buildPostSessionVars } from '../services/email-vars';
+import { buildPreSessionVars, buildPostSessionVars, buildPreAgmVars } from '../services/email-vars';
 
 import { computeAndSaveProfileStats } from '../services/profile-stats';
 import { refreshSessionMediaStats } from '../services/session-stats';
@@ -1210,12 +1210,17 @@ router.post('/entries/:entryId/notify', async (req: Request, res: Response) => {
     }
 
     const sessionEntries = await entriesRepository.getBySessionIds([spSession.ID]);
+    const profileRecords = profileId !== undefined
+      ? await recordsRepository.getByProfile(profileId)
+      : [];
 
     const base = process.env.FRONTEND_URL || `${req.protocol}://${req.get('host')}`;
     const templateName = (req.body?.template as string) || 'pre-session';
     const vars = templateName === 'post-session'
-      ? buildPostSessionVars(spEntry, spSession, profile, spGroup, sessionEntries, allSessions, base)
-      : buildPreSessionVars(spEntry, spSession, profile, spGroup, sessionEntries, base);
+      ? buildPostSessionVars(spEntry, spSession, profile, spGroup, sessionEntries, allSessions, base, profileRecords)
+      : templateName === 'pre-agm'
+      ? buildPreAgmVars(spEntry, spSession, profile, spGroup, sessionEntries, base, profileRecords)
+      : buildPreSessionVars(spEntry, spSession, profile, spGroup, sessionEntries, base, profileRecords);
     const { subject, html, text } = await renderEmail(templateName, vars);
 
     const preview = req.body?.preview === true;

--- a/backend/routes/entries.ts
+++ b/backend/routes/entries.ts
@@ -877,7 +877,7 @@ router.post('/sessions/:group/:date/refresh', async (req: Request, res: Response
     }
 
     const todayStr = new Date().toISOString().slice(0, 10);
-    if ((spSession.Date || '').slice(0, 10) < todayStr) {
+    if ((spSession.Date || '').slice(0, 10) < todayStr && req.session.user?.role !== 'admin') {
       res.status(400).json({ success: false, error: 'Cannot refresh a past session' });
       return;
     }

--- a/backend/routes/profiles.ts
+++ b/backend/routes/profiles.ts
@@ -23,8 +23,11 @@ import {
   profileSlug,
   profileIdFromSlug,
   toMatchName,
-  parseEmails
+  parseEmails,
 } from '../services/data-layer';
+import { renderEmail } from '../services/email-renderer';
+import { buildProfileTemplateVars, PROFILE_EMAIL_TEMPLATES, type ProfileEmailTemplate } from '../services/email-vars';
+import { sendEmail } from '../services/graph-mail';
 import {
   GROUP_LOOKUP,
   SESSION_LOOKUP,
@@ -36,7 +39,7 @@ import {
 } from '../services/field-names';
 import type { ProfileResponse, ProfileDetailResponse, ProfileEntryResponse, ProfileGroupHours, ConsentRecordResponse } from '../../types/api-responses';
 import { trackerAccessForProfileUser } from '../services/tracker-access';
-import type { ApiResponse } from '../../types/sharepoint';
+import type { ApiResponse, SharePointProfile } from '../../types/sharepoint';
 
 const router: Router = express.Router();
 
@@ -497,6 +500,98 @@ router.post('/records/bulk', async (req: Request, res: Response) => {
   } catch (error: any) {
     console.error('Error bulk updating records:', error);
     res.status(500).json({ success: false, error: 'Failed to bulk update records', message: error.message });
+  }
+});
+
+router.post('/profiles/bulk-email', async (req: Request, res: Response) => {
+  try {
+    if (!process.env.MAIL_SENDER) {
+      res.status(503).json({ success: false, error: 'MAIL_SENDER env var is not set' });
+      return;
+    }
+
+    const { profileIds, template, preview } = req.body as {
+      profileIds?: unknown;
+      template?: string;
+      preview?: boolean;
+    };
+
+    if (!Array.isArray(profileIds) || profileIds.length === 0) {
+      res.status(400).json({ success: false, error: 'profileIds array is required' });
+      return;
+    }
+    const templateName = (template as ProfileEmailTemplate) || 'membership-invite';
+    if (!PROFILE_EMAIL_TEMPLATES.includes(templateName)) {
+      res.status(400).json({ success: false, error: `Unknown template: ${template}` });
+      return;
+    }
+
+    const allProfiles = await profilesRepository.getAll();
+    const allRecords = await recordsRepository.getAll();
+    const base = process.env.FRONTEND_URL || `${req.protocol}://${req.get('host')}`;
+
+    const recordsForProfile = (profileId: number) =>
+      allRecords.filter(r => safeParseLookupId(r.ProfileLookupId as unknown as string) === profileId);
+
+    const targets: Array<{ profile: SharePointProfile; email: string }> = [];
+    let skipped = 0;
+
+    for (const profileId of profileIds) {
+      const id = parseInt(String(profileId), 10);
+      if (isNaN(id)) {
+        skipped++;
+        continue;
+      }
+      const spProfile = allProfiles.find(p => p.ID === id);
+      if (!spProfile || spProfile.IsGroup) {
+        skipped++;
+        continue;
+      }
+      const primaryEmail = parseEmails(spProfile.Email)[0];
+      if (!primaryEmail) {
+        skipped++;
+        continue;
+      }
+      targets.push({ profile: spProfile, email: primaryEmail });
+    }
+
+    if (!targets.length) {
+      res.status(400).json({ success: false, error: 'No selected profiles have an email address' });
+      return;
+    }
+
+    const renderAndSend = async (profile: SharePointProfile, toEmail: string) => {
+      const vars = buildProfileTemplateVars(
+        templateName,
+        profile,
+        base,
+        recordsForProfile(profile.ID),
+      );
+      const rendered = await renderEmail(templateName, vars);
+      await sendEmail({ to: toEmail, subject: rendered.subject, html: rendered.html, text: rendered.text });
+    };
+
+    if (preview === true) {
+      const adminEmail = req.session.user?.email;
+      if (!adminEmail) {
+        res.status(400).json({ success: false, error: 'No email address on your account for preview' });
+        return;
+      }
+      await renderAndSend(targets[0].profile, adminEmail);
+      res.json({ success: true, data: { sent: 1, skipped } } as ApiResponse<{ sent: number; skipped: number }>);
+      return;
+    }
+
+    let sent = 0;
+    for (const { profile, email } of targets) {
+      await renderAndSend(profile, email);
+      sent++;
+    }
+
+    res.json({ success: true, data: { sent, skipped } } as ApiResponse<{ sent: number; skipped: number }>);
+  } catch (error: any) {
+    console.error('Error sending bulk profile email:', error);
+    res.status(500).json({ success: false, error: 'Failed to send email', message: error.message });
   }
 });
 

--- a/backend/services/email-renderer.test.ts
+++ b/backend/services/email-renderer.test.ts
@@ -126,3 +126,50 @@ describe('post-session email', () => {
     expect(html).toContain('7 June')
   })
 })
+
+describe('pre-agm email', () => {
+  const PRE_AGM_VARS = {
+    baseUrl: 'https://example.com',
+    volunteerName: 'Alice',
+    groupName: 'Trail Crew',
+    sessionTitle: null,
+    formattedDateShort: '26 June',
+    formattedDateLong: 'Friday, 26 June 2026',
+    formattedTime: '7pm',
+    description: '',
+    sessionUrl: 'https://example.com/sessions/trail-crew/2026-06-26',
+    loginUrl: 'https://example.com/login?returnTo=%2Fsessions%2Ftrail-crew%2F2026-06-26',
+    myChildNames: null,
+    isRegular: false,
+    isMember: false,
+    tags: null,
+    agendaUrl: 'https://example.com/docs/charity/annual-reports/2025-26/agm-agenda-25-26.pdf',
+    reportUrl: 'https://example.com/docs/charity/annual-reports/2025-26/agm-presentation-25-26.pdf',
+    financialUrl: 'https://example.com/docs/charity/annual-reports/2025-26/dtv-draft-accounts-2025-26-22-jun-2026-14-53.pdf',
+  }
+
+  it('renders AGM copy with doc and session links', async () => {
+    const { subject, text, html } = await renderEmail('pre-agm', PRE_AGM_VARS)
+    expect(subject).toContain("Thursday's AGM")
+    expect(text).toContain('Dear Alice')
+    expect(text).toContain('agm-agenda-25-26.pdf')
+    expect(text).toContain('sessions/trail-crew/2026-06-26')
+    expect(html).toContain('Dear Alice')
+    expect(html).toContain('href="' + PRE_AGM_VARS.sessionUrl + '"')
+    expect(html).toContain('>My Tracker</a>')
+  })
+})
+
+describe('membership-invite email', () => {
+  it('renders membership date when set', async () => {
+    const { html, text } = await renderEmail('membership-invite', {
+      baseUrl: 'https://example.com',
+      name: 'Alice',
+      email: 'alice@example.com',
+      loginUrl: 'https://example.com/login?email=alice%40example.com',
+      charityMembershipDate: '1 April 2024',
+    })
+    expect(text).toContain('1 April 2024')
+    expect(html).toContain('1 April 2024')
+  })
+})

--- a/backend/services/email-vars.test.ts
+++ b/backend/services/email-vars.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
-import { buildPreSessionVars } from './email-vars'
+import { buildPreSessionVars, buildPreAgmVars, buildProfileTemplateVars, buildProfileLoginUrl, profileIsMember } from './email-vars'
 import { SESSION_TIME, SESSION_LENGTH } from './field-names'
-import type { SharePointEntry, SharePointProfile } from '../../types/sharepoint'
+import type { SharePointEntry, SharePointProfile, SharePointRecord } from '../../types/sharepoint'
 import type { SharePointSession } from '../../types/session'
 import type { SharePointGroup } from '../../types/group'
 
@@ -54,5 +54,107 @@ describe('buildPreSessionVars', () => {
     const vars = buildPreSessionVars(baseEntry, session, baseProfile, baseGroup, [], 'https://example.com')
 
     expect(vars.formattedTime).toBe('10:00 to 12:00 (about 2 hours)')
+  })
+
+  it('sets isMember from Charity Membership record', () => {
+    const session = {
+      ID: 100,
+      Date: '2026-04-23',
+      Created: '',
+      Modified: '',
+    } as SharePointSession
+
+    const records = [{
+      ID: 1,
+      Type: 'Charity Membership',
+      Status: 'Accepted',
+      Created: '',
+      Modified: '',
+    }] as SharePointRecord[]
+
+    const vars = buildPreSessionVars(baseEntry, session, baseProfile, baseGroup, [], 'https://example.com', records)
+    expect(vars.isMember).toBe(true)
+  })
+})
+
+describe('buildPreAgmVars', () => {
+  it('includes session URL and AGM doc links', () => {
+    const session = {
+      ID: 100,
+      Date: '2026-06-26',
+      Created: '',
+      Modified: '',
+    } as SharePointSession
+
+    const vars = buildPreAgmVars(baseEntry, session, baseProfile, baseGroup, [], 'https://example.com')
+
+    expect(vars.volunteerName).toBe('Alice')
+    expect(vars.sessionUrl).toBe('https://example.com/sessions/trail crew/2026-06-26')
+    expect(vars.agendaUrl).toContain('agm-agenda-25-26.pdf')
+    expect(vars.reportUrl).toContain('agm-presentation-25-26.pdf')
+    expect(vars.financialUrl).toContain('dtv-draft-accounts')
+  })
+})
+describe('profileIsMember', () => {
+  it('is true for Accepted Charity Membership', () => {
+    expect(profileIsMember([{
+      ID: 1,
+      Type: 'Charity Membership',
+      Status: 'Accepted',
+      Created: '',
+      Modified: '',
+    } as SharePointRecord])).toBe(true)
+  })
+
+  it('is false for Invited or missing record', () => {
+    expect(profileIsMember([{
+      ID: 1,
+      Type: 'Charity Membership',
+      Status: 'Invited',
+      Created: '',
+      Modified: '',
+    } as SharePointRecord])).toBe(false)
+    expect(profileIsMember([])).toBe(false)
+  })
+})
+
+describe('buildProfileTemplateVars', () => {
+  const profile = {
+    ID: 42,
+    Title: 'Alice Smith',
+    Email: 'alice@example.com, other@example.com',
+    Created: '',
+    Modified: '',
+  } as SharePointProfile
+
+  it('builds membership-invite vars with loginUrl', () => {
+    const vars = buildProfileTemplateVars('membership-invite', profile, 'https://example.com', [])
+
+    expect(vars.name).toBe('Alice Smith')
+    expect(vars.email).toBe('alice@example.com')
+    expect(vars.loginUrl).toBe('https://example.com/login?email=alice%40example.com')
+  })
+
+  it('includes charityMembershipDate for membership-invite', () => {
+    const records = [{
+      ID: 1,
+      Type: 'Charity Membership',
+      Status: 'Accepted',
+      Date: '2024-04-01T00:00:00Z',
+      Created: '',
+      Modified: '',
+    }] as SharePointRecord[]
+
+    const vars = buildProfileTemplateVars('membership-invite', profile, 'https://example.com', records)
+
+    expect(vars.charityMembershipDate).toBe('1 April 2024')
+  })
+})
+
+describe('buildProfileLoginUrl', () => {
+  it('encodes email in login query param', () => {
+    expect(buildProfileLoginUrl('https://example.com', 'a+b@c.com')).toBe(
+      'https://example.com/login?email=a%2Bb%40c.com',
+    )
   })
 })

--- a/backend/services/email-vars.ts
+++ b/backend/services/email-vars.ts
@@ -1,7 +1,8 @@
 import { SharePointEntry, SharePointProfile } from '../../types/sharepoint';
 import { SharePointSession } from '../../types/session';
 import { SharePointGroup } from '../../types/group';
-import { extractMetadataTags, safeParseLookupId, parseHours, sessionScheduleFields, formatSessionTimeRangeProse } from './data-layer';
+import { extractMetadataTags, safeParseLookupId, parseHours, sessionScheduleFields, formatSessionTimeRangeProse, parseEmails } from './data-layer';
+import type { SharePointRecord } from '../../types/sharepoint';
 import {
   SESSION_NOTES, SESSION_METADATA, SESSION_STATS, SESSION_COVER_MEDIA,
   GROUP_LOOKUP, PROFILE_DISPLAY, ENTRY_CANCELLED,
@@ -47,6 +48,13 @@ function findChildEntries(sessionEntries: SharePointEntry[], profileId: number |
     : [];
 }
 
+const CHARITY_MEMBERSHIP_TYPE = 'Charity Membership';
+
+/** True when the profile has an Accepted Charity Membership record. */
+export function profileIsMember(profileRecords: SharePointRecord[]): boolean {
+  return profileRecords.some(r => r.Type === CHARITY_MEMBERSHIP_TYPE && r.Status === 'Accepted');
+}
+
 // ============================================================================
 // Pre-session
 // ============================================================================
@@ -64,6 +72,7 @@ export interface PreSessionVars extends Record<string, unknown> {
   loginUrl: string;
   myChildNames: string | null;
   isRegular: boolean;
+  isMember: boolean;
   tags: string | null;
 }
 
@@ -73,7 +82,8 @@ export function buildPreSessionVars(
   profile: SharePointProfile,
   group: SharePointGroup,
   sessionEntries: SharePointEntry[],
-  baseUrl: string
+  baseUrl: string,
+  profileRecords: SharePointRecord[] = [],
 ): PreSessionVars {
   const profileId = entry.ProfileLookupId as number | undefined;
   const groupName = group.Name || group.Title || '';
@@ -105,7 +115,44 @@ export function buildPreSessionVars(
     loginUrl: `${baseUrl}/login?returnTo=${encodeURIComponent(`/sessions/${groupKey}/${dateParam}`)}`,
     myChildNames: myChildNames || null,
     isRegular: /#Regular\b/i.test(String(entry.Notes || '')),
+    isMember: profileIsMember(profileRecords),
     tags,
+  };
+}
+
+// ============================================================================
+// Pre-AGM (session entry notify)
+// ============================================================================
+
+/** FY2025-26 AGM documents on the public docs proxy. */
+const AGM_REPORTS_PATH = '/docs/charity/annual-reports/2025-26';
+
+export interface PreAgmVars extends PreSessionVars {
+  agendaUrl: string;
+  reportUrl: string;
+  financialUrl: string;
+}
+
+function buildPreAgmDocUrls(baseUrl: string) {
+  return {
+    agendaUrl: `${baseUrl}${AGM_REPORTS_PATH}/agm-agenda-25-26.pdf`,
+    reportUrl: `${baseUrl}${AGM_REPORTS_PATH}/agm-presentation-25-26.pdf`,
+    financialUrl: `${baseUrl}${AGM_REPORTS_PATH}/dtv-draft-accounts-2025-26-22-jun-2026-14-53.pdf`,
+  };
+}
+
+export function buildPreAgmVars(
+  entry: SharePointEntry,
+  session: SharePointSession,
+  profile: SharePointProfile,
+  group: SharePointGroup,
+  sessionEntries: SharePointEntry[],
+  baseUrl: string,
+  profileRecords: SharePointRecord[] = [],
+): PreAgmVars {
+  return {
+    ...buildPreSessionVars(entry, session, profile, group, sessionEntries, baseUrl, profileRecords),
+    ...buildPreAgmDocUrls(baseUrl),
   };
 }
 
@@ -136,6 +183,7 @@ export interface PostSessionVars extends Record<string, unknown> {
   myChildNames: string | null;
   myChildHours: number | null;
   isRegular: boolean;
+  isMember: boolean;
   stats: SessionStats | null;
   nextSessionUrl: string | null;
   nextSessionDate: string | null;
@@ -150,7 +198,8 @@ export function buildPostSessionVars(
   group: SharePointGroup,
   sessionEntries: SharePointEntry[],
   allSessions: SharePointSession[],
-  baseUrl: string
+  baseUrl: string,
+  profileRecords: SharePointRecord[] = [],
 ): PostSessionVars {
   const profileId = entry.ProfileLookupId as number | undefined;
   const groupName = group.Name || group.Title || '';
@@ -197,10 +246,61 @@ export function buildPostSessionVars(
     myChildNames: myChildNames || null,
     myChildHours: myChildHours > 0 ? myChildHours : null,
     isRegular: /#Regular\b/i.test(String(entry.Notes || '')),
+    isMember: profileIsMember(profileRecords),
     stats,
     nextSessionUrl,
     nextSessionDate,
     uploadUrl: `${baseUrl}/upload?entryId=${entry.ID}`,
     loginUrl: `${baseUrl}/login?returnTo=${encodeURIComponent(`/sessions/${groupKey}/${dateParam}`)}`,
   };
+}
+
+// ============================================================================
+// Profile bulk email
+// ============================================================================
+
+export const PROFILE_EMAIL_TEMPLATES = ['membership-invite'] as const;
+export type ProfileEmailTemplate = typeof PROFILE_EMAIL_TEMPLATES[number];
+
+export interface ProfileEmailVars extends Record<string, unknown> {
+  baseUrl: string;
+  name: string;
+  email: string;
+  loginUrl: string;
+  charityMembershipDate?: string | null;
+}
+
+function formatRecordDate(dateParam: string): string {
+  const d = new Date(dateParam);
+  if (isNaN(d.getTime())) return dateParam;
+  return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' });
+}
+
+export function buildProfileLoginUrl(baseUrl: string, email: string): string {
+  return `${baseUrl}/login?email=${encodeURIComponent(email)}`;
+}
+
+function charityMembershipRecord(records: SharePointRecord[]): SharePointRecord | undefined {
+  const matching = records.filter(r => r.Type === CHARITY_MEMBERSHIP_TYPE);
+  return matching.find(r => r.Status === 'Accepted') ?? matching[0];
+}
+
+export function buildProfileTemplateVars(
+  template: ProfileEmailTemplate,
+  profile: SharePointProfile,
+  baseUrl: string,
+  profileRecords: SharePointRecord[],
+): ProfileEmailVars {
+  const name = String(profile.Title || '').trim();
+  const email = parseEmails(profile.Email)[0] || '';
+  const loginUrl = buildProfileLoginUrl(baseUrl, email);
+
+  const vars: ProfileEmailVars = { baseUrl, name, email, loginUrl };
+
+  if (template === 'membership-invite') {
+    const record = charityMembershipRecord(profileRecords);
+    vars.charityMembershipDate = record?.Date ? formatRecordDate(record.Date) : null;
+  }
+
+  return vars;
 }

--- a/backend/services/profile-stats.ts
+++ b/backend/services/profile-stats.ts
@@ -118,12 +118,11 @@ export async function computeAndSaveProfileStats(profileId: number): Promise<voi
     return sid !== undefined && (sessionDateMap.get(sid) ?? '') > today;
   });
   const hasPrivacyConsent = profileRecordsRaw.some(r => r.Type === 'Privacy Consent' && r.Status === 'Accepted');
-  const hasPhotoConsent = profileRecordsRaw.some(r => r.Type === 'Photo Consent' && r.Status === 'Accepted');
   const warnings: Array<{ text: string; url?: string }> = [];
   if (hasDuplicate) warnings.push({ text: 'Possible Duplicate', url: `/profiles?fy=all&search=${encodeURIComponent(thisProfile?.Title || '')}` });
   if (hasMatchNameError) warnings.push({ text: 'Match Name Error' });
   if (hasChildNoAdult) warnings.push({ text: 'Child No Adult', url: `/entries?q=%23child&fy=all&accompanyingAdult=empty&profileId=${profileId}&profileName=${encodeURIComponent(thisProfile?.Title || '')}` });
-  if (!thisProfile?.IsGroup && hasFutureBooking && (!hasPrivacyConsent || !hasPhotoConsent)) {
+  if (!thisProfile?.IsGroup && hasFutureBooking && !hasPrivacyConsent) {
     warnings.push({ text: 'No Consent' });
   }
 
@@ -246,7 +245,7 @@ export async function runProfileStatsRefresh(): Promise<ProfileStatsRefreshResul
   }
   const noPhotoIds = new Set(profilesRaw.filter(p => !consentedPhotoIds.has(p.ID)).map(p => p.ID));
 
-  // No Consent: future booking but missing Privacy or Photo consent
+  // No Consent: future booking but missing Accepted Privacy Consent (photo consent is separate — noPhoto badge)
   const futureBookingIds = new Set<number>();
   for (const e of entriesRaw) {
     if (e[ENTRY_CANCELLED]) continue;
@@ -298,7 +297,7 @@ export async function runProfileStatsRefresh(): Promise<ProfileStatsRefreshResul
         if (possibleDuplicateIds.has(spProfile.ID)) warnings.push({ text: 'Possible Duplicate', url: `/profiles?fy=all&search=${encodeURIComponent(spProfile.Title || '')}` });
         if (spProfile.Title && spProfile.MatchName && toMatchName(spProfile.Title) !== spProfile.MatchName) warnings.push({ text: 'Match Name Error' });
         if (childNoAdultIds.has(spProfile.ID)) warnings.push({ text: 'Child No Adult', url: `/entries?q=%23child&fy=all&accompanyingAdult=empty&profileId=${spProfile.ID}&profileName=${encodeURIComponent(spProfile.Title || '')}` });
-        if (!spProfile.IsGroup && futureBookingIds.has(spProfile.ID) && (!consentedPrivacyIds.has(spProfile.ID) || !consentedPhotoIds.has(spProfile.ID))) {
+        if (!spProfile.IsGroup && futureBookingIds.has(spProfile.ID) && !consentedPrivacyIds.has(spProfile.ID)) {
           warnings.push({ text: 'No Consent' });
         }
         if (spProfile.IsGroup && memberIds.has(spProfile.ID)) warnings.push({ text: 'Group + Member' });

--- a/docs/api.md
+++ b/docs/api.md
@@ -101,6 +101,7 @@ Consent and governance records are personal data. All write access is Admin-only
 |---|---|---|---|
 | `/api/records/export` | GET | Admin | Export records as CSV |
 | `/api/records/bulk` | POST | Admin | Bulk create or update records |
+| `/api/profiles/bulk-email` | POST | Admin | Bulk send profile email (`membership-invite`) |
 | `/api/records/:id` | PATCH | Admin | Update record |
 | `/api/records/:id` | DELETE | Admin | Delete record |
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -65,6 +65,7 @@ Volunteer attendance records are personal data. The list endpoint is Admin-only.
 | Endpoint | Method | Access | Description |
 |---|---|---|---|
 | `/api/entries` | GET | Admin | All entries across all sessions |
+| `/api/entries/bulk` | POST | Admin | Bulk add entries for selected profiles to a future session (skips profiles with any existing entry) |
 | `/api/entries/recent` | GET | Trusted | Recent entries |
 | `/api/entries/refresh-stats` | POST | Admin | Bulk refresh entry stats |
 | `/api/entries/:id` | GET | SS (own) / Trusted | Entry detail with FY hours |

--- a/docs/features/backend.md
+++ b/docs/features/backend.md
@@ -42,7 +42,7 @@ Four independent caches (NodeCache, column schema, taxonomy tree, cover image). 
 
 ## Pre-Session Email Notifications
 
-Handlebars template system (`templates/email/`). `renderEmail(template, vars)` renders templates with MSO-safe table structure via `{{#section}}` block helper. Sent via Microsoft Graph Mail using app credentials (`MAIL_SENDER` env var). Sandbox preview at `POST /api/email/render`.
+Handlebars template system (`templates/email/`). `renderEmail(template, vars)` renders templates with MSO-safe table structure via `{{#section}}` block helper. Session entry notify supports `pre-session`, `post-session`, and `pre-agm`. Profile bulk email supports `membership-invite`. Sent via Microsoft Graph Mail using app credentials (`MAIL_SENDER` env var). Sandbox preview at `POST /api/email/render`.
 
 ## Nightly Backup Export
 

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -166,6 +166,7 @@ Check In can make a session photo non-public via `PATCH /media/:itemId`; permane
 | PATCH | `/records/:id` | Edit record |
 | DELETE | `/records/:id` | Delete record |
 | POST | `/records/bulk` | Bulk create/update records |
+| POST | `/profiles/bulk-email` | Bulk send Handlebars email to selected profiles |
 | POST | `/profiles/:slug/transfer` | Transfer profile |
 | DELETE | `/profiles/:slug` | Delete profile |
 | DELETE | `/media/:itemId` | Delete session photo from media library |

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -71,7 +71,7 @@ Check In and Admin share the **same** base visibility on these pages; **Admin** 
 | **Groups list** | Full view, regulars count | — | — |
 | **Group detail** | Group info, stats, sessions, regulars list | — | Edit button, Create Session button |
 | **Sessions list** | Full view | CSV download, checkboxes (Advanced) | Add Tags, Update Project buttons |
-| **Session detail** | Session info, stats, tags, photos; Privacy Protection card | Entries list, Free Parking card; check-in, Set Hours, Add Entry, Refresh, Edit (title + description); photo edit (caption, public, cover — not delete) | Delete session; delete photos; edit modal: Group, Date, Eventbrite ID |
+| **Session detail** | Session info, stats, tags, photos; Privacy Protection card | Entries list, Free Parking card; check-in, Set Hours, Add Entry, Refresh, Edit (title + description); photo edit (caption, public, cover — not delete); past sessions: Refresh and Set Hours disabled | Delete session; delete photos; edit modal: Group, Date, Eventbrite ID; past sessions: Refresh and Set Hours enabled |
 | **Add entry** | Redirected (auth required) | Full access | — |
 | **Entry detail** | Redirected (auth required) | Checked In toggle, Hours, Count, Upload | Notes, tag buttons, Delete Entry |
 | **Volunteers list** | Redirected (auth required) | View, search, filter, sort, CSV download | Bulk Records, Add Entries, Send Email |

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -74,7 +74,7 @@ Check In and Admin share the **same** base visibility on these pages; **Admin** 
 | **Session detail** | Session info, stats, tags, photos; Privacy Protection card | Entries list, Free Parking card; check-in, Set Hours, Add Entry, Refresh, Edit (title + description); photo edit (caption, public, cover — not delete) | Delete session; delete photos; edit modal: Group, Date, Eventbrite ID |
 | **Add entry** | Redirected (auth required) | Full access | — |
 | **Entry detail** | Redirected (auth required) | Checked In toggle, Hours, Count, Upload | Notes, tag buttons, Delete Entry |
-| **Volunteers list** | Redirected (auth required) | View, search, filter, sort, CSV download | Bulk Records |
+| **Volunteers list** | Redirected (auth required) | View, search, filter, sort, CSV download | Bulk Records, Add Entries, Send Email |
 | **Profile detail** | Redirected (auth required) | Edit profile (name/email/match name), Regulars checkboxes, inline hours (own profile only), Collect Consent | **`User`** field in edit modal, Add Record, record pill editing, inline hours (all profiles), Transfer, Delete Profile |
 | **Consent page** | Redirected (auth required) | Full access | Full access |
 | **Admin** | Redirected (auth required) | — | Eventbrite sync, Exports, Site link |
@@ -167,6 +167,7 @@ Check In can make a session photo non-public via `PATCH /media/:itemId`; permane
 | DELETE | `/records/:id` | Delete record |
 | POST | `/records/bulk` | Bulk create/update records |
 | POST | `/profiles/bulk-email` | Bulk send Handlebars email to selected profiles |
+| POST | `/entries/bulk` | Bulk add entries for profiles to a future session (skips anyone with any existing entry, including cancelled) |
 | POST | `/profiles/:slug/transfer` | Transfer profile |
 | DELETE | `/profiles/:slug` | Delete profile |
 | DELETE | `/media/:itemId` | Delete session photo from media library |

--- a/docs/testing/full-regression.md
+++ b/docs/testing/full-regression.md
@@ -48,11 +48,11 @@ Run with `npm run dev` at http://localhost:3000. Log in via Microsoft Entra ID.
 - [ ] **Admin user** (in `ADMIN_USERS` env var): all edit/create/delete buttons visible, all API calls succeed
 - [ ] **Check In user** (profile has matching `User` field): admin buttons hidden, check-in controls visible
 - [ ] Check In: check-in checkbox on session detail works (PATCH `/api/entries/:id`)
-- [ ] Check In: Set Hours button on session detail works
+- [ ] Check In: Set Hours button on session detail works (today/future sessions; disabled on past sessions)
 - [ ] Check In: session edit modal shows only Display Name and Description (Group, Date, Eventbrite ID, Delete hidden)
 - [ ] Check In: saving session edit with title/description works (PATCH succeeds)
 - [ ] Check In: regulars checkbox on profile detail works (add/remove)
-- [ ] Check In: Refresh button visible on session detail, can refresh session
+- [ ] Check In: Refresh button visible on session detail; enabled for today/future sessions only (disabled on past sessions)
 - [ ] Check In: Add Entry link visible on session detail, can add entry for existing volunteer
 - [ ] Check In: can create new profile from add-entry page ("+ Add New" button)
 - [ ] Check In: edit profile button visible, can update name/email
@@ -157,12 +157,15 @@ Run with `npm run dev` at http://localhost:3000. Log in via Microsoft Entra ID.
 ### H12. Set default hours (bulk)
 - [ ] Session detail → "Set Hours" button → modal with hours input (default 3)
 - [ ] Applies to checked-in entries where hours = 0
+- [ ] Admin on past session: Set Hours enabled; applies to all active entries without hours (marks checked in)
+- [ ] Check In on past session: Set Hours disabled when no checked-in entries without hours
 - [ ] Multiple `PATCH /api/entries/:id` calls in parallel
 - [ ] Does not overwrite entries with existing hours
 
 ### H13. Refresh session (bulk)
 - [ ] Session detail → "Refresh" button
 - [ ] `POST /api/sessions/:group/:date/refresh`
+- [ ] Admin on past session: Refresh enabled; Check In on past session: button disabled, API returns 400
 - [ ] Adds missing regulars, syncs Eventbrite attendees (with `EventbriteAttendeeID`), tags #NoPhoto
 - [ ] Shows summary: "Added: X regulars, Y from Eventbrite, Z new profiles, W #NoPhoto"
 

--- a/docs/testing/full-regression.md
+++ b/docs/testing/full-regression.md
@@ -246,6 +246,13 @@ Run with `npm run dev` at http://localhost:3000. Log in via Microsoft Entra ID.
 - [ ] Group profiles and profiles without email skipped (`skipped` count in response)
 - [ ] Requires `MAIL_SENDER` env var
 
+### H23c. Bulk add entries (admin)
+- [ ] Volunteers page → select individual profiles → "Add Entries" enabled (groups excluded)
+- [ ] Modal: session dropdown lists future sessions only, next session first (`date — group name`)
+- [ ] `POST /api/entries/bulk` — `{ profileIds, sessionId }`; past session → 400
+- [ ] Profiles already on session skipped (including cancelled bookings — cancellation left in place); returns `{ created, skipped }`
+- [ ] On success: modal closes, selection cleared, profile list reloads
+
 ### H24b. Entries page (admin)
 
 - [ ] Admin: "Entries" nav link visible in header; non-admin users (Check In, Self-Service, Public) do not see the link

--- a/docs/testing/full-regression.md
+++ b/docs/testing/full-regression.md
@@ -238,6 +238,14 @@ Run with `npm run dev` at http://localhost:3000. Log in via Microsoft Entra ID.
 - [ ] Shows "Done: X created, Y updated", auto-closes, reloads list
 - [ ] Upsert: same type updates existing records, doesn't duplicate
 
+### H23b. Bulk send email (admin)
+- [ ] Volunteers page → select profiles with emails → "Send Email" enabled; profiles without email excluded from count
+- [ ] Modal: template dropdown (Membership Invite); preview checkbox defaults on
+- [ ] Preview: `POST /api/profiles/bulk-email` with `{ profileIds, template, preview: true }` → one email to signed-in admin
+- [ ] Send: `POST /api/profiles/bulk-email` — `{ profileIds, template, preview? }`; sends to all selected profiles with email
+- [ ] Group profiles and profiles without email skipped (`skipped` count in response)
+- [ ] Requires `MAIL_SENDER` env var
+
 ### H24b. Entries page (admin)
 
 - [ ] Admin: "Entries" nav link visible in header; non-admin users (Check In, Self-Service, Public) do not see the link
@@ -316,8 +324,8 @@ Run with `npm run dev` at http://localhost:3000. Log in via Microsoft Entra ID.
 ### H27b. Profile stats warnings
 - [ ] After `POST /api/profiles/refresh-stats`, a profile whose Title matches another profile has `"Possible Duplicate"` in its stored `Stats.warnings` array (verify in SharePoint or via `GET /api/profiles`)
 - [ ] After refresh, a profile with an active entry containing `#child` in Notes but no `AccompanyingAdultLookupId` has `"Child No Adult"` in `Stats.warnings`; the warning URL includes `profileId` and `profileName` query params
-- [ ] After refresh, a profile with a future booking but no accepted Privacy Consent or Photo Consent has `"No Consent"` in `Stats.warnings`
-- [ ] After refresh, a profile with a future booking and both Privacy and Photo Consent accepted does **not** have `"No Consent"`
+- [ ] After refresh, a profile with a future booking but no accepted Privacy Consent has `"No Consent"` in `Stats.warnings`
+- [ ] After refresh, a profile with a future booking and Accepted Privacy Consent does **not** have `"No Consent"` (Photo Consent Declined is OK — use noPhoto badge instead)
 - [ ] After refresh, a profile with no future bookings does **not** have `"No Consent"` (past sessions only)
 - [ ] After refresh, a clean profile (no duplicates, no unassigned child entries, consent present) has `warnings: []`
 - [ ] Fixing the condition and re-running refresh removes the warning
@@ -394,9 +402,11 @@ Run with `npm run dev` at http://localhost:3000. Log in via Microsoft Entra ID.
 - [ ] Arrow-key navigation (left/right) scrolls the carousel
 - [ ] Breadcrumb: Home > Media (Home links to `/`, Media links to `/media/`)
 
-### H32. Pre-session email
-- [ ] Session detail → "Notify" button → `POST /api/entries/:id/notify` — email sent to volunteer
-- [ ] Email renders with correct volunteer name, group name, date, session URL, login URL
+### H32. Session email (pre-session / post-session / pre-agm)
+- [ ] Session detail → "Send Email" → template dropdown includes Pre-Session, Post-Session, Pre-AGM
+- [ ] `POST /api/entries/:id/notify` with `template: pre-session` — email sent to volunteer
+- [ ] Pre-AGM: renders volunteer name, AGM doc links, and session URL (My Tracker link)
+- [ ] Send All sends to each entry with an email address
 - [ ] Description block present when session has notes; absent when no notes
 - [ ] Regular block shown for regular volunteers; absent otherwise
 - [ ] Child block shown when entry has accompanying child name; absent otherwise

--- a/frontend/src/components/profiles/ProfileListActions.vue
+++ b/frontend/src/components/profiles/ProfileListActions.vue
@@ -5,6 +5,7 @@
     </span>
     <div class="list-actions-buttons">
       <AppButton label="Add Records" icon="file-add" mode="icon-responsive" :disabled="individualSelected.length === 0" @click="emit('add-records')" />
+      <AppButton label="Send Email" icon="email" mode="icon-responsive" :disabled="emailableSelected.length === 0" @click="emit('send-email')" />
       <AppButton label="Download CSV" icon="download" mode="icon-only" :disabled="selectedInFiltered.length === 0" @click="onDownload" />
       <AppButton label="Share" icon="share" mode="icon-only" @click="onShare" />
       <AppButton label="Add profile" icon="add" mode="icon-only" @click="emit('add-profile')" />
@@ -29,12 +30,17 @@ const props = defineProps<{
 const emit = defineEmits<{
   'add-records': []
   'add-profile': []
+  'send-email': []
   'update:selected': [ids: number[]]
 }>()
 
 const selectedInFiltered = computed(() => props.filteredProfiles.filter(p => props.selected.includes(p.id)))
 
 const individualSelected = computed(() => selectedInFiltered.value.filter(p => !p.isGroup))
+
+const emailableSelected = computed(() =>
+  individualSelected.value.filter(p => !!p.email?.trim())
+)
 
 function hoursFor(p: ProfileResponse): number {
   return props.fy === 'all' ? p.hoursAll : p.hoursThisFY

--- a/frontend/src/components/profiles/ProfileListActions.vue
+++ b/frontend/src/components/profiles/ProfileListActions.vue
@@ -5,6 +5,7 @@
     </span>
     <div class="list-actions-buttons">
       <AppButton label="Add Records" icon="file-add" mode="icon-responsive" :disabled="individualSelected.length === 0" @click="emit('add-records')" />
+      <AppButton label="Add Entries" icon="register" mode="icon-responsive" :disabled="individualSelected.length === 0" @click="emit('add-entries')" />
       <AppButton label="Send Email" icon="email" mode="icon-responsive" :disabled="emailableSelected.length === 0" @click="emit('send-email')" />
       <AppButton label="Download CSV" icon="download" mode="icon-only" :disabled="selectedInFiltered.length === 0" @click="onDownload" />
       <AppButton label="Share" icon="share" mode="icon-only" @click="onShare" />
@@ -29,6 +30,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   'add-records': []
+  'add-entries': []
   'add-profile': []
   'send-email': []
   'update:selected': [ids: number[]]

--- a/frontend/src/components/sessions/SessionEntryList.vue
+++ b/frontend/src/components/sessions/SessionEntryList.vue
@@ -8,7 +8,7 @@
         <span v-if="activeCount" class="sel-count">({{ checkedCount }} / {{ activeCount }})</span>
       </h2>
       <div v-if="allowEdit" class="sel-actions">
-        <AppButton label="Refresh" icon="refresh" mode="icon-responsive" :working="refreshWorking" :disabled="isPastSession" @click="emit('refreshRequest')" />
+        <AppButton label="Refresh" icon="refresh" mode="icon-responsive" :working="refreshWorking" :disabled="refreshDisabled" @click="emit('refreshRequest')" />
         <AppButton label="Set Hours" icon="clock" mode="icon-responsive" :disabled="eligibleCount === 0" @click="showSetHours = true" />
         <AppButton label="Add" icon="add" mode="icon-responsive" @click="showAdd = true" />
       </div>
@@ -58,6 +58,7 @@
       v-if="showSetHours"
       :entry-count="eligibleCount"
       :default-hours="3"
+      :past-session-admin="!!(isPastSession && isAdmin)"
       :working="workingSetHours"
       :error="setHoursError"
       @close="closeSetHoursModal"
@@ -120,6 +121,8 @@ function entryHeadcount(e: EntryItem): number {
   return 1
 }
 
+const refreshDisabled = computed(() => !!props.isPastSession && !props.isAdmin)
+
 const activeCount = computed(() =>
   props.entries.filter(e => !e.cancelled).reduce((sum, e) => sum + entryHeadcount(e), 0)
 )
@@ -128,7 +131,12 @@ const checkedCount = computed(() =>
     .filter(e => e.checkedIn && !e.cancelled)
     .reduce((sum, e) => sum + entryHeadcount(e), 0)
 )
-const eligibleCount = computed(() => props.entries.filter(e => e.checkedIn && !e.hours).length)
+const eligibleCount = computed(() => {
+  if (props.isPastSession && props.isAdmin) {
+    return props.entries.filter(e => !e.cancelled && !e.hours).length
+  }
+  return props.entries.filter(e => e.checkedIn && !e.hours).length
+})
 const sessionAdults = computed(() =>
   props.entries
     .filter(e => e.profileId && !e.profile.isGroup && !e.accompanyingAdultId)

--- a/frontend/src/pages/LoginPage.vue
+++ b/frontend/src/pages/LoginPage.vue
@@ -230,8 +230,10 @@ onMounted(async () => {
 
   const prefillCode = route.query.code as string | undefined
   const prefillEmail = route.query.email as string | undefined
-  if (prefillCode && prefillEmail) {
+  if (prefillEmail && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(prefillEmail)) {
     email.value = prefillEmail
+  }
+  if (prefillCode && prefillEmail) {
     verifyInput.value = prefillCode
     sent.value = true
     startCountdown(15 * 60)

--- a/frontend/src/pages/ProfileListPage.vue
+++ b/frontend/src/pages/ProfileListPage.vue
@@ -15,7 +15,7 @@
       :can-bulk-edit="profile.isAdmin"
       :fy="fy"
       @add-records="showBulkModal = true"
-      @add-entries="showEntriesModal = true"
+      @add-entries="onAddEntries"
       @send-email="showEmailModal = true"
       @add-profile="showAddProfile = true"
       @update:selected="selected = $event"
@@ -60,6 +60,9 @@
     <ProfileBulkEntriesModal
       v-if="showEntriesModal"
       :count="individualSelectedCount"
+      :session-options="bulkEntrySessionOptions"
+      :sessions-loading="sessionsStore.loading"
+      :sessions-error="sessionsStore.error ?? undefined"
       :working="entriesWorking"
       :error="entriesError"
       @close="showEntriesModal = false"
@@ -87,6 +90,8 @@ import { usePageTitle } from '../composables/usePageTitle'
 import { useViewer } from '../composables/useViewer'
 import { useProfileListStore } from '../stores/profileList'
 import { useGroupListStore } from '../stores/groupList'
+import { useSessionListStore } from '../stores/sessionList'
+import { bulkEntrySessionOptions as buildBulkEntrySessionOptions } from '../utils/bulkEntrySessionOptions'
 import { useRouter } from 'vue-router'
 import { profilePath } from '../router'
 import type { ProfileResponse } from '../../../types/api-responses'
@@ -98,6 +103,7 @@ const profile = useViewer()
 const router = useRouter()
 const store = useProfileListStore()
 const groupsStore = useGroupListStore()
+const sessionsStore = useSessionListStore()
 
 const fy = ref('future')
 const group = ref('')
@@ -129,6 +135,13 @@ const individualSelectedCount = computed(() =>
 const emailableSelectedCount = computed(() =>
   visibleSelected(selected.value, filtered.value).filter(p => !p.isGroup && !!p.email?.trim()).length,
 )
+
+const bulkEntrySessionOptions = computed(() => buildBulkEntrySessionOptions(sessionsStore.sessions))
+
+function onAddEntries() {
+  showEntriesModal.value = true
+  sessionsStore.fetch()
+}
 
 function onFiltersChange({ fy: newFy, group: newGroup }: { fy: string; group: string }) {
   fy.value = newFy

--- a/frontend/src/pages/ProfileListPage.vue
+++ b/frontend/src/pages/ProfileListPage.vue
@@ -15,6 +15,7 @@
       :can-bulk-edit="profile.isAdmin"
       :fy="fy"
       @add-records="showBulkModal = true"
+      @send-email="showEmailModal = true"
       @add-profile="showAddProfile = true"
       @update:selected="selected = $event"
     />
@@ -45,6 +46,15 @@
       @close="showBulkModal = false"
       @save="onBulkSave"
     />
+
+    <ProfileBulkEmailModal
+      v-if="showEmailModal"
+      :count="emailableSelectedCount"
+      :working="emailWorking"
+      :error="emailError"
+      @close="showEmailModal = false"
+      @send="onBulkEmail"
+    />
   </DefaultLayout>
 </template>
 
@@ -57,6 +67,8 @@ import ProfileListActions from '../components/profiles/ProfileListActions.vue'
 import ProfileListResults from '../components/profiles/ProfileListResults.vue'
 import ProfileBulkRecordsModal from './modals/ProfileBulkRecordsModal.vue'
 import type { BulkRecordPayload } from './modals/ProfileBulkRecordsModal.vue'
+import ProfileBulkEmailModal from './modals/ProfileBulkEmailModal.vue'
+import type { BulkEmailPayload } from './modals/ProfileBulkEmailModal.vue'
 import ProfileAddModal from './modals/ProfileAddModal.vue'
 import type { AddProfilePayload } from './modals/ProfileAddModal.vue'
 import { usePageTitle } from '../composables/usePageTitle'
@@ -82,6 +94,9 @@ const selected = ref<number[]>([])
 const showBulkModal = ref(false)
 const bulkWorking = ref(false)
 const bulkError = ref('')
+const showEmailModal = ref(false)
+const emailWorking = ref(false)
+const emailError = ref('')
 const showAddProfile = ref(false)
 const addProfileWorking = ref(false)
 const addProfileError = ref('')
@@ -94,6 +109,10 @@ watch(filtered, list => {
 
 const individualSelectedCount = computed(() =>
   visibleSelected(selected.value, filtered.value).filter(p => !p.isGroup).length,
+)
+
+const emailableSelectedCount = computed(() =>
+  visibleSelected(selected.value, filtered.value).filter(p => !p.isGroup && !!p.email?.trim()).length,
 )
 
 function onFiltersChange({ fy: newFy, group: newGroup }: { fy: string; group: string }) {
@@ -123,6 +142,30 @@ async function onBulkSave(payload: BulkRecordPayload) {
     console.error('[ProfileListPage] onBulkSave', e)
   } finally {
     bulkWorking.value = false
+  }
+}
+
+async function onBulkEmail(payload: BulkEmailPayload) {
+  emailWorking.value = true
+  emailError.value = ''
+  try {
+    const profileIds = visibleSelected(selected.value, filtered.value)
+      .filter(p => !p.isGroup && !!p.email?.trim())
+      .map(p => p.id)
+    const res = await fetch('/api/profiles/bulk-email', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ profileIds, ...payload }),
+    })
+    const json = await res.json().catch(() => ({}))
+    if (!res.ok) throw new Error(json.error || `Send email failed (${res.status})`)
+    showEmailModal.value = false
+    if (!payload.preview) selected.value = []
+  } catch (e) {
+    emailError.value = e instanceof Error ? e.message : 'An error occurred'
+    console.error('[ProfileListPage] onBulkEmail', e)
+  } finally {
+    emailWorking.value = false
   }
 }
 

--- a/frontend/src/pages/ProfileListPage.vue
+++ b/frontend/src/pages/ProfileListPage.vue
@@ -15,6 +15,7 @@
       :can-bulk-edit="profile.isAdmin"
       :fy="fy"
       @add-records="showBulkModal = true"
+      @add-entries="showEntriesModal = true"
       @send-email="showEmailModal = true"
       @add-profile="showAddProfile = true"
       @update:selected="selected = $event"
@@ -55,6 +56,15 @@
       @close="showEmailModal = false"
       @send="onBulkEmail"
     />
+
+    <ProfileBulkEntriesModal
+      v-if="showEntriesModal"
+      :count="individualSelectedCount"
+      :working="entriesWorking"
+      :error="entriesError"
+      @close="showEntriesModal = false"
+      @save="onBulkEntries"
+    />
   </DefaultLayout>
 </template>
 
@@ -69,6 +79,8 @@ import ProfileBulkRecordsModal from './modals/ProfileBulkRecordsModal.vue'
 import type { BulkRecordPayload } from './modals/ProfileBulkRecordsModal.vue'
 import ProfileBulkEmailModal from './modals/ProfileBulkEmailModal.vue'
 import type { BulkEmailPayload } from './modals/ProfileBulkEmailModal.vue'
+import ProfileBulkEntriesModal from './modals/ProfileBulkEntriesModal.vue'
+import type { BulkEntriesPayload } from './modals/ProfileBulkEntriesModal.vue'
 import ProfileAddModal from './modals/ProfileAddModal.vue'
 import type { AddProfilePayload } from './modals/ProfileAddModal.vue'
 import { usePageTitle } from '../composables/usePageTitle'
@@ -97,6 +109,9 @@ const bulkError = ref('')
 const showEmailModal = ref(false)
 const emailWorking = ref(false)
 const emailError = ref('')
+const showEntriesModal = ref(false)
+const entriesWorking = ref(false)
+const entriesError = ref('')
 const showAddProfile = ref(false)
 const addProfileWorking = ref(false)
 const addProfileError = ref('')
@@ -142,6 +157,31 @@ async function onBulkSave(payload: BulkRecordPayload) {
     console.error('[ProfileListPage] onBulkSave', e)
   } finally {
     bulkWorking.value = false
+  }
+}
+
+async function onBulkEntries(payload: BulkEntriesPayload) {
+  entriesWorking.value = true
+  entriesError.value = ''
+  try {
+    const profileIds = visibleSelected(selected.value, filtered.value)
+      .filter(p => !p.isGroup)
+      .map(p => p.id)
+    const res = await fetch('/api/entries/bulk', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ profileIds, sessionId: payload.sessionId }),
+    })
+    const json = await res.json().catch(() => ({}))
+    if (!res.ok) throw new Error(json.error || `Add entries failed (${res.status})`)
+    showEntriesModal.value = false
+    selected.value = []
+    await store.fetch(fy.value, group.value)
+  } catch (e) {
+    entriesError.value = e instanceof Error ? e.message : 'An error occurred'
+    console.error('[ProfileListPage] onBulkEntries', e)
+  } finally {
+    entriesWorking.value = false
   }
 }
 

--- a/frontend/src/pages/SessionDetailPage.vue
+++ b/frontend/src/pages/SessionDetailPage.vue
@@ -562,7 +562,12 @@ function entryHeadcountForHours(count: number | undefined): number {
 }
 
 async function onSetHours(hoursPerPerson: number) {
-  const eligible = store.session?.entries.filter(e => e.checkedIn && !e.hours) ?? []
+  const past = isPastSession.value
+  const eligible = store.session?.entries.filter(e => {
+    if (e.cancelled || e.hours) return false
+    if (profile.isAdmin && past) return true
+    return e.checkedIn
+  }) ?? []
   try {
     await Promise.all(eligible.map(e => {
       const storedHours = hoursPerPerson * entryHeadcountForHours(e.count)

--- a/frontend/src/pages/modals/ProfileBulkEmailModal.vue
+++ b/frontend/src/pages/modals/ProfileBulkEmailModal.vue
@@ -1,0 +1,59 @@
+<template>
+  <ModalLayout
+    :title="`Send Email — ${count} ${count === 1 ? 'profile' : 'profiles'}`"
+    action="Send"
+    action-icon="email"
+    :action-disabled="count === 0"
+    :working="working"
+    :error="error"
+    @close="emit('close')"
+    @action="onSend"
+  >
+    <FormLayout :disabled="working">
+      <FormRow title="Template">
+        <ModalFormSelect v-model="template">
+          <option value="membership-invite">Membership Invite</option>
+        </ModalFormSelect>
+      </FormRow>
+
+      <FormRow title="Preview">
+        <label class="modal-form-check-label">
+          <ModalFormCheckbox v-model="preview" />
+          Send to my email address only
+        </label>
+      </FormRow>
+    </FormLayout>
+  </ModalLayout>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import ModalLayout from '../../components/ModalLayout.vue'
+import FormLayout from '../../components/FormLayout.vue'
+import FormRow from '../../components/FormRow.vue'
+import ModalFormSelect from '../../components/forms/ModalFormSelect.vue'
+import ModalFormCheckbox from '../../components/forms/ModalFormCheckbox.vue'
+
+export interface BulkEmailPayload {
+  template: 'membership-invite'
+  preview: boolean
+}
+
+defineProps<{
+  count: number
+  working: boolean
+  error?: string
+}>()
+
+const emit = defineEmits<{
+  close: []
+  send: [payload: BulkEmailPayload]
+}>()
+
+const template = ref<'membership-invite'>('membership-invite')
+const preview = ref(true)
+
+function onSend() {
+  emit('send', { template: template.value, preview: preview.value })
+}
+</script>

--- a/frontend/src/pages/modals/ProfileBulkEntriesModal.vue
+++ b/frontend/src/pages/modals/ProfileBulkEntriesModal.vue
@@ -3,7 +3,7 @@
     :title="`Add Entries — ${count} ${count === 1 ? 'profile' : 'profiles'}`"
     action="Add"
     action-icon="add"
-    :action-disabled="!sessionId || count === 0 || loadingSessions || !futureSessions.length"
+    :action-disabled="!sessionId || count === 0 || sessionsLoading || !sessionOptions.length"
     :working="working"
     :error="error"
     @close="emit('close')"
@@ -11,12 +11,12 @@
   >
     <FormLayout :disabled="working">
       <FormRow title="Session" :full-width="true">
-        <LoadingSpinner v-if="loadingSessions" />
+        <LoadingSpinner v-if="sessionsLoading" />
         <p v-else-if="sessionsError" class="modal-form-hint">{{ sessionsError }}</p>
-        <p v-else-if="!futureSessions.length" class="modal-form-hint">No future sessions available.</p>
+        <p v-else-if="!sessionOptions.length" class="modal-form-hint">No future sessions available.</p>
         <ModalFormSelect v-else v-model="sessionId">
           <option value="" disabled>Select session…</option>
-          <option v-for="s in futureSessions" :key="s.id" :value="String(s.id)">{{ sessionLabel(s) }}</option>
+          <option v-for="s in sessionOptions" :key="s.id" :value="String(s.id)">{{ s.label }}</option>
         </ModalFormSelect>
       </FormRow>
     </FormLayout>
@@ -24,21 +24,13 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref } from 'vue'
 import ModalLayout from '../../components/ModalLayout.vue'
 import FormLayout from '../../components/FormLayout.vue'
 import FormRow from '../../components/FormRow.vue'
 import ModalFormSelect from '../../components/forms/ModalFormSelect.vue'
 import LoadingSpinner from '../../components/LoadingSpinner.vue'
-
-interface SessionOption {
-  id: number
-  date: string
-  groupName?: string
-  groupKey?: string
-  displayName?: string
-  isBookable: boolean
-}
+import type { BulkEntrySessionOption } from '../../utils/bulkEntrySessionOptions'
 
 export interface BulkEntriesPayload {
   sessionId: number
@@ -46,6 +38,9 @@ export interface BulkEntriesPayload {
 
 defineProps<{
   count: number
+  sessionOptions: BulkEntrySessionOption[]
+  sessionsLoading?: boolean
+  sessionsError?: string
   working: boolean
   error?: string
 }>()
@@ -56,39 +51,10 @@ const emit = defineEmits<{
 }>()
 
 const sessionId = ref('')
-const loadingSessions = ref(true)
-const sessionsError = ref('')
-const sessions = ref<SessionOption[]>([])
-
-const futureSessions = computed(() =>
-  sessions.value.filter(s => s.isBookable).sort((a, b) => a.date.localeCompare(b.date))
-)
-
-function sessionLabel(s: SessionOption): string {
-  const date = new Date(s.date).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
-  const name = s.displayName || s.groupName || s.groupKey || 'Session'
-  return `${date} — ${name}`
-}
 
 function save() {
   const id = parseInt(sessionId.value, 10)
   if (isNaN(id)) return
   emit('save', { sessionId: id })
 }
-
-onMounted(async () => {
-  loadingSessions.value = true
-  sessionsError.value = ''
-  try {
-    const res = await fetch('/api/sessions')
-    if (!res.ok) throw new Error(`Failed to load sessions (${res.status})`)
-    const json = await res.json()
-    sessions.value = json.data ?? []
-  } catch (e) {
-    sessionsError.value = e instanceof Error ? e.message : 'Failed to load sessions'
-    console.error('[ProfileBulkEntriesModal] load sessions', e)
-  } finally {
-    loadingSessions.value = false
-  }
-})
 </script>

--- a/frontend/src/pages/modals/ProfileBulkEntriesModal.vue
+++ b/frontend/src/pages/modals/ProfileBulkEntriesModal.vue
@@ -1,0 +1,94 @@
+<template>
+  <ModalLayout
+    :title="`Add Entries — ${count} ${count === 1 ? 'profile' : 'profiles'}`"
+    action="Add"
+    action-icon="add"
+    :action-disabled="!sessionId || count === 0 || loadingSessions || !futureSessions.length"
+    :working="working"
+    :error="error"
+    @close="emit('close')"
+    @action="save"
+  >
+    <FormLayout :disabled="working">
+      <FormRow title="Session" :full-width="true">
+        <LoadingSpinner v-if="loadingSessions" />
+        <p v-else-if="sessionsError" class="modal-form-hint">{{ sessionsError }}</p>
+        <p v-else-if="!futureSessions.length" class="modal-form-hint">No future sessions available.</p>
+        <ModalFormSelect v-else v-model="sessionId">
+          <option value="" disabled>Select session…</option>
+          <option v-for="s in futureSessions" :key="s.id" :value="String(s.id)">{{ sessionLabel(s) }}</option>
+        </ModalFormSelect>
+      </FormRow>
+    </FormLayout>
+  </ModalLayout>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import ModalLayout from '../../components/ModalLayout.vue'
+import FormLayout from '../../components/FormLayout.vue'
+import FormRow from '../../components/FormRow.vue'
+import ModalFormSelect from '../../components/forms/ModalFormSelect.vue'
+import LoadingSpinner from '../../components/LoadingSpinner.vue'
+
+interface SessionOption {
+  id: number
+  date: string
+  groupName?: string
+  groupKey?: string
+  displayName?: string
+  isBookable: boolean
+}
+
+export interface BulkEntriesPayload {
+  sessionId: number
+}
+
+defineProps<{
+  count: number
+  working: boolean
+  error?: string
+}>()
+
+const emit = defineEmits<{
+  close: []
+  save: [payload: BulkEntriesPayload]
+}>()
+
+const sessionId = ref('')
+const loadingSessions = ref(true)
+const sessionsError = ref('')
+const sessions = ref<SessionOption[]>([])
+
+const futureSessions = computed(() =>
+  sessions.value.filter(s => s.isBookable).sort((a, b) => a.date.localeCompare(b.date))
+)
+
+function sessionLabel(s: SessionOption): string {
+  const date = new Date(s.date).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
+  const name = s.displayName || s.groupName || s.groupKey || 'Session'
+  return `${date} — ${name}`
+}
+
+function save() {
+  const id = parseInt(sessionId.value, 10)
+  if (isNaN(id)) return
+  emit('save', { sessionId: id })
+}
+
+onMounted(async () => {
+  loadingSessions.value = true
+  sessionsError.value = ''
+  try {
+    const res = await fetch('/api/sessions')
+    if (!res.ok) throw new Error(`Failed to load sessions (${res.status})`)
+    const json = await res.json()
+    sessions.value = json.data ?? []
+  } catch (e) {
+    sessionsError.value = e instanceof Error ? e.message : 'Failed to load sessions'
+    console.error('[ProfileBulkEntriesModal] load sessions', e)
+  } finally {
+    loadingSessions.value = false
+  }
+})
+</script>

--- a/frontend/src/pages/modals/SessionEmailSendModal.vue
+++ b/frontend/src/pages/modals/SessionEmailSendModal.vue
@@ -14,6 +14,7 @@
         <ModalFormSelect v-model="template">
           <option value="pre-session">Pre-Session</option>
           <option value="post-session">Post-Session</option>
+          <option value="pre-agm">Pre-AGM</option>
         </ModalFormSelect>
       </FormRow>
 
@@ -61,7 +62,7 @@ const emit = defineEmits<{
   send: [{ recipient: number | 'send-all', preview: boolean, template: string }]
 }>()
 
-const template = ref<'pre-session' | 'post-session'>('pre-session')
+const template = ref<'pre-session' | 'post-session' | 'pre-agm'>('pre-session')
 const recipient = ref<number | 'send-all'>(props.adults.find(a => a.email)?.entryId ?? 'send-all')
 const preview = ref(true)
 

--- a/frontend/src/pages/modals/SessionSetHoursModal.vue
+++ b/frontend/src/pages/modals/SessionSetHoursModal.vue
@@ -9,7 +9,12 @@
     @action="apply"
   >
     <p class="shm-desc">
-      Sets hours for all checked-in entries where hours are not yet recorded.
+      <template v-if="pastSessionAdmin">
+        Sets hours for all active entries where hours are not yet recorded (and marks them checked in).
+      </template>
+      <template v-else>
+        Sets hours for all checked-in entries where hours are not yet recorded.
+      </template>
       {{ entryCount === 1 ? '1 entry' : `${entryCount} entries` }} will be updated.
     </p>
 
@@ -28,7 +33,7 @@ import FormLayout from '../../components/FormLayout.vue'
 import FormRow from '../../components/FormRow.vue'
 import ModalFormInput from '../../components/forms/ModalFormInput.vue'
 
-const props = defineProps<{ entryCount: number; defaultHours: number; working: boolean; error?: string }>()
+const props = defineProps<{ entryCount: number; defaultHours: number; pastSessionAdmin?: boolean; working: boolean; error?: string }>()
 const emit = defineEmits<{ close: []; setHours: [hours: number] }>()
 
 const hours = ref(props.defaultHours)

--- a/frontend/src/utils/bulkEntrySessionOptions.test.ts
+++ b/frontend/src/utils/bulkEntrySessionOptions.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest'
+import { bulkEntrySessionOptions } from './bulkEntrySessionOptions'
+
+describe('bulkEntrySessionOptions', () => {
+  it('returns future bookable sessions sorted by date ascending with labels', () => {
+    const result = bulkEntrySessionOptions([
+      { id: 3, date: '2026-12-01', groupName: 'Far', isBookable: true },
+      { id: 1, date: '2026-06-01', groupName: 'Near', isBookable: true },
+      { id: 2, date: '2025-01-01', groupName: 'Past', isBookable: false },
+    ])
+
+    expect(result).toEqual([
+      { id: 1, label: '1 Jun 2026 — Near' },
+      { id: 3, label: '1 Dec 2026 — Far' },
+    ])
+  })
+})

--- a/frontend/src/utils/bulkEntrySessionOptions.ts
+++ b/frontend/src/utils/bulkEntrySessionOptions.ts
@@ -1,0 +1,26 @@
+export interface BulkEntrySessionOption {
+  id: number
+  label: string
+}
+
+interface SessionLike {
+  id: number
+  date: string
+  displayName?: string
+  groupName?: string
+  groupKey?: string
+  isBookable: boolean
+}
+
+function sessionLabel(s: SessionLike): string {
+  const date = new Date(s.date).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
+  const name = s.displayName || s.groupName || s.groupKey || 'Session'
+  return `${date} — ${name}`
+}
+
+export function bulkEntrySessionOptions(sessions: SessionLike[]): BulkEntrySessionOption[] {
+  return sessions
+    .filter(s => s.isBookable)
+    .sort((a, b) => a.date.localeCompare(b.date))
+    .map(s => ({ id: s.id, label: sessionLabel(s) }))
+}

--- a/templates/email/membership-invite/html.hbs
+++ b/templates/email/membership-invite/html.hbs
@@ -1,0 +1,18 @@
+{{#section}}
+  <p style="margin:0;">Hi {{name}}, thank you for volunteering with <strong>Dean Trail Volunteers</strong>. We'd like to invite you to become a charity member.</p>
+{{/section}}
+
+{{#if charityMembershipDate}}
+{{#section style="sand"}}
+  <strong>Membership date:</strong> {{charityMembershipDate}}
+{{/section}}
+{{/if}}
+
+{{#section}}
+  <p style="margin:0 0 16px;">Log in to view your profile and respond.</p>
+  <p style="margin:0;"><a href="{{loginUrl}}" style="color:#41903D;">Login</a></p>
+{{/section}}
+
+{{#section style="green"}}
+  <h2 style="margin:0;">Thank you for all you do.</h2>
+{{/section}}

--- a/templates/email/membership-invite/subject.hbs
+++ b/templates/email/membership-invite/subject.hbs
@@ -1,0 +1,1 @@
+Charity Membership — Dean Trail Volunteers

--- a/templates/email/membership-invite/text.hbs
+++ b/templates/email/membership-invite/text.hbs
@@ -1,0 +1,12 @@
+Hi {{name}},
+
+Thank you for volunteering with Dean Trail Volunteers. We'd like to invite you to become a charity member.
+{{#if charityMembershipDate}}
+
+Your membership date: {{charityMembershipDate}}
+{{/if}}
+
+Log in to view your profile and respond:
+{{{loginUrl}}}
+
+Dean Trail Volunteers

--- a/templates/email/pre-agm/html.hbs
+++ b/templates/email/pre-agm/html.hbs
@@ -1,0 +1,19 @@
+{{#section}}
+  <p style="margin:0 0 16px;">Dear {{volunteerName}},</p>
+  <p style="margin:0 0 16px;">Please find links here to <a href="{{agendaUrl}}" style="color:#41903D;">Agenda</a> for Thursday's AGM, plus the Trustees <a href="{{reportUrl}}" style="color:#41903D;">Report</a> and Draft <a href="{{financialUrl}}" style="color:#41903D;">Financial</a> Statement for the year to end of March.</p>
+  <p style="margin:0 0 16px;">The meeting will still go ahead under the stretch tent at PBA, but the social ride has been cancelled due to the red warning for extreme heat. Water will be available, but please bring preferred cold drinks, hats etc. Food will be available at 6:30pm and the meeting will start at 7pm. If you are vulnerable or have health conditions that might be exacerbated by the heat, please do not feel obliged to attend. We can arrange a proxy or online vote for you — just email us at <a href="mailto:admin@dtv.org.uk" style="color:#41903D;">admin@dtv.org.uk</a> if you would prefer this option.</p>
+  <p style="margin:0 0 8px;">Votes will include:</p>
+  <ul style="margin:0 0 16px;padding-left:20px;">
+    <li>Confirmation of Ruth Hallett as Digital, Data and Compliance Trustee</li>
+    <li>Confirmation of Morgan Jones as Inclusivity and Diversity Trustee</li>
+    <li>Election of Ian Officer as Trustee (Chair)</li>
+    <li>Election of Rebecca Prayoga as Trustee (Marketing)</li>
+    <li>Acceptance of Trustee Report</li>
+    <li>Confirmation of priorities for 2026/27</li>
+  </ul>
+  <p style="margin:0;">If you can't make it you can let us know by email or directly on <a href="{{sessionUrl}}" style="color:#41903D;">My Tracker</a>.</p>
+{{/section}}
+
+{{#section style="green"}}
+  <p style="margin:0;">Cheers,<br>Ian</p>
+{{/section}}

--- a/templates/email/pre-agm/subject.hbs
+++ b/templates/email/pre-agm/subject.hbs
@@ -1,0 +1,1 @@
+Thursday's AGM — Dean Trail Volunteers

--- a/templates/email/pre-agm/text.hbs
+++ b/templates/email/pre-agm/text.hbs
@@ -1,0 +1,19 @@
+Dear {{volunteerName}},
+
+Please find links here to Agenda ({{{agendaUrl}}}) for Thursday's AGM, plus the Trustees Report ({{{reportUrl}}}) and Draft Financial Statement ({{{financialUrl}}}) for the year to end of March.
+
+The meeting will still go ahead under the stretch tent at PBA, but the social ride has been cancelled due to the red warning for extreme heat. Water will be available, but please bring preferred cold drinks, hats etc. Food will be available at 6:30pm and the meeting will start at 7pm. If you are vulnerable or have health conditions that might be exacerbated by the heat, please do not feel obliged to attend. We can arrange a proxy or online vote for you - just email us at admin@dtv.org.uk if you would prefer this option.
+
+Votes will include:
+- Confirmation of Ruth Hallett as Digital, Data and Compliance Trustee
+- Confirmation of Morgan Jones as Inclusivity and Diversity Trustee
+- Election of Ian Officer as Trustee (Chair)
+- Election of Rebecca Prayoga as Trustee (Marketing)
+- Acceptance of Trustee Report
+- Confirmation of priorities for 2026/27
+
+If you can't make it you can let us know by email or directly on My Tracker: {{{sessionUrl}}}.
+
+Cheers,
+
+Ian


### PR DESCRIPTION
## Summary
- **Volunteers list (admin):** bulk **Send Email** (`membership-invite` with preview) and **Add Entries** — modal picks a future session (next first); skips profiles with any existing entry including cancelled bookings.
- **Session emails:** **Pre-AGM** template from session detail notify; `isMember` available in pre/post/pre-AGM templates; login page prefills email from `?email=`.
- **Profile stats:** **No Consent** warning requires Privacy Consent only (not Photo Consent).
- **Past sessions (admin only):** **Refresh** and **Set Hours** enabled for admins on past sessions (check-in unchanged); Set Hours applies to all active entries without hours and marks them checked in.

## Test plan
- [ ] Volunteers list → select profiles → Send Email (preview to self, then send)
- [ ] Volunteers list → Add Entries → pick future session; confirm skipped count for already-booked/cancelled profiles
- [ ] Session detail → Send Email → Pre-AGM template; verify AGM doc links and session URL in email
- [ ] Session pre/post emails render `{{#if isMember}}` correctly
- [ ] Login with `?email=` query param prefills address
- [ ] Admin on past session: Refresh and Set Hours work; check-in user sees both disabled
- [ ] `npm run build` and backend email-vars/renderer tests pass