### PR TITLE
Add session start time and length to create/edit modals

### DIFF
--- a/backend/routes/sessions.ts
+++ b/backend/routes/sessions.ts
@@ -67,7 +67,7 @@ function resolveSessionLengthFromBody(length: unknown): { length: number } | { e
     return { length: DEFAULT_SESSION_LENGTH };
   }
   const parsed = parseSessionLength(length);
-  if (!parsed) {
+  if (parsed === undefined) {
     return { error: 'length must be a positive number of hours' };
   }
   return { length: parsed };

--- a/backend/routes/sessions.ts
+++ b/backend/routes/sessions.ts
@@ -27,11 +27,16 @@ import {
   extractMetadataTags,
   parseEmails,
   sessionScheduleFields,
+  parseSessionTime,
+  parseSessionLength,
+  DEFAULT_SESSION_TIME,
+  DEFAULT_SESSION_LENGTH,
 } from '../services/data-layer';
 import { parseSessionStats } from '../services/data-layer';
 import {
   GROUP_LOOKUP, GROUP_DISPLAY, PROJECT_LOOKUP,
   SESSION_LOOKUP, SESSION_NOTES, SESSION_METADATA, SESSION_COVER_MEDIA, SESSION_STATS, SESSION_LIMITS,
+  SESSION_TIME, SESSION_LENGTH,
   PROFILE_LOOKUP, PROFILE_DISPLAY, PROFILE_STATS, ENTRY_CANCELLED, ENTRY_EVENTBRITE_ATTENDEE_ID
 } from '../services/field-names';
 import type { SessionResponse, SessionDetailResponse, EntryResponse } from '../../types/api-responses';
@@ -43,6 +48,30 @@ import { runSessionStatsRefresh, refreshSessionMediaStats } from '../services/se
 import { mediaDriveId } from '../services/media-upload';
 
 const router: Router = express.Router();
+
+/** Resolve body time to HH:MM; blank/omitted → 09:30. Returns error message if invalid. */
+function resolveSessionTimeFromBody(time: unknown): { time: string } | { error: string } {
+  if (time === undefined || time === null || (typeof time === 'string' && !time.trim())) {
+    return { time: DEFAULT_SESSION_TIME };
+  }
+  const parsed = parseSessionTime(time);
+  if (!parsed) {
+    return { error: 'time must be HH:MM (24-hour clock)' };
+  }
+  return { time: parsed };
+}
+
+/** Resolve body length in hours; blank/omitted → 3. Returns error message if invalid. */
+function resolveSessionLengthFromBody(length: unknown): { length: number } | { error: string } {
+  if (length === undefined || length === null || length === '' || (typeof length === 'string' && !String(length).trim())) {
+    return { length: DEFAULT_SESSION_LENGTH };
+  }
+  const parsed = parseSessionLength(length);
+  if (!parsed) {
+    return { error: 'length must be a positive number of hours' };
+  }
+  return { length: parsed };
+}
 
 function projectLookupFromBody(
   projectId: unknown,
@@ -131,7 +160,7 @@ router.get('/sessions', async (req: Request, res: Response) => {
 
 router.post('/sessions', async (req: Request, res: Response) => {
   try {
-    const { groupId, date, name, description, projectId } = req.body;
+    const { groupId, date, name, description, projectId, time, length } = req.body;
 
     if (!groupId || !date) {
       res.status(400).json({ success: false, error: 'groupId and date are required' });
@@ -141,6 +170,17 @@ router.post('/sessions', async (req: Request, res: Response) => {
     const dateStr = String(date);
     if (!/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) {
       res.status(400).json({ success: false, error: 'date must be YYYY-MM-DD format' });
+      return;
+    }
+
+    const resolvedTime = resolveSessionTimeFromBody(time);
+    if ('error' in resolvedTime) {
+      res.status(400).json({ success: false, error: resolvedTime.error });
+      return;
+    }
+    const resolvedLength = resolveSessionLengthFromBody(length);
+    if ('error' in resolvedLength) {
+      res.status(400).json({ success: false, error: resolvedLength.error });
       return;
     }
 
@@ -170,7 +210,9 @@ router.post('/sessions', async (req: Request, res: Response) => {
     const fields: { Title: string; Date: string; [key: string]: any } = {
       Title: title,
       Date: dateStr,
-      [GROUP_LOOKUP]: String(groupId)
+      [GROUP_LOOKUP]: String(groupId),
+      [SESSION_TIME]: resolvedTime.time,
+      [SESSION_LENGTH]: resolvedLength.length,
     };
     if (typeof name === 'string' && name.trim()) {
       fields.Name = name.trim();
@@ -750,7 +792,7 @@ router.patch('/sessions/:group/:date', async (req: Request, res: Response) => {
   try {
     const groupKey = String(req.params.group).toLowerCase();
     const dateParam = String(req.params.date);
-    const { displayName, description, eventbriteEventId, date, groupId, projectId, metadata, coverMediaId, limits } = req.body;
+    const { displayName, description, eventbriteEventId, date, groupId, projectId, metadata, coverMediaId, limits, time, length } = req.body;
 
     const [rawGroups, rawProjects, spSession] = await Promise.all([
       groupsRepository.getAll(),
@@ -764,6 +806,22 @@ router.patch('/sessions/:group/:date', async (req: Request, res: Response) => {
     if (typeof eventbriteEventId === 'string') fields.EventbriteEventID = eventbriteEventId;
     if (typeof date === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(date)) {
       fields.Date = date;
+    }
+    if ('time' in req.body) {
+      const resolvedTime = resolveSessionTimeFromBody(time);
+      if ('error' in resolvedTime) {
+        res.status(400).json({ success: false, error: resolvedTime.error });
+        return;
+      }
+      fields[SESSION_TIME] = resolvedTime.time;
+    }
+    if ('length' in req.body) {
+      const resolvedLength = resolveSessionLengthFromBody(length);
+      if ('error' in resolvedLength) {
+        res.status(400).json({ success: false, error: resolvedLength.error });
+        return;
+      }
+      fields[SESSION_LENGTH] = resolvedLength.length;
     }
     if (typeof groupId === 'number') fields[GROUP_LOOKUP] = String(groupId);
     if ('projectId' in req.body) {

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -2,8 +2,10 @@
 
 ## Session: 2026-07-16 (Session start time / length in create/edit modals)
 
-- Add/edit session modals include Start time (`type="time"`, HH:MM; blank → `09:30`) and Length in hours (blank → `3`).
-- `POST` / `PATCH /api/sessions` accept `time` / `length` and write SharePoint `Time` / `Length` (same defaults + validation).
+- Add/edit session modals include Start time and Length; both screens prefill `09:30` / `3` (blank SharePoint or cleared fields resolve to the same defaults).
+- Shared frontend helpers in `sessionTime.ts`; detail Time display always shows a full range with those defaults.
+- Form field stored as `hours` (not `length`) so reactive v-model updates correctly.
+- `POST` / `PATCH /api/sessions` accept `time` / `length` and write SharePoint `Time` / `Length`.
 - Schema + regression checklist updated for Time/Length.
 
 ## Session: 2026-07-10 (Session-day parking notice)

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,5 +1,11 @@
 # Development Progress
 
+## Session: 2026-07-16 (Session start time / length in create/edit modals)
+
+- Add/edit session modals include Start time (`type="time"`, HH:MM; blank → `09:30`) and Length in hours (blank → `3`).
+- `POST` / `PATCH /api/sessions` accept `time` / `length` and write SharePoint `Time` / `Length` (same defaults + validation).
+- Schema + regression checklist updated for Time/Length.
+
 ## Session: 2026-07-10 (Session-day parking notice)
 
 - Session detail: check-in/admin-only parking notice under title/description/tags for today and future sessions; mailto `fodtrails@forestryengland.uk`.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -3,6 +3,7 @@
 ## Session: 2026-07-16 (Session start time / length in create/edit modals)
 
 - Add/edit session modals include Start time and Length; both screens prefill `09:30` / `3` (blank SharePoint or cleared fields resolve to the same defaults).
+- Invalid Length (0, negative, non-numeric) is rejected in the modal and by POST/PATCH — only blank uses the 3h default.
 - Shared frontend helpers in `sessionTime.ts`; detail Time display always shows a full range with those defaults.
 - Form field stored as `hours` (not `length`) so reactive v-model updates correctly.
 - `POST` / `PATCH /api/sessions` accept `time` / `length` and write SharePoint `Time` / `Length`.

--- a/docs/sharepoint-schema.md
+++ b/docs/sharepoint-schema.md
@@ -57,10 +57,14 @@ This document describes the SharePoint list schema for the Tracker site (`/sites
 | **Title** | Title | Single line of text | No | Lookup key (e.g., "2026-02-15 Sat") |
 | **Name** | Name | Single line of text | No | Display name for the session |
 | **Date** | Date | Date (Date only) | Yes | Session date |
+| **Time** | Time | Single line of text | No | Start time HH:MM (24-hour); app defaults to 09:30 when blank |
+| **Length** | Length | Number | No | Session duration in hours; app defaults to 3 when blank |
 | **Notes** | Notes | Multiple lines of text | No | Planning notes, work done, and actions |
 | **Group** | Group | Lookup | No | Links to Groups list (shows Title) |
 | **Project** | Project | Lookup | No | Links to Projects list (shows Title) |
 | **EventbriteEventID** | EventbriteEventID | Single line of text | No | Eventbrite Event identifier |
+| **Limits** | Limits | Single line of text | No | JSON capacity config e.g. `{"new":4,"total":20}` |
+| **CoverMedia** | CoverMedia | Number | No | Media library item ID used as session cover photo |
 | **Stats** | Stats | Multiple lines of text | No | Pre-computed JSON: `{ "count": N, "hours": N, "media": N, "new": N, "child": N, "regular": N, "cancelledRegular": N, "eventbrite": N }` |
 | **Modified** | Modified | Date and Time | Auto | Last modified timestamp (read-only) |
 | **Created** | Created | Date and Time | Auto | Creation timestamp (read-only) |

--- a/docs/testing/full-regression.md
+++ b/docs/testing/full-regression.md
@@ -106,14 +106,18 @@ Run with `npm run dev` at http://localhost:3000. Log in via Microsoft Entra ID.
 - [ ] Redirects to groups listing
 
 ### H5. Create session
-- [ ] Group detail or sessions page → "New Session" button → modal with Group, Date (required), Name, Description
-- [ ] `POST /api/sessions` — `{ groupId, date, name?, description? }`
+- [ ] Group detail or sessions page → "New Session" button → modal with Group, Project, Date, Start time (optional), Length (optional), Name
+- [ ] Start time blank → stored/treated as `09:30`; non-default times saved as HH:MM (24-hour)
+- [ ] Length blank → stored/treated as `3` hours
+- [ ] `POST /api/sessions` — `{ groupId, date, time?, length?, name?, description?, projectId? }`
 - [ ] Redirects to session detail / appears in list
 
 ### H6. Edit session
-- [ ] Session detail → pencil icon → modal with Group dropdown, Date, Display Name, Description, Eventbrite Event ID
+- [ ] Session detail → pencil icon → modal with Display Name, Description; admin also sees Date, Start time, Length, Group, Project, Limits, Eventbrite Event ID
+- [ ] Start time prefills from session (default `09:30`); blank on save → `09:30`
+- [ ] Length prefills from session (default `3`); blank on save → `3`
 - [ ] Group dropdown pre-selects current group
-- [ ] `PATCH /api/sessions/:group/:date` — `{ displayName?, description?, eventbriteEventId?, date?, groupId? }`
+- [ ] `PATCH /api/sessions/:group/:date` — `{ displayName?, description?, eventbriteEventId?, date?, time?, length?, groupId?, projectId?, limits? }`
 - [ ] Changing date redirects to new URL
 - [ ] Changing date on a session whose Title matches the auto-generated format (`YYYY-MM-DD GroupKey`) — Title is automatically updated to the new date; verify in SharePoint
 - [ ] Changing group shows confirmation: "Move this session to [group]? All existing entries will remain attached."

--- a/docs/testing/full-regression.md
+++ b/docs/testing/full-regression.md
@@ -106,16 +106,15 @@ Run with `npm run dev` at http://localhost:3000. Log in via Microsoft Entra ID.
 - [ ] Redirects to groups listing
 
 ### H5. Create session
-- [ ] Group detail or sessions page → "New Session" button → modal with Group, Project, Date, Start time (optional), Length (optional), Name
-- [ ] Start time blank → stored/treated as `09:30`; non-default times saved as HH:MM (24-hour)
-- [ ] Length blank → stored/treated as `3` hours
+- [ ] Group detail or sessions page → "New Session" button → modal with Group, Project, Date, Start time, Length, Name
+- [ ] Start time and Length prefill defaults (`09:30`, `3`); blank on submit still stores those defaults
 - [ ] `POST /api/sessions` — `{ groupId, date, time?, length?, name?, description?, projectId? }`
 - [ ] Redirects to session detail / appears in list
 
 ### H6. Edit session
 - [ ] Session detail → pencil icon → modal with Display Name, Description; admin also sees Date, Start time, Length, Group, Project, Limits, Eventbrite Event ID
-- [ ] Start time prefills from session (default `09:30`); blank on save → `09:30`
-- [ ] Length prefills from session (default `3`); blank on save → `3`
+- [ ] Start time / Length prefill from session (blank SharePoint → `09:30` / `3`); blank on save → same defaults
+- [ ] Session detail Time row always shows a range (defaults when SharePoint Time/Length blank)
 - [ ] Group dropdown pre-selects current group
 - [ ] `PATCH /api/sessions/:group/:date` — `{ displayName?, description?, eventbriteEventId?, date?, time?, length?, groupId?, projectId?, limits? }`
 - [ ] Changing date redirects to new URL

--- a/docs/testing/full-regression.md
+++ b/docs/testing/full-regression.md
@@ -160,7 +160,7 @@ Run with `npm run dev` at http://localhost:3000. Log in via Microsoft Entra ID.
 - [ ] Redirects to session detail or profile
 
 ### H12. Set default hours (bulk)
-- [ ] Session detail → "Set Hours" button → modal with hours input (default 3)
+- [ ] Session detail → "Set Hours" button → modal with hours input (defaults to session length, 3 when unset)
 - [ ] Applies to checked-in entries where hours = 0
 - [ ] Admin on past session: Set Hours enabled; applies to all active entries without hours (marks checked in)
 - [ ] Check In on past session: Set Hours disabled when no checked-in entries without hours

--- a/docs/testing/full-regression.md
+++ b/docs/testing/full-regression.md
@@ -108,12 +108,14 @@ Run with `npm run dev` at http://localhost:3000. Log in via Microsoft Entra ID.
 ### H5. Create session
 - [ ] Group detail or sessions page → "New Session" button → modal with Group, Project, Date, Start time, Length, Name
 - [ ] Start time and Length prefill defaults (`09:30`, `3`); blank on submit still stores those defaults
+- [ ] Invalid Length (0, negative) shows an error and does not create the session
 - [ ] `POST /api/sessions` — `{ groupId, date, time?, length?, name?, description?, projectId? }`
 - [ ] Redirects to session detail / appears in list
 
 ### H6. Edit session
 - [ ] Session detail → pencil icon → modal with Display Name, Description; admin also sees Date, Start time, Length, Group, Project, Limits, Eventbrite Event ID
 - [ ] Start time / Length prefill from session (blank SharePoint → `09:30` / `3`); blank on save → same defaults
+- [ ] Invalid Length (0, negative) shows an error and does not save / overwrite the session
 - [ ] Session detail Time row always shows a range (defaults when SharePoint Time/Length blank)
 - [ ] Group dropdown pre-selects current group
 - [ ] `PATCH /api/sessions/:group/:date` — `{ displayName?, description?, eventbriteEventId?, date?, time?, length?, groupId?, projectId?, limits? }`

--- a/frontend/src/components/sessions/SessionEntryList.vue
+++ b/frontend/src/components/sessions/SessionEntryList.vue
@@ -57,7 +57,7 @@
     <SessionSetHoursModal
       v-if="showSetHours"
       :entry-count="eligibleCount"
-      :default-hours="resolveSessionLength(sessionLength)"
+      :default-hours="resolveSessionLength(sessionLength) ?? DEFAULT_SESSION_LENGTH"
       :past-session-admin="!!(isPastSession && isAdmin)"
       :working="workingSetHours"
       :error="setHoursError"
@@ -81,7 +81,7 @@ import EntryAddModal from '../../pages/modals/EntryAddModal.vue'
 import SessionSetHoursModal from '../../pages/modals/SessionSetHoursModal.vue'
 import { profilePath } from '../../router/index'
 import { iconsForEntry } from '../../utils/labelIcons'
-import { resolveSessionLength } from '../../utils/sessionTime'
+import { DEFAULT_SESSION_LENGTH, resolveSessionLength } from '../../utils/sessionTime'
 
 type AddPayload = { profileId: number } | { newName: string; newEmail: string }
 type EditData = { checkedIn: boolean; count: number; hours: number; notes: string; accompanyingAdultId: number | null; labels: string[]; cancelled: boolean; eventbriteAttendeeId: string | null }

--- a/frontend/src/components/sessions/SessionEntryList.vue
+++ b/frontend/src/components/sessions/SessionEntryList.vue
@@ -57,7 +57,7 @@
     <SessionSetHoursModal
       v-if="showSetHours"
       :entry-count="eligibleCount"
-      :default-hours="3"
+      :default-hours="resolveSessionLength(sessionLength)"
       :past-session-admin="!!(isPastSession && isAdmin)"
       :working="workingSetHours"
       :error="setHoursError"
@@ -81,6 +81,7 @@ import EntryAddModal from '../../pages/modals/EntryAddModal.vue'
 import SessionSetHoursModal from '../../pages/modals/SessionSetHoursModal.vue'
 import { profilePath } from '../../router/index'
 import { iconsForEntry } from '../../utils/labelIcons'
+import { resolveSessionLength } from '../../utils/sessionTime'
 
 type AddPayload = { profileId: number } | { newName: string; newEmail: string }
 type EditData = { checkedIn: boolean; count: number; hours: number; notes: string; accompanyingAdultId: number | null; labels: string[]; cancelled: boolean; eventbriteAttendeeId: string | null }
@@ -93,6 +94,8 @@ const props = defineProps<{
   workingId?: number | null
   refreshWorking?: boolean
   isPastSession?: boolean
+  /** Session duration in hours (SharePoint Length; defaults to 3 when unset) */
+  sessionLength?: number
 }>()
 
 const emit = defineEmits<{

--- a/frontend/src/pages/SessionDetailPage.vue
+++ b/frontend/src/pages/SessionDetailPage.vue
@@ -191,6 +191,7 @@
             :working-id="workingId"
             :refresh-working="refreshWorking"
             :is-past-session="isPastSession"
+            :session-length="store.session.length"
             @refresh-request="onRefreshRequest"
             @update="onEntryUpdate"
             @set-hours="onSetHours"

--- a/frontend/src/pages/SessionDetailPage.vue
+++ b/frontend/src/pages/SessionDetailPage.vue
@@ -831,6 +831,8 @@ async function onSessionSave(data: SessionSaveData) {
     }
     if (profile.isAdmin) {
       body.date = data.date
+      body.time = data.time
+      body.length = data.length
       body.groupId = data.groupId
       body.projectId = data.projectId
       body.limits = data.limits

--- a/frontend/src/pages/modals/GroupAddSessionModal.vue
+++ b/frontend/src/pages/modals/GroupAddSessionModal.vue
@@ -39,11 +39,13 @@
         <ModalFormInput v-model="form.name" :placeholder="group?.displayName || group?.key || ''" />
       </FormRow>
     </FormLayout>
+
+    <p v-if="validationError" class="modal-form-error">{{ validationError }}</p>
   </ModalLayout>
 </template>
 
 <script setup lang="ts">
-import { reactive, computed } from 'vue'
+import { ref, reactive, computed } from 'vue'
 import type { GroupDetailResponse } from '../../../../types/api-responses'
 import type { ProjectItem } from './SessionEditModal.vue'
 import ModalLayout from '../../components/ModalLayout.vue'
@@ -84,6 +86,8 @@ const emit = defineEmits<{
   add: [payload: AddSessionPayload]
 }>()
 
+const validationError = ref('')
+
 const form = reactive({
   date: '',
   time: DEFAULT_SESSION_TIME,
@@ -100,11 +104,17 @@ const resolvedGroupId = computed(() =>
 
 function add() {
   if (!resolvedGroupId.value) return
+  validationError.value = ''
+  const length = resolveSessionLength(form.hours)
+  if (length === null) {
+    validationError.value = 'Length must be a positive number of hours'
+    return
+  }
   emit('add', {
     groupId: resolvedGroupId.value,
     date: form.date,
     time: resolveSessionTime(form.time),
-    length: resolveSessionLength(form.hours),
+    length,
     name: form.name || undefined,
     projectId: form.projectId,
   })

--- a/frontend/src/pages/modals/GroupAddSessionModal.vue
+++ b/frontend/src/pages/modals/GroupAddSessionModal.vue
@@ -32,7 +32,7 @@
       </FormRow>
 
       <FormRow title="Length (hours)" :full-width="true">
-        <ModalFormInput v-model="form.length" type="number" min="0.25" step="0.25" placeholder="3" />
+        <ModalFormInput v-model="form.hours" type="number" min="0.25" step="0.25" />
       </FormRow>
 
       <FormRow title="Display Name" :full-width="true">
@@ -51,6 +51,12 @@ import FormLayout from '../../components/FormLayout.vue'
 import FormRow from '../../components/FormRow.vue'
 import ModalFormInput from '../../components/forms/ModalFormInput.vue'
 import ModalFormSelect from '../../components/forms/ModalFormSelect.vue'
+import {
+  DEFAULT_SESSION_LENGTH,
+  DEFAULT_SESSION_TIME,
+  resolveSessionLength,
+  resolveSessionTime,
+} from '../../utils/sessionTime'
 
 export type AddSessionPayload = {
   groupId: number
@@ -61,20 +67,6 @@ export type AddSessionPayload = {
   length?: number
   name?: string
   projectId?: number | null
-}
-
-const DEFAULT_SESSION_TIME = '09:30'
-const DEFAULT_SESSION_LENGTH = 3
-
-function resolveSessionTime(raw: string): string {
-  return raw.trim() || DEFAULT_SESSION_TIME
-}
-
-function resolveSessionLength(raw: string | number): number {
-  if (raw === '' || raw === null || raw === undefined) return DEFAULT_SESSION_LENGTH
-  const value = typeof raw === 'number' ? raw : parseFloat(String(raw).trim())
-  if (!Number.isFinite(value) || value <= 0) return DEFAULT_SESSION_LENGTH
-  return value
 }
 
 type GroupOption = { id: number; key: string; displayName?: string | null }
@@ -94,8 +86,9 @@ const emit = defineEmits<{
 
 const form = reactive({
   date: '',
-  time: '',
-  length: '' as string | number,
+  time: DEFAULT_SESSION_TIME,
+  // Named hours (not length) — reactive objects with a numeric `length` break v-model updates
+  hours: String(DEFAULT_SESSION_LENGTH),
   name: '',
   groupId: '' as number | '',
   projectId: null as number | null,
@@ -111,7 +104,7 @@ function add() {
     groupId: resolvedGroupId.value,
     date: form.date,
     time: resolveSessionTime(form.time),
-    length: resolveSessionLength(form.length),
+    length: resolveSessionLength(form.hours),
     name: form.name || undefined,
     projectId: form.projectId,
   })

--- a/frontend/src/pages/modals/GroupAddSessionModal.vue
+++ b/frontend/src/pages/modals/GroupAddSessionModal.vue
@@ -27,6 +27,14 @@
         <ModalFormInput v-model="form.date" type="date" />
       </FormRow>
 
+      <FormRow title="Start time" :full-width="true">
+        <ModalFormInput v-model="form.time" type="time" />
+      </FormRow>
+
+      <FormRow title="Length (hours)" :full-width="true">
+        <ModalFormInput v-model="form.length" type="number" min="0.25" step="0.25" placeholder="3" />
+      </FormRow>
+
       <FormRow title="Display Name" :full-width="true">
         <ModalFormInput v-model="form.name" :placeholder="group?.displayName || group?.key || ''" />
       </FormRow>
@@ -47,8 +55,26 @@ import ModalFormSelect from '../../components/forms/ModalFormSelect.vue'
 export type AddSessionPayload = {
   groupId: number
   date: string
+  /** HH:MM 24-hour; blank / omitted → 09:30 */
+  time?: string
+  /** Hours; blank / omitted → 3 */
+  length?: number
   name?: string
   projectId?: number | null
+}
+
+const DEFAULT_SESSION_TIME = '09:30'
+const DEFAULT_SESSION_LENGTH = 3
+
+function resolveSessionTime(raw: string): string {
+  return raw.trim() || DEFAULT_SESSION_TIME
+}
+
+function resolveSessionLength(raw: string | number): number {
+  if (raw === '' || raw === null || raw === undefined) return DEFAULT_SESSION_LENGTH
+  const value = typeof raw === 'number' ? raw : parseFloat(String(raw).trim())
+  if (!Number.isFinite(value) || value <= 0) return DEFAULT_SESSION_LENGTH
+  return value
 }
 
 type GroupOption = { id: number; key: string; displayName?: string | null }
@@ -68,6 +94,8 @@ const emit = defineEmits<{
 
 const form = reactive({
   date: '',
+  time: '',
+  length: '' as string | number,
   name: '',
   groupId: '' as number | '',
   projectId: null as number | null,
@@ -82,6 +110,8 @@ function add() {
   emit('add', {
     groupId: resolvedGroupId.value,
     date: form.date,
+    time: resolveSessionTime(form.time),
+    length: resolveSessionLength(form.length),
     name: form.name || undefined,
     projectId: form.projectId,
   })

--- a/frontend/src/pages/modals/SessionEditModal.vue
+++ b/frontend/src/pages/modals/SessionEditModal.vue
@@ -24,6 +24,14 @@
           <ModalFormInput v-model="form.date" type="date" />
         </FormRow>
 
+        <FormRow title="Start time" :full-width="true">
+          <ModalFormInput v-model="form.time" type="time" />
+        </FormRow>
+
+        <FormRow title="Length (hours)" :full-width="true">
+          <ModalFormInput v-model="form.length" type="number" min="0.25" step="0.25" placeholder="3" />
+        </FormRow>
+
         <FormRow title="Group" :full-width="true">
           <ModalFormSelect v-model="form.groupId">
             <option v-for="g in groups" :key="g.id" :value="g.id">{{ g.name }}</option>
@@ -81,10 +89,28 @@ export interface SessionSaveData {
   displayName: string
   description: string
   date: string
+  /** HH:MM 24-hour; blank → 09:30 */
+  time: string
+  /** Hours; blank → 3 */
+  length: number
   groupId: number | null
   projectId: number | null
   limits: Record<string, unknown> | null
   eventbriteEventId: string
+}
+
+const DEFAULT_SESSION_TIME = '09:30'
+const DEFAULT_SESSION_LENGTH = 3
+
+function resolveSessionTime(raw: string): string {
+  return raw.trim() || DEFAULT_SESSION_TIME
+}
+
+function resolveSessionLength(raw: string | number): number {
+  if (raw === '' || raw === null || raw === undefined) return DEFAULT_SESSION_LENGTH
+  const value = typeof raw === 'number' ? raw : parseFloat(String(raw).trim())
+  if (!Number.isFinite(value) || value <= 0) return DEFAULT_SESSION_LENGTH
+  return value
 }
 
 const props = defineProps<{
@@ -110,6 +136,8 @@ const form = reactive({
   displayName: props.session.displayName ?? '',
   description: props.session.description ?? '',
   date: props.session.date,
+  time: props.session.time ?? DEFAULT_SESSION_TIME,
+  length: (props.session.length ?? DEFAULT_SESSION_LENGTH) as string | number,
   groupId: props.session.groupId ?? null as number | null,
   projectId: props.session.projectId ?? null as number | null,
   limitsRaw: props.session.storedLimits && Object.keys(props.session.storedLimits).length ? JSON.stringify(props.session.storedLimits) : '',
@@ -134,6 +162,8 @@ function save() {
     displayName: form.displayName,
     description: form.description,
     date: form.date,
+    time: resolveSessionTime(form.time),
+    length: resolveSessionLength(form.length),
     groupId: form.groupId,
     projectId: form.projectId,
     limits,

--- a/frontend/src/pages/modals/SessionEditModal.vue
+++ b/frontend/src/pages/modals/SessionEditModal.vue
@@ -81,6 +81,7 @@ import ModalFormTextarea from '../../components/forms/ModalFormTextarea.vue'
 import ModalFormSelect from '../../components/forms/ModalFormSelect.vue'
 import DeleteModal from './DeleteModal.vue'
 import {
+  DEFAULT_SESSION_LENGTH,
   resolveSessionLength,
   resolveSessionTime,
 } from '../../utils/sessionTime'
@@ -128,7 +129,7 @@ const form = reactive({
   date: props.session.date,
   time: resolveSessionTime(props.session.time),
   // Named hours (not length) — reactive objects with a numeric `length` break v-model updates
-  hours: String(resolveSessionLength(props.session.length)),
+  hours: String(resolveSessionLength(props.session.length) ?? DEFAULT_SESSION_LENGTH),
   groupId: props.session.groupId ?? null as number | null,
   projectId: props.session.projectId ?? null as number | null,
   limitsRaw: props.session.storedLimits && Object.keys(props.session.storedLimits).length ? JSON.stringify(props.session.storedLimits) : '',
@@ -149,12 +150,17 @@ function save() {
       }
     }
   }
+  const length = resolveSessionLength(form.hours)
+  if (length === null) {
+    validationError.value = 'Length must be a positive number of hours'
+    return
+  }
   emit('save', {
     displayName: form.displayName,
     description: form.description,
     date: form.date,
     time: resolveSessionTime(form.time),
-    length: resolveSessionLength(form.hours),
+    length,
     groupId: form.groupId,
     projectId: form.projectId,
     limits,

--- a/frontend/src/pages/modals/SessionEditModal.vue
+++ b/frontend/src/pages/modals/SessionEditModal.vue
@@ -29,7 +29,7 @@
         </FormRow>
 
         <FormRow title="Length (hours)" :full-width="true">
-          <ModalFormInput v-model="form.length" type="number" min="0.25" step="0.25" placeholder="3" />
+          <ModalFormInput v-model="form.hours" type="number" min="0.25" step="0.25" />
         </FormRow>
 
         <FormRow title="Group" :full-width="true">
@@ -80,6 +80,10 @@ import ModalFormInput from '../../components/forms/ModalFormInput.vue'
 import ModalFormTextarea from '../../components/forms/ModalFormTextarea.vue'
 import ModalFormSelect from '../../components/forms/ModalFormSelect.vue'
 import DeleteModal from './DeleteModal.vue'
+import {
+  resolveSessionLength,
+  resolveSessionTime,
+} from '../../utils/sessionTime'
 
 export interface GroupItem { id: number; name: string; key: string }
 
@@ -97,20 +101,6 @@ export interface SessionSaveData {
   projectId: number | null
   limits: Record<string, unknown> | null
   eventbriteEventId: string
-}
-
-const DEFAULT_SESSION_TIME = '09:30'
-const DEFAULT_SESSION_LENGTH = 3
-
-function resolveSessionTime(raw: string): string {
-  return raw.trim() || DEFAULT_SESSION_TIME
-}
-
-function resolveSessionLength(raw: string | number): number {
-  if (raw === '' || raw === null || raw === undefined) return DEFAULT_SESSION_LENGTH
-  const value = typeof raw === 'number' ? raw : parseFloat(String(raw).trim())
-  if (!Number.isFinite(value) || value <= 0) return DEFAULT_SESSION_LENGTH
-  return value
 }
 
 const props = defineProps<{
@@ -136,8 +126,9 @@ const form = reactive({
   displayName: props.session.displayName ?? '',
   description: props.session.description ?? '',
   date: props.session.date,
-  time: props.session.time ?? DEFAULT_SESSION_TIME,
-  length: (props.session.length ?? DEFAULT_SESSION_LENGTH) as string | number,
+  time: resolveSessionTime(props.session.time),
+  // Named hours (not length) — reactive objects with a numeric `length` break v-model updates
+  hours: String(resolveSessionLength(props.session.length)),
   groupId: props.session.groupId ?? null as number | null,
   projectId: props.session.projectId ?? null as number | null,
   limitsRaw: props.session.storedLimits && Object.keys(props.session.storedLimits).length ? JSON.stringify(props.session.storedLimits) : '',
@@ -163,7 +154,7 @@ function save() {
     description: form.description,
     date: form.date,
     time: resolveSessionTime(form.time),
-    length: resolveSessionLength(form.length),
+    length: resolveSessionLength(form.hours),
     groupId: form.groupId,
     projectId: form.projectId,
     limits,

--- a/frontend/src/utils/sessionTime.test.ts
+++ b/frontend/src/utils/sessionTime.test.ts
@@ -21,12 +21,18 @@ describe('resolveSessionTime', () => {
 })
 
 describe('resolveSessionLength', () => {
-  it('returns default for blank or invalid values', () => {
+  it('returns default for blank values only', () => {
     expect(resolveSessionLength('')).toBe(DEFAULT_SESSION_LENGTH)
+    expect(resolveSessionLength('   ')).toBe(DEFAULT_SESSION_LENGTH)
     expect(resolveSessionLength(undefined)).toBe(DEFAULT_SESSION_LENGTH)
     expect(resolveSessionLength(null)).toBe(DEFAULT_SESSION_LENGTH)
-    expect(resolveSessionLength(0)).toBe(DEFAULT_SESSION_LENGTH)
-    expect(resolveSessionLength(-1)).toBe(DEFAULT_SESSION_LENGTH)
+  })
+
+  it('returns null for invalid non-blank values', () => {
+    expect(resolveSessionLength(0)).toBeNull()
+    expect(resolveSessionLength(-1)).toBeNull()
+    expect(resolveSessionLength('0')).toBeNull()
+    expect(resolveSessionLength('abc')).toBeNull()
   })
 
   it('keeps positive lengths', () => {

--- a/frontend/src/utils/sessionTime.test.ts
+++ b/frontend/src/utils/sessionTime.test.ts
@@ -1,5 +1,39 @@
 import { describe, expect, it } from 'vitest'
-import { formatSessionTimeRange } from './sessionTime'
+import {
+  DEFAULT_SESSION_LENGTH,
+  DEFAULT_SESSION_TIME,
+  formatSessionTimeRange,
+  resolveSessionLength,
+  resolveSessionTime,
+} from './sessionTime'
+
+describe('resolveSessionTime', () => {
+  it('returns default for blank values', () => {
+    expect(resolveSessionTime('')).toBe(DEFAULT_SESSION_TIME)
+    expect(resolveSessionTime('   ')).toBe(DEFAULT_SESSION_TIME)
+    expect(resolveSessionTime(undefined)).toBe(DEFAULT_SESSION_TIME)
+    expect(resolveSessionTime(null)).toBe(DEFAULT_SESSION_TIME)
+  })
+
+  it('keeps explicit times', () => {
+    expect(resolveSessionTime('10:00')).toBe('10:00')
+  })
+})
+
+describe('resolveSessionLength', () => {
+  it('returns default for blank or invalid values', () => {
+    expect(resolveSessionLength('')).toBe(DEFAULT_SESSION_LENGTH)
+    expect(resolveSessionLength(undefined)).toBe(DEFAULT_SESSION_LENGTH)
+    expect(resolveSessionLength(null)).toBe(DEFAULT_SESSION_LENGTH)
+    expect(resolveSessionLength(0)).toBe(DEFAULT_SESSION_LENGTH)
+    expect(resolveSessionLength(-1)).toBe(DEFAULT_SESSION_LENGTH)
+  })
+
+  it('keeps positive lengths', () => {
+    expect(resolveSessionLength(2.5)).toBe(2.5)
+    expect(resolveSessionLength('4')).toBe(4)
+  })
+})
 
 describe('formatSessionTimeRange', () => {
   it('formats start time, end time, and duration', () => {
@@ -14,15 +48,16 @@ describe('formatSessionTimeRange', () => {
     expect(formatSessionTimeRange('09:30', 2.33)).toBe('9:30 to 11:50 (2.33h)')
   })
 
-  it('shows start time only when length is missing', () => {
-    expect(formatSessionTimeRange('09:30')).toBe('9:30')
+  it('defaults blank time and length to 09:30 and 3h', () => {
+    expect(formatSessionTimeRange()).toBe('9:30 to 12:30 (3h)')
+    expect(formatSessionTimeRange('', undefined)).toBe('9:30 to 12:30 (3h)')
   })
 
-  it('shows duration only when start time is missing', () => {
-    expect(formatSessionTimeRange(undefined, 3)).toBe('3h')
+  it('defaults missing length when only time is provided', () => {
+    expect(formatSessionTimeRange('10:00')).toBe('10:00 to 13:00 (3h)')
   })
 
-  it('returns null when both values are missing', () => {
-    expect(formatSessionTimeRange()).toBeNull()
+  it('defaults missing time when only length is provided', () => {
+    expect(formatSessionTimeRange(undefined, 2)).toBe('9:30 to 11:30 (2h)')
   })
 })

--- a/frontend/src/utils/sessionTime.ts
+++ b/frontend/src/utils/sessionTime.ts
@@ -7,10 +7,15 @@ export function resolveSessionTime(raw: string | null | undefined): string {
   return String(raw).trim() || DEFAULT_SESSION_TIME
 }
 
-export function resolveSessionLength(raw: string | number | null | undefined): number {
-  if (raw === '' || raw === null || raw === undefined) return DEFAULT_SESSION_LENGTH
+/**
+ * Blank / omitted → default 3 hours.
+ * Invalid non-blank values (0, negative, NaN) → null so callers can show an error.
+ */
+export function resolveSessionLength(raw: string | number | null | undefined): number | null {
+  if (raw === null || raw === undefined) return DEFAULT_SESSION_LENGTH
+  if (typeof raw === 'string' && !raw.trim()) return DEFAULT_SESSION_LENGTH
   const value = typeof raw === 'number' ? raw : parseFloat(String(raw).trim())
-  if (!Number.isFinite(value) || value <= 0) return DEFAULT_SESSION_LENGTH
+  if (!Number.isFinite(value) || value <= 0) return null
   return value
 }
 
@@ -42,7 +47,7 @@ function formatLengthHours(hours: number): string {
  */
 export function formatSessionTimeRange(time?: string, lengthHours?: number): string {
   const resolvedTime = resolveSessionTime(time)
-  const resolvedLength = resolveSessionLength(lengthHours)
+  const resolvedLength = resolveSessionLength(lengthHours) ?? DEFAULT_SESSION_LENGTH
   const startMinutes = parseTimeToMinutes(resolvedTime) ?? parseTimeToMinutes(DEFAULT_SESSION_TIME)!
   const endMinutes = startMinutes + resolvedLength * 60
   return `${formatMinutesAsTime(startMinutes)} to ${formatMinutesAsTime(endMinutes)} (${formatLengthHours(resolvedLength)})`

--- a/frontend/src/utils/sessionTime.ts
+++ b/frontend/src/utils/sessionTime.ts
@@ -1,3 +1,19 @@
+/** Matches backend DEFAULT_SESSION_TIME / DEFAULT_SESSION_LENGTH when SharePoint fields are blank. */
+export const DEFAULT_SESSION_TIME = '09:30'
+export const DEFAULT_SESSION_LENGTH = 3
+
+export function resolveSessionTime(raw: string | null | undefined): string {
+  if (raw === null || raw === undefined) return DEFAULT_SESSION_TIME
+  return String(raw).trim() || DEFAULT_SESSION_TIME
+}
+
+export function resolveSessionLength(raw: string | number | null | undefined): number {
+  if (raw === '' || raw === null || raw === undefined) return DEFAULT_SESSION_LENGTH
+  const value = typeof raw === 'number' ? raw : parseFloat(String(raw).trim())
+  if (!Number.isFinite(value) || value <= 0) return DEFAULT_SESSION_LENGTH
+  return value
+}
+
 function parseTimeToMinutes(time: string): number | null {
   const match = time.trim().match(/^(\d{1,2}):(\d{2})$/)
   if (!match) return null
@@ -20,18 +36,14 @@ function formatLengthHours(hours: number): string {
   return `${label}h`
 }
 
-/** Formats session start time and duration for display, e.g. "9:30 to 12:30 (3h)". */
-export function formatSessionTimeRange(time?: string, lengthHours?: number): string | null {
-  if (!time && lengthHours === undefined) return null
-
-  const startMinutes = time ? parseTimeToMinutes(time) : null
-  const lengthLabel = lengthHours !== undefined ? formatLengthHours(lengthHours) : null
-
-  if (startMinutes !== null && lengthHours !== undefined && lengthHours > 0) {
-    const endMinutes = startMinutes + lengthHours * 60
-    return `${formatMinutesAsTime(startMinutes)} to ${formatMinutesAsTime(endMinutes)} (${lengthLabel})`
-  }
-  if (startMinutes !== null) return formatMinutesAsTime(startMinutes)
-  if (lengthLabel) return lengthLabel
-  return null
+/**
+ * Formats session start time and duration for display, e.g. "9:30 to 12:30 (3h)".
+ * Blank / missing values use the same defaults as the API (09:30, 3h).
+ */
+export function formatSessionTimeRange(time?: string, lengthHours?: number): string {
+  const resolvedTime = resolveSessionTime(time)
+  const resolvedLength = resolveSessionLength(lengthHours)
+  const startMinutes = parseTimeToMinutes(resolvedTime) ?? parseTimeToMinutes(DEFAULT_SESSION_TIME)!
+  const endMinutes = startMinutes + resolvedLength * 60
+  return `${formatMinutesAsTime(startMinutes)} to ${formatMinutesAsTime(endMinutes)} (${formatLengthHours(resolvedLength)})`
 }


### PR DESCRIPTION
## Summary
- Add Start time and Length fields to session create and edit modals, writing SharePoint `Time` / `Length` via POST/PATCH with blank → `09:30` / 3h defaults
- Share display/default helpers in `sessionTime.ts`; fix reactive v-model bug by naming the form field `hours` instead of `length`
- Set Hours bulk check-in modal now defaults to the session length instead of a hardcoded 3 hours

## Test plan
- [ ] Create session from group detail and sessions list — defaults prefill; custom time/length save and show on detail
- [ ] Edit session as admin — change length to 2h, save, reopen modal and confirm value persists
- [ ] Session detail Time row shows correct range for blank and custom SharePoint values
- [ ] Set Hours on session with 2h length — modal opens with 2 pre-filled
- [ ] `cd frontend && npm test -- --run src/utils/sessionTime.test.ts`